### PR TITLE
feat: add MTG domain knowledge and code-pattern skills

### DIFF
--- a/.claude/commands/add-known-combo.md
+++ b/.claude/commands/add-known-combo.md
@@ -1,0 +1,100 @@
+# Add a known combo
+
+Add a new combo to the known combo registry. The combo: $ARGUMENTS
+
+## Steps
+
+### 1. Verify card names via Scryfall
+
+Before adding any combo, verify that all card names are exact Scryfall matches. The `findCombosInDeck()` function uses exact string matching against a `Set`, so names must be precise:
+
+```bash
+# Verify each card name
+curl -s "https://api.scryfall.com/cards/named?exact=Card+Name" | jq '.name'
+```
+
+Common pitfalls:
+- Apostrophes: `Thassa's Oracle` (not `Thassas Oracle`)
+- Accented characters: `Bolas's Citadel` (double possessive)
+- Full names: `Mikaeus, the Unhallowed` (include the comma and epithet)
+
+### 2. Determine combo type
+
+Choose from the four established types:
+
+| Type | Definition | Example |
+|------|-----------|---------|
+| `"infinite"` | Creates an unbounded loop (mana, damage, tokens, etc.) | Dramatic Reversal + Isochron Scepter |
+| `"wincon"` | Directly wins the game or effectively ends it | Thassa's Oracle + Demonic Consultation |
+| `"lock"` | Prevents opponents from playing the game | Knowledge Pool + Drannith Magistrate |
+| `"value"` | Generates significant recurring value but is bounded | Sensei's Divining Top + Bolas's Citadel |
+
+### 3. Write a clear description
+
+The description should explain the combo loop in one sentence:
+- Start with the mechanic: "Infinite mana:", "Lock:", "Win:"
+- Explain the loop clearly: which card does what, and how they feed back
+- Example: `"Infinite mana: blink Drake to untap 5 lands, soulbond re-establishes"`
+
+### 4. Add to `src/lib/known-combos.ts`
+
+Place the combo in the appropriate section (Win Conditions, Infinite Combos, Locks, Value Engines) matching the existing organization:
+
+```ts
+{
+  cards: ["Card Name A", "Card Name B"],
+  description: "Type: explanation of the combo loop",
+  type: "infinite",
+},
+```
+
+For 3-card combos, include all three:
+```ts
+{
+  cards: ["Card A", "Card B", "Card C"],
+  description: "Win: explanation requiring all three pieces",
+  type: "wincon",
+},
+```
+
+### 5. Write unit tests in `tests/unit/known-combos.spec.ts`
+
+Add tests within the existing file structure:
+
+```ts
+test("detects New Combo", () => {
+  const cards = ["Card Name A", "Card Name B", "Other Card"];
+  const combos = findCombosInDeck(cards);
+  expect(combos).toContainEqual(
+    expect.objectContaining({
+      cards: expect.arrayContaining(["Card Name A", "Card Name B"]),
+      type: "infinite",
+    })
+  );
+});
+
+test("does not detect partial New Combo", () => {
+  const cards = ["Card Name A", "Unrelated Card"];
+  const combos = findCombosInDeck(cards);
+  const match = combos.find((c) =>
+    c.cards.includes("Card Name A") && c.cards.includes("Card Name B")
+  );
+  expect(match).toBeUndefined();
+});
+```
+
+### 6. Verify
+
+```bash
+npx playwright test --config playwright.unit.config.ts tests/unit/known-combos.spec.ts
+```
+
+## Combo Sourcing Guidelines
+
+When identifying combos to add:
+- **cEDH staples**: Thoracle combos, Ad Nauseam lines, Underworld Breach piles
+- **Popular casual combos**: Exquisite Blood + Sanguine Bond, Peregrine Drake blinks
+- **Format-specific locks**: Stax pieces that combine to create hard locks
+- **2-card combos preferred**: These are most common and most impactful to detect
+- **3-card combos**: Include only if they're well-known and have a single clear line
+- Cards must be Commander-legal (check `f:commander` on Scryfall)

--- a/.claude/commands/evaluate-detection.md
+++ b/.claude/commands/evaluate-detection.md
@@ -1,0 +1,151 @@
+# Evaluate Detection Accuracy
+
+Audit the accuracy of the card tagging and/or synergy axis detection systems against real MTG cards. Focus area: $ARGUMENTS
+
+## Purpose
+
+This skill bridges MTG domain knowledge with the codebase's regex-based detection systems. Use it to find false positives, false negatives, and edge cases in `src/lib/card-tags.ts` and `src/lib/synergy-axes.ts`.
+
+## Process
+
+### 1. Select Test Cards
+
+Choose 10-20 real MTG cards that stress-test the detection area being audited. Include:
+
+- **Clear positives**: Cards that obviously belong (e.g., Swords to Plowshares for Removal)
+- **Clear negatives**: Cards that obviously don't belong
+- **Edge cases**: Cards that are ambiguous or use unusual templating
+- **False positive candidates**: Cards whose oracle text might accidentally match
+- **Multi-tag cards**: Cards that should trigger multiple detections
+- **DFCs / Adventures / MDFCs**: Cards with unusual oracle text structure
+
+### 2. Fetch Real Oracle Text
+
+For each test card, get the actual oracle text from Scryfall:
+
+```bash
+curl -s "https://api.scryfall.com/cards/named?exact=Card+Name" | jq '{name, oracle_text, keywords, type_line}'
+```
+
+### 3. Run Against Current Detection
+
+For tags, mentally (or actually) execute `generateTags()` against each card's data:
+- Read the regexes in `src/lib/card-tags.ts`
+- Check which patterns would match the real oracle text
+- Note any surprising matches or misses
+
+For synergy axes, evaluate each axis's `detect()` function:
+- Read the regexes in `src/lib/synergy-axes.ts`
+- Calculate the expected relevance score (0-1) for each axis
+- Note scores that seem too high or too low
+
+### 4. Classify Results
+
+For each card, report:
+
+```
+## Card: [Name]
+Oracle: "..."
+Keywords: [...]
+
+### Tags
+| Tag | Expected | Detected | Status |
+|-----|----------|----------|--------|
+| Ramp | Yes | Yes | OK |
+| Removal | No | Yes | FALSE POSITIVE — regex matches "exile target" in unrelated context |
+| Card Draw | Yes | No | FALSE NEGATIVE — uses "draw" with unusual templating |
+
+### Synergy Axes
+| Axis | Expected Relevance | Detected | Status |
+|------|-------------------|----------|--------|
+| Graveyard | 0.7 | 0.3 | UNDER-SCORED — flashback keyword detected but reanimate pattern missed |
+```
+
+### 5. Propose Fixes
+
+For each issue found, propose a specific fix:
+
+**For false negatives** (missed detection):
+- Identify the oracle text pattern that should match
+- Propose a new or modified regex
+- Ensure the fix doesn't introduce false positives
+
+**For false positives** (incorrect detection):
+- Identify why the current regex matches
+- Propose an exclusion rule or tighter regex
+- Provide a counter-example to test
+
+**For scoring issues** (wrong relevance):
+- Identify which sub-pattern is over/under-weighted
+- Propose adjusted score values
+
+### 6. Write Regression Tests
+
+For every issue found, write a unit test that captures it:
+
+```ts
+// False negative: [Card Name] should be tagged [Tag]
+test("[Card Name] (reason) → [Tag]", () => {
+  const card = makeCard({
+    name: "Card Name",
+    oracleText: "real oracle text from Scryfall",
+    keywords: ["Real", "Keywords"],
+    typeLine: "Real Type Line",
+  });
+  expect(generateTags(card)).toContain("Tag");
+});
+
+// False positive: [Card Name] should NOT be tagged [Tag]
+test("[Card Name] (reason) → no [Tag]", () => {
+  const card = makeCard({
+    name: "Card Name",
+    oracleText: "real oracle text that falsely matches",
+  });
+  expect(generateTags(card)).not.toContain("Tag");
+});
+```
+
+### 7. Implement and Verify
+
+1. Add the regression tests (they should fail first for false negatives / pass-incorrectly for false positives)
+2. Update the regex patterns in `card-tags.ts` or `synergy-axes.ts`
+3. Run the full test suite:
+
+```bash
+npx playwright test --config playwright.unit.config.ts tests/unit/card-tags.spec.ts
+npx playwright test --config playwright.unit.config.ts tests/unit/synergy-axes.spec.ts
+```
+
+## Common Edge Cases to Check
+
+### Oracle Text Patterns
+- **Modal spells** ("Choose one —"): May have removal text in one mode but not be primarily removal
+- **ETB vs cast triggers**: "When ~ enters" vs "When you cast ~"
+- **Self-referential**: "Sacrifice ~" is NOT a sacrifice outlet (it's a cost)
+- **Conditional effects**: "If you control a Dragon, destroy target creature" — still Removal
+- **Negative text**: "can't be countered" contains "counter" — should NOT tag as Counterspell
+- **DFC back faces**: Oracle text may contain both faces separated by `//`
+
+### Keyword Subtleties
+- **Keyword abilities vs keyword actions**: "Flying" (ability) vs "destroy" (action)
+- **Ability words**: Landfall, Constellation — NOT keywords in Scryfall data, they're ability words
+- **Keyword counters**: "Flying counter" is different from having Flying
+
+### Type Line Patterns
+- **Artifact Creature**: Is both an artifact AND a creature — should score on both axes
+- **Enchantment Creature**: Similarly dual-typed
+- **Kindred (Tribal)**: "Kindred Instant" has tribal implications
+- **Legendary**: Relevant for commander eligibility, not for synergy detection
+
+## Useful Scryfall Searches for Bulk Testing
+
+```bash
+# Cards with unusual "destroy" patterns (false positive risk for Removal)
+curl -s "https://api.scryfall.com/cards/search?q=o%3A%22destroy+target%22+-t%3Ainstant+-t%3Asorcery&order=edhrec" | jq '.data[:5] | .[].name'
+
+# Cards with "counter" that aren't counterspells
+curl -s "https://api.scryfall.com/cards/search?q=o%3Acounter+-o%3A%22counter+target%22&order=edhrec" | jq '.data[:5] | .[].name'
+
+# Cards with "search your library" that aren't tutors
+curl -s "https://api.scryfall.com/cards/search?q=o%3A%22search+your+library%22+o%3Aland&order=edhrec" | jq '.data[:5] | .[].name'
+```

--- a/.claude/commands/mtg-card-expert.md
+++ b/.claude/commands/mtg-card-expert.md
@@ -1,0 +1,132 @@
+# MTG Card Expert
+
+You are a Magic: The Gathering domain expert sub-agent. Your purpose is to assist with card-level analysis tasks that require deep game knowledge. The task: $ARGUMENTS
+
+## Core Capabilities
+
+### 1. Card Lookup via Scryfall
+
+When asked about a specific card, fetch its data from the Scryfall API:
+
+```bash
+# Exact name lookup
+curl -s "https://api.scryfall.com/cards/named?exact=Sol+Ring" | jq .
+
+# Fuzzy name lookup (when exact name is uncertain)
+curl -s "https://api.scryfall.com/cards/named?fuzzy=thassa+oracle" | jq .
+
+# Search with query syntax
+curl -s "https://api.scryfall.com/cards/search?q=o%3A%22destroy+all+creatures%22+c%3Dw" | jq .
+```
+
+Scryfall query syntax reference:
+- `o:"text"` — oracle text contains
+- `t:creature` — type line contains
+- `c:w` / `c=wu` — color / exact color identity
+- `cmc=3` / `cmc>=5` — converted mana cost
+- `kw:flying` — has keyword
+- `is:commander` — legal as commander
+- `f:commander` — legal in Commander format
+- `set:mh2` — from specific set
+
+Rate limit: 50ms between requests. No API key required.
+
+### 2. Oracle Text Interpretation
+
+When analyzing oracle text, break it down into these categories:
+
+**Ability types:**
+- **Static abilities**: Always active (e.g., "Other creatures you control get +1/+1")
+- **Triggered abilities**: "When/Whenever/At" — fires on events
+- **Activated abilities**: "Cost: Effect" — requires payment to use
+- **Replacement effects**: "If X would happen, Y instead"
+- **Characteristic-defining**: Defines power/toughness/colors (e.g., "\* / \*")
+
+**Keyword mechanics** (and what they mean for the evaluator):
+- **ETB (Enters the Battlefield)**: Triggers on arrival — relevant to blink, reanimate axes
+- **Death triggers**: Relevant to sacrifice axis
+- **Cast triggers**: Relevant to spellslinger axis
+- **Landfall**: Land-enter triggers — relevant to landfall axis
+- **Constellation**: Enchantment-enter triggers — relevant to enchantment axis
+
+**Mana symbol conventions:**
+- `{W}` White, `{U}` Blue, `{B}` Black, `{R}` Red, `{G}` Green
+- `{C}` Colorless, `{X}` Variable, `{T}` Tap, `{Q}` Untap
+- `{W/U}` Hybrid, `{W/P}` Phyrexian, `{2/W}` Two-generic hybrid
+
+### 3. Play Pattern Analysis
+
+When evaluating cards for strategic fit, consider these archetypes and their key indicators:
+
+**Commander Archetypes:**
+
+| Archetype | Key Signals | Win Conditions |
+|-----------|-------------|----------------|
+| **Aggro** | Low CMC creatures, haste, pump effects | Combat damage, Craterhoof |
+| **Control** | Counterspells, removal, card draw, high CMC bombs | Value grinding, late-game threats |
+| **Combo** | Tutors, card draw, specific 2-3 card combos | Infinite loops, alt wincons |
+| **Midrange** | Efficient creatures, removal, value engines | Incremental advantage |
+| **Stax** | Tax effects, resource denial, asymmetric locks | Opponents can't play; slow grind |
+| **Storm** | Cost reduction, untap effects, cantrips | High storm count + payoff |
+| **Voltron** | Equipment/auras, evasion, protection | 21 commander damage |
+| **Aristocrats** | Sacrifice outlets, death triggers, token makers | Drain effects (Blood Artist pattern) |
+| **Reanimator** | Self-mill, discard outlets, reanimate spells | Cheat expensive creatures into play |
+| **Group Hug** | Symmetrical draw/ramp, political effects | Alternate win (Approach, Thassa's Oracle) |
+| **Tokens** | Token generators, anthem effects, go-wide payoffs | Overrun / mass pump |
+| **Spellslinger** | Instant/sorcery payoffs, copy effects, cost reducers | Spell-based combo / value |
+
+**Card evaluation heuristics (Commander format):**
+- **Mana efficiency**: CMC vs. impact. Sol Ring is format-defining because 1 mana → 2 mana.
+- **Card advantage**: Does this card replace itself? Generate ongoing value?
+- **Board impact**: Does this change the game state meaningfully?
+- **Synergy density**: How many other cards in the deck does this interact with?
+- **Removal resilience**: How vulnerable is this to common interaction?
+- **Political value**: Does this affect opponents selectively (good in multiplayer)?
+
+### 4. Card Interaction Analysis
+
+When asked about how cards interact:
+
+1. **Check for known combos** — reference `src/lib/known-combos.ts` for the existing registry
+2. **Analyze trigger chains** — when card A does X, does card B trigger from X?
+3. **Check for synergy** — do both cards advance the same strategy axis?
+4. **Check for anti-synergy** — does card A undermine what card B is trying to do?
+5. **Evaluate in context** — consider the commander identity and deck theme
+
+### 5. Tag and Axis Validation
+
+When evaluating whether a card should have a specific tag or synergy axis score:
+
+**Current tags** (defined in `src/lib/card-tags.ts`):
+Ramp, Card Draw, Card Advantage, Removal, Board Wipe, Counterspell, Tutor, Cost Reduction, Protection, Recursion
+
+**Current synergy axes** (defined in `src/lib/synergy-axes.ts`):
+Counters, Tokens, Graveyard, Graveyard Hate, Sacrifice, Tribal, Landfall, Spellslinger, Artifacts, Enchantments, Lifegain, Evasion
+
+For each card, you should be able to say:
+- Which tags it should receive and why
+- Which synergy axes it scores on and what relevance (0-1) is appropriate
+- Whether any edge cases in the current regex detection would cause false positives/negatives
+
+## Output Format
+
+When providing card analysis, structure your response as:
+
+```
+## Card: [Name]
+- **Mana Cost**: {cost}
+- **Type**: type line
+- **Oracle Text**: full text
+- **Tags**: [expected tags with reasoning]
+- **Synergy Axes**: [axis: relevance score with reasoning]
+- **Play Pattern**: [how this card is typically used in Commander]
+- **Key Interactions**: [notable synergies/combos in the format]
+```
+
+## Important Notes
+
+- Always use real card data from Scryfall — never guess at oracle text or mechanics
+- Be precise about rules interactions — MTG has complex layering rules
+- When uncertain about a ruling, note the uncertainty rather than guessing
+- Consider Commander-specific context: 4-player multiplayer, singleton, color identity restrictions
+- Card names are case-sensitive in the codebase (must match Scryfall exactly)

--- a/.claude/commands/review-deck-analysis.md
+++ b/.claude/commands/review-deck-analysis.md
@@ -1,0 +1,161 @@
+# Review Deck Analysis
+
+Perform a holistic review of a deck's analysis results, tying together all analysis modules into a coherent evaluation. The deck or focus area: $ARGUMENTS
+
+## Purpose
+
+This skill combines the output of all analysis engines — mana curve, color distribution, land base efficiency, synergy scoring, card tags, and known combos — into a unified deck evaluation. Use it to validate that the analysis modules are producing sensible, consistent results for a given decklist.
+
+## Analysis Modules to Review
+
+The evaluator runs these independent analysis pipelines (all in `src/lib/`):
+
+| Module | File | Key Function | Output |
+|--------|------|-------------|--------|
+| Mana Curve | `mana-curve.ts` | `computeManaCurve()` | 8 CMC buckets with permanent/non-permanent split |
+| Color Distribution | `color-distribution.ts` | `computeColorDistribution()` | Pips demanded vs sources available per color |
+| Mana Base Metrics | `color-distribution.ts` | `computeManaBaseMetrics()` | Land %, avg CMC, source-to-demand ratios |
+| Land Base Efficiency | `land-base-efficiency.ts` | `computeLandBaseEfficiency()` | 0-100 score across 5 weighted factors |
+| Card Tags | `card-tags.ts` | `generateTags()` | Per-card functional role tags |
+| Synergy Axes | `synergy-axes.ts` | `SYNERGY_AXES[].detect()` | Per-card 0-1 relevance on 12 strategic axes |
+| Synergy Engine | `synergy-engine.ts` | `analyzeDeckSynergy()` | Card scores, synergy pairs, themes, anti-synergies |
+| Known Combos | `known-combos.ts` | `findCombosInDeck()` | Matched combo entries |
+| Commander Validation | `commander-validation.ts` | `validateDeck()` | Rule violations |
+
+## Review Process
+
+### 1. Validate Deck Composition
+
+Check the basics:
+- **Card count**: Should be exactly 100 (commanders + mainboard) for Commander
+- **Commander legality**: Colors, legendary creature/planeswalker status
+- **Singleton rule**: No duplicates (except basic lands and exempt cards)
+- **Color identity**: All cards within commander's color identity
+
+### 2. Assess Mana Base Health
+
+Cross-reference multiple modules:
+
+**Land count** (from mana curve/color distribution):
+- Typical range: 33-38 lands for Commander
+- Below 33: Risky unless heavy on mana rocks and low curve
+- Above 40: Likely too many unless landfall-focused
+
+**Color balance** (from color distribution):
+- Source-to-demand ratio per color should be >= 0.8 for consistency
+- 5-color producers (Command Tower, Mana Confluence) scoped to commander identity
+- Watch for colors with high pip demand but few sources
+
+**Land quality** (from land base efficiency):
+- Untapped ratio: >70% is good, <50% is sluggish
+- Fixing ratio: Depends on color count (mono needs ~0%, 3+ colors needs >30%)
+- Conditional lands: Count as 0.5 untapped — check if conditions are easy to meet
+
+### 3. Evaluate Curve
+
+From mana curve analysis:
+- **Ideal Commander curve**: Peak at CMC 2-3, tapering off sharply after 5
+- **Average CMC**: 2.5-3.5 is typical; above 4.0 signals a slow deck
+- **Low-end density**: At least 8-10 cards at CMC 0-2 for early plays
+- **High-end bombs**: 3-6 cards at CMC 6+ is normal; more needs ramp support
+
+Cross-check: If average CMC is high, does the deck have enough ramp tags?
+
+### 4. Assess Functional Role Distribution
+
+From card tags, check that the deck has adequate coverage:
+
+| Role | Recommended Count | Notes |
+|------|------------------|-------|
+| Ramp | 10-15 | Essential in Commander; more if high CMC |
+| Card Draw | 8-12 | Keeps the engine running |
+| Removal | 8-12 | Mix of targeted and board wipes |
+| Board Wipe | 3-5 | Too many hurts your own board |
+| Counterspell | 2-6 (blue) | Optional; more in control builds |
+| Tutor | 2-5 | More in combo builds |
+| Protection | 3-6 | Especially for commander |
+| Recursion | 2-4 | Graveyard recovery |
+
+Flag imbalances: "This deck has 3 Ramp cards but an average CMC of 4.2 — it will struggle to deploy threats on time."
+
+### 5. Evaluate Synergy Coherence
+
+From synergy engine output:
+
+**Theme consistency**:
+- A focused deck should have 1-2 dominant themes with 15+ cards each
+- 3+ strong themes with <10 cards each suggests unfocused strategy
+- Check that the commander aligns with the detected themes
+
+**Card synergy scores**:
+- Average score 50-60: Baseline (minimal synergy bonus)
+- Average score 65-75: Good synergy density
+- Average score 80+: Very focused / combo-oriented
+- Cards scoring <30: Potential cuts (anti-synergistic or off-theme)
+
+**Anti-synergies**:
+- Graveyard + Graveyard Hate in same deck: Internal conflict
+- Board Wipes + Tokens strategy: Self-destructive
+- Flag specific card pairs that work against each other
+
+**Known combos**:
+- Do detected combos align with the deck's strategy?
+- Are all combo pieces present (partial combos are liabilities)?
+- Does the deck have tutors to assemble combos consistently?
+
+### 6. Cross-Module Consistency Checks
+
+Look for contradictions between modules:
+
+- **High Ramp tag count + low average CMC**: Overinvested in ramp
+- **Landfall theme detected + below-average land count**: Theme won't fire consistently
+- **Sacrifice theme + no low-CMC creatures**: Nothing to sacrifice early
+- **Spellslinger theme + heavy creature count**: Strategy mismatch
+- **Combo detected + no tutors/card draw**: Can't find the pieces
+- **High land base efficiency score + poor color coverage**: Efficient but wrong colors
+
+### 7. Produce Evaluation Summary
+
+Structure the output as:
+
+```
+## Deck Evaluation: [Deck Name]
+Commander: [Name(s)]
+Colors: [Identity]
+
+### Strengths
+- [What the deck does well, with specific evidence]
+
+### Weaknesses
+- [What needs improvement, with specific evidence]
+
+### Mana Base: [Score]/100
+- Lands: X/99 (Y%)
+- Average CMC: Z
+- Color coverage: [per-color summary]
+- Key concern: [if any]
+
+### Synergy: [Average Score]
+- Primary theme(s): [themes with card counts]
+- Notable combos: [if any]
+- Anti-synergies: [if any]
+
+### Role Coverage
+| Role | Count | Status |
+|------|-------|--------|
+| Ramp | X | OK / Low / High |
+...
+
+### Recommended Changes
+1. [Specific, actionable suggestion with reasoning]
+2. [Another suggestion]
+```
+
+## Important Notes
+
+- All analysis should be data-driven — cite specific cards, scores, and counts
+- Recommendations should reference the commander's strategy and color identity
+- Don't recommend cards outside the commander's color identity
+- Consider budget when making card suggestions (note if a suggestion is expensive)
+- A "bad" score in one area might be intentional (e.g., stax decks want low creature count)
+- Always consider the deck's apparent archetype before flagging issues

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,44 @@ tests/unit/                         # Pure function tests (no browser, no dev se
 
 When working on a feature, the test file should be created or updated _before_ the implementation code. This ensures the test suite always describes the intended behavior and catches regressions.
 
+## Skills (Slash Commands)
+
+Skills live in `.claude/commands/` and are invoked with `/skill-name`. They fall into two categories:
+
+### Code-Pattern Skills
+
+These enforce consistent patterns when adding new code to the codebase:
+
+| Skill | Purpose | Invoked As |
+|-------|---------|------------|
+| `add-api-route` | Scaffold a new Next.js API route with validation patterns | `/add-api-route` |
+| `add-component` | Create a React component following dark theme + a11y patterns | `/add-component` |
+| `add-lib-module` | Create a pure TypeScript module in `src/lib/` | `/add-lib-module` |
+| `add-e2e-test` | Create or extend a Playwright e2e test | `/add-e2e-test` |
+| `add-card-tag` | Add a new heuristic card tag to `card-tags.ts` | `/add-card-tag` |
+| `add-synergy-axis` | Add a new synergy detection axis to `synergy-axes.ts` | `/add-synergy-axis` |
+| `add-known-combo` | Add a new combo to the known combo registry | `/add-known-combo` |
+| `write-plan` | Create an implementation plan in `docs/plans/` | `/write-plan` |
+| `run-tests` | Run tests and report results with diagnostics | `/run-tests` |
+
+### MTG Domain Knowledge Skills
+
+These provide Magic: The Gathering expertise for card analysis and deck evaluation:
+
+| Skill | Purpose | Invoked As |
+|-------|---------|------------|
+| `mtg-card-expert` | Card lookup via Scryfall, oracle text interpretation, play pattern analysis, card interaction reasoning | `/mtg-card-expert` |
+| `evaluate-detection` | Audit tag/synergy regex accuracy against real cards, find false positives/negatives | `/evaluate-detection` |
+| `review-deck-analysis` | Holistic deck evaluation tying together all analysis modules | `/review-deck-analysis` |
+
+### When to Use Which Skill
+
+- Adding a new feature? Start with `/write-plan`, then use the appropriate `add-*` skill for each piece
+- Need to understand a card's mechanics? Use `/mtg-card-expert`
+- Suspect tags or synergy detection is wrong for certain cards? Use `/evaluate-detection`
+- Want to validate that the analysis pipeline produces sensible results for a deck? Use `/review-deck-analysis`
+- Adding a new combo to the registry? Use `/add-known-combo`
+
 ## Plans
 
 All implementation plans live in `docs/plans/` as Markdown files. When generating a plan:


### PR DESCRIPTION
Add 4 new Claude Code skills to improve specialization and consistency:

- mtg-card-expert: Domain agent for Scryfall card lookup, oracle text
  interpretation, play pattern analysis, and card interaction reasoning
- add-known-combo: Code-pattern skill for adding combos to the registry
  with Scryfall name verification and proper test patterns
- evaluate-detection: Bridging skill to audit tag/synergy regex accuracy
  against real cards, finding false positives/negatives
- review-deck-analysis: Holistic deck evaluation skill that ties together
  all analysis modules (mana curve, colors, synergy, land efficiency)

Update CLAUDE.md with a Skills section documenting all 12 skills organized
by category (code-pattern vs domain knowledge) with usage guidance.

https://claude.ai/code/session_011yS1bfWeHx1HnexLescNay