### PR TITLE
Remove unused Deck Name and Format input fields

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -54,11 +54,6 @@ export class DeckPage {
     await this.page.getByLabel("Decklist").fill(text);
   }
 
-  /** Fill the deck name field */
-  async fillDeckName(name: string) {
-    await this.page.getByPlaceholder("Enter deck name").fill(name);
-  }
-
   /** Click the Import Deck submit button */
   async submitImport() {
     await this.page.getByRole("button", { name: "Import Deck" }).click();
@@ -82,18 +77,6 @@ export class DeckPage {
   /** Return the textarea locator */
   get decklistTextarea() {
     return this.page.getByLabel("Decklist");
-  }
-
-  /** Return the deck name input locator */
-  get deckNameInput() {
-    return this.page.getByPlaceholder("Enter deck name");
-  }
-
-  /** Return the format input locator (manual tab only) */
-  get formatInput() {
-    return this.page.getByPlaceholder(
-      "e.g. Commander, Standard, Modern"
-    );
   }
 
   /** Wait for the deck list panel to appear after a successful import */

--- a/e2e/tab-navigation.spec.ts
+++ b/e2e/tab-navigation.spec.ts
@@ -6,8 +6,6 @@ test.describe("Tab Navigation", () => {
   });
 
   test("defaults to Manual Import tab", async ({ deckPage }) => {
-    // Format field is only visible on the Manual tab
-    await expect(deckPage.formatInput).toBeVisible();
     // Load Example button is only on the Manual tab
     await expect(deckPage.loadExampleButton).toBeVisible();
   });
@@ -15,8 +13,7 @@ test.describe("Tab Navigation", () => {
   test("switches to Moxfield tab", async ({ deckPage }) => {
     await deckPage.selectTab("Moxfield");
 
-    // Format field and Load Example should not be visible on Moxfield tab
-    await expect(deckPage.formatInput).toBeHidden();
+    // Load Example should not be visible on Moxfield tab
     await expect(deckPage.loadExampleButton).toBeHidden();
 
     // Textarea should still be present with Moxfield placeholder
@@ -26,7 +23,6 @@ test.describe("Tab Navigation", () => {
   test("switches to Archidekt tab", async ({ deckPage }) => {
     await deckPage.selectTab("Archidekt");
 
-    await expect(deckPage.formatInput).toBeHidden();
     await expect(deckPage.loadExampleButton).toBeHidden();
     await expect(deckPage.decklistTextarea).toBeVisible();
   });
@@ -35,10 +31,9 @@ test.describe("Tab Navigation", () => {
     deckPage,
   }) => {
     await deckPage.selectTab("Moxfield");
-    await expect(deckPage.formatInput).toBeHidden();
+    await expect(deckPage.loadExampleButton).toBeHidden();
 
     await deckPage.selectTab("Manual Import");
-    await expect(deckPage.formatInput).toBeVisible();
     await expect(deckPage.loadExampleButton).toBeVisible();
   });
 
@@ -52,7 +47,7 @@ test.describe("Tab Navigation", () => {
     await expect(deckPage.decklistTextarea).toHaveValue("1 Sol Ring");
   });
 
-  test("Load Example populates textarea and metadata fields", async ({
+  test("Load Example populates textarea", async ({
     deckPage,
   }) => {
     await deckPage.loadExample();
@@ -62,12 +57,6 @@ test.describe("Tab Navigation", () => {
     await expect(deckPage.decklistTextarea).toContainText(
       "Atraxa, Praetors' Voice"
     );
-
-    // Deck name should be filled
-    await expect(deckPage.deckNameInput).toHaveValue("Atraxa Superfriends");
-
-    // Format should be filled
-    await expect(deckPage.formatInput).toHaveValue("Commander");
   });
 
   test("Load Example decklist can be imported successfully", async ({

--- a/src/components/DeckInput.tsx
+++ b/src/components/DeckInput.tsx
@@ -35,8 +35,6 @@ export default function DeckInput({
   loading,
 }: DeckInputProps) {
   const [activeTab, setActiveTab] = useState<ImportTab>("manual");
-  const [deckName, setDeckName] = useState("");
-  const [format, setFormat] = useState("");
   const [textValue, setTextValue] = useState("");
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
@@ -48,8 +46,6 @@ export default function DeckInput({
 
   const loadExample = () => {
     setTextValue(EXAMPLE_DECKLIST);
-    setDeckName("Atraxa Superfriends");
-    setFormat("Commander");
   };
 
   const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
@@ -129,46 +125,6 @@ export default function DeckInput({
           aria-busy={loading}
           className="flex flex-col gap-4"
         >
-          {/* Deck Name */}
-          <div>
-            <label
-              htmlFor="deck-name"
-              className="mb-1 block text-sm font-medium text-slate-300"
-            >
-              Deck Name
-            </label>
-            <input
-              id="deck-name"
-              type="text"
-              value={deckName}
-              onChange={(e) => setDeckName(e.target.value)}
-              placeholder="Enter deck name"
-              className="w-full rounded-lg border border-slate-600 bg-slate-900 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-purple-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/50 disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={loading}
-            />
-          </div>
-
-          {/* Format (manual tab only) */}
-          {activeTab === "manual" && (
-            <div>
-              <label
-                htmlFor="deck-format"
-                className="mb-1 block text-sm font-medium text-slate-300"
-              >
-                Format
-              </label>
-              <input
-                id="deck-format"
-                type="text"
-                value={format}
-                onChange={(e) => setFormat(e.target.value)}
-                placeholder="e.g. Commander, Standard, Modern"
-                className="w-full rounded-lg border border-slate-600 bg-slate-900 px-4 py-2 text-sm text-white placeholder-slate-400 focus:border-purple-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/50 disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={loading}
-              />
-            </div>
-          )}
-
           {/* Decklist textarea */}
           <div>
             <label


### PR DESCRIPTION
## Summary
- Removed the Deck Name and Format text inputs from the deck import form — they were not connected to any downstream logic
- Cleaned up related state variables (`deckName`, `format`) and the `loadExample` helper
- Removed corresponding page-object helpers and test assertions from the E2E suite

## Test plan
- [x] All 190 existing Playwright E2E tests pass
- [x] Tab navigation tests updated to no longer reference removed fields
- [x] Load Example test updated to only assert textarea population

🤖 Generated with [Claude Code](https://claude.com/claude-code)