### PR TITLE
feat: add power level estimator

### DIFF
--- a/e2e/deck-analysis.spec.ts
+++ b/e2e/deck-analysis.spec.ts
@@ -1178,3 +1178,112 @@ test.describe("Deck Analysis — Composition Scorecard", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Power Level Estimator
+// ---------------------------------------------------------------------------
+
+test.describe("Deck Analysis — Power Level Estimator", () => {
+  test.beforeEach(async ({ deckPage }) => {
+    const { page } = deckPage;
+    await page.route("**/api/deck-enrich", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_ANALYSIS_RESPONSE),
+      })
+    );
+    await deckPage.goto();
+    await deckPage.fillDecklist(
+      "1 Sol Ring\n1 Counterspell\n1 Cultivate\n1 Command Tower"
+    );
+    await deckPage.submitImport();
+    await deckPage.waitForDeckDisplay();
+
+    await expect(
+      page.locator('[aria-label="Mana cost: 1 generic"]')
+    ).toBeVisible({ timeout: 10_000 });
+
+    await deckPage.selectDeckViewTab("Analysis");
+  });
+
+  test("Power Level Estimator section appears on Analysis tab", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    await expect(
+      page.getByRole("heading", { name: "Power Level Estimator" })
+    ).toBeVisible();
+  });
+
+  test("displays power level score between 1 and 10", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    const scoreEl = page.getByTestId("power-level-score");
+    await expect(scoreEl).toBeVisible();
+    const text = await scoreEl.textContent();
+    const score = parseInt(text ?? "0", 10);
+    expect(score).toBeGreaterThanOrEqual(1);
+    expect(score).toBeLessThanOrEqual(10);
+  });
+
+  test("displays band label (Casual/Focused/Optimized/High Power/cEDH)", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    const bandEl = page.getByTestId("power-level-band");
+    await expect(bandEl).toBeVisible();
+    const text = await bandEl.textContent();
+    const validBands = ["Casual", "Focused", "Optimized", "High Power", "cEDH"];
+    expect(validBands).toContain(text?.trim());
+  });
+
+  test("displays factor breakdown rows", async ({ deckPage }) => {
+    const { page } = deckPage;
+    const factors = page.getByTestId("power-level-factor");
+    await expect(factors).toHaveCount(8);
+  });
+
+  test("section has accessible heading structure", async ({ deckPage }) => {
+    const { page } = deckPage;
+    const section = page.locator(
+      'section[aria-labelledby="power-level-heading"]'
+    );
+    await expect(section).toBeVisible();
+    const heading = section.getByRole("heading", {
+      name: "Power Level Estimator",
+    });
+    await expect(heading).toBeVisible();
+  });
+
+  test("raw score is visible", async ({ deckPage }) => {
+    const { page } = deckPage;
+    const rawScoreEl = page.getByTestId("power-level-raw-score");
+    await expect(rawScoreEl).toBeVisible();
+    const text = await rawScoreEl.textContent();
+    const score = parseInt(text ?? "0", 10);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  test("power level section appears before Mana Curve", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    const powerSection = page.locator(
+      'section[aria-labelledby="power-level-heading"]'
+    );
+    const manaSection = page.locator(
+      'section[aria-labelledby="mana-curve-heading"]'
+    );
+    await expect(powerSection).toBeVisible();
+    await expect(manaSection).toBeVisible();
+
+    const powerBound = await powerSection.boundingBox();
+    const manaBound = await manaSection.boundingBox();
+    expect(powerBound).not.toBeNull();
+    expect(manaBound).not.toBeNull();
+    // Power level section should appear higher (smaller y) than Mana Curve
+    expect(powerBound!.y).toBeLessThan(manaBound!.y);
+  });
+});

--- a/src/components/DeckAnalysis.tsx
+++ b/src/components/DeckAnalysis.tsx
@@ -14,6 +14,7 @@ import {
   resolveCommanderIdentity,
 } from "@/lib/color-distribution";
 import { computeLandBaseEfficiency } from "@/lib/land-base-efficiency";
+import { computePowerLevel } from "@/lib/power-level";
 import ManaCurveChart from "@/components/ManaCurveChart";
 import TypeFilterBar from "@/components/TypeFilterBar";
 import ColorDistributionChart from "@/components/ColorDistributionChart";
@@ -22,6 +23,7 @@ import CommanderSection from "@/components/CommanderSection";
 import LandBaseEfficiency from "@/components/LandBaseEfficiency";
 import DeckCompositionScorecard from "@/components/DeckCompositionScorecard";
 import HypergeometricCalculator from "@/components/HypergeometricCalculator";
+import PowerLevelEstimator from "@/components/PowerLevelEstimator";
 
 interface DeckAnalysisProps {
   deck: DeckData;
@@ -78,6 +80,11 @@ export default function DeckAnalysis({ deck, cardMap }: DeckAnalysisProps) {
     [deck, cardMap]
   );
 
+  const powerLevel = useMemo(
+    () => computePowerLevel(deck, cardMap),
+    [deck, cardMap]
+  );
+
   const filteredSpells = curveData.reduce(
     (sum, b) => sum + b.permanents + b.nonPermanents,
     0
@@ -102,6 +109,8 @@ export default function DeckAnalysis({ deck, cardMap }: DeckAnalysisProps) {
       <CommanderSection deck={deck} cardMap={cardMap} />
 
       <DeckCompositionScorecard deck={deck} cardMap={cardMap} />
+
+      <PowerLevelEstimator result={powerLevel} />
 
       <section aria-labelledby="mana-curve-heading">
         <h3

--- a/src/components/PowerLevelEstimator.tsx
+++ b/src/components/PowerLevelEstimator.tsx
@@ -1,0 +1,150 @@
+import type { PowerLevelResult } from "@/lib/power-level";
+
+interface PowerLevelEstimatorProps {
+  result: PowerLevelResult;
+}
+
+function getPowerLevelColor(powerLevel: number): string {
+  if (powerLevel <= 3) return "text-green-400";
+  if (powerLevel <= 5) return "text-yellow-400";
+  if (powerLevel <= 7) return "text-orange-400";
+  if (powerLevel <= 9) return "text-red-400";
+  return "text-purple-400";
+}
+
+function getBandBadgeClasses(powerLevel: number): string {
+  if (powerLevel <= 3)
+    return "bg-green-900/50 text-green-400 border-green-700";
+  if (powerLevel <= 5)
+    return "bg-yellow-900/50 text-yellow-400 border-yellow-700";
+  if (powerLevel <= 7)
+    return "bg-orange-900/50 text-orange-400 border-orange-700";
+  if (powerLevel <= 9)
+    return "bg-red-900/50 text-red-400 border-red-700";
+  return "bg-purple-900/50 text-purple-400 border-purple-700";
+}
+
+function getBarColor(score: number): string {
+  if (score >= 80) return "bg-green-500";
+  if (score >= 60) return "bg-yellow-500";
+  if (score >= 40) return "bg-orange-500";
+  return "bg-red-500";
+}
+
+function getRawScoreBarColor(rawScore: number): string {
+  if (rawScore >= 70) return "bg-red-500";
+  if (rawScore >= 50) return "bg-orange-500";
+  if (rawScore >= 30) return "bg-yellow-500";
+  return "bg-green-500";
+}
+
+export default function PowerLevelEstimator({
+  result,
+}: PowerLevelEstimatorProps) {
+  return (
+    <section aria-labelledby="power-level-heading">
+      <h3
+        id="power-level-heading"
+        className="mb-1 text-sm font-semibold uppercase tracking-wide text-slate-300"
+      >
+        Power Level Estimator
+      </h3>
+      <p className="mb-4 text-xs text-slate-400">
+        Transparent, explainable power level score based on 8 weighted factors
+      </p>
+
+      {/* Main score display */}
+      <div className="mb-5 flex items-center gap-5">
+        {/* Large power level number */}
+        <div className="flex flex-col items-center">
+          <span
+            data-testid="power-level-score"
+            className={`text-5xl font-bold leading-none ${getPowerLevelColor(result.powerLevel)}`}
+          >
+            {result.powerLevel}
+          </span>
+          <span className="mt-1 text-xs text-slate-400">/ 10</span>
+        </div>
+
+        {/* Band label and description */}
+        <div className="flex flex-col gap-2">
+          <span
+            data-testid="power-level-band"
+            className={`inline-block w-fit rounded border px-2 py-0.5 text-xs font-semibold ${getBandBadgeClasses(result.powerLevel)}`}
+          >
+            {result.bandLabel}
+          </span>
+          <p className="max-w-xs text-xs text-slate-400">
+            {result.bandDescription}
+          </p>
+        </div>
+
+        {/* Raw score */}
+        <div className="ml-auto flex flex-col items-end gap-1">
+          <div className="flex items-baseline gap-1">
+            <span
+              data-testid="power-level-raw-score"
+              className="text-xl font-semibold text-slate-200"
+            >
+              {result.rawScore}
+            </span>
+            <span className="text-xs text-slate-400">/ 100</span>
+          </div>
+          <div className="h-2 w-32 overflow-hidden rounded-full bg-slate-700">
+            <div
+              role="progressbar"
+              aria-valuenow={result.rawScore}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label="Raw power level score"
+              className={`h-full rounded-full transition-all ${getRawScoreBarColor(result.rawScore)}`}
+              style={{ width: `${result.rawScore}%` }}
+            />
+          </div>
+          <span className="text-xs text-slate-500">raw score</span>
+        </div>
+      </div>
+
+      {/* Factor breakdown */}
+      <div className="space-y-2">
+        {result.factors.map((factor) => (
+          <div
+            key={factor.id}
+            data-testid="power-level-factor"
+            className="rounded-lg bg-slate-800/40 px-3 py-2"
+          >
+            <div className="mb-1 flex items-center justify-between gap-2">
+              <span className="text-sm font-medium text-slate-200">
+                {factor.name}
+              </span>
+              <div className="flex items-center gap-2 shrink-0">
+                <span className="text-xs text-slate-500">
+                  {Math.round(factor.weight * 100)}% weight
+                </span>
+                <span
+                  className={`text-sm font-semibold ${factor.score >= 60 ? "text-orange-400" : factor.score >= 30 ? "text-yellow-400" : "text-green-400"}`}
+                >
+                  {factor.score}
+                </span>
+              </div>
+            </div>
+
+            <div className="mb-1 h-1.5 overflow-hidden rounded-full bg-slate-700">
+              <div
+                role="progressbar"
+                aria-valuenow={factor.score}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${factor.name} score`}
+                className={`h-full rounded-full transition-all ${getBarColor(factor.score)}`}
+                style={{ width: `${factor.score}%` }}
+              />
+            </div>
+
+            <p className="text-xs text-slate-400">{factor.explanation}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/lib/power-level.ts
+++ b/src/lib/power-level.ts
@@ -1,0 +1,571 @@
+import type { DeckData, EnrichedCard } from "./types";
+import { generateTags } from "./card-tags";
+import { findCombosInDeck, type KnownCombo } from "./known-combos";
+import { computeManaBaseMetrics } from "./color-distribution";
+import { computeLandBaseEfficiency } from "./land-base-efficiency";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PowerLevelFactor {
+  id: string;
+  name: string;
+  rawValue: number;
+  score: number; // 0–100
+  weight: number; // 0–1
+  maxRawValue: number;
+  explanation: string;
+}
+
+export interface PowerLevelResult {
+  powerLevel: number; // 1–10
+  rawScore: number; // 0–100
+  bandLabel: string;
+  bandDescription: string;
+  factors: PowerLevelFactor[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Curated list of fast mana card names for power level detection */
+export const FAST_MANA_NAMES: Set<string> = new Set([
+  "Sol Ring",
+  "Mana Crypt",
+  "Mana Vault",
+  "Chrome Mox",
+  "Mox Diamond",
+  "Jeweled Lotus",
+  "Mox Opal",
+  "Lotus Petal",
+  "Mox Amber",
+  "Lion's Eye Diamond",
+  "Dark Ritual",
+  "Cabal Ritual",
+  "Simian Spirit Guide",
+  "Elvish Spirit Guide",
+  "Rite of Flame",
+  "Pyretic Ritual",
+  "Desperate Ritual",
+]);
+
+/** Factor weights — must sum to 1.0 */
+export const FACTOR_WEIGHTS = {
+  tutorDensity: 0.18,
+  fastMana: 0.16,
+  averageCmc: 0.12,
+  interactionDensity: 0.14,
+  infiniteCombos: 0.14,
+  manaBaseQuality: 0.10,
+  cardDrawDensity: 0.08,
+  winConditionSpeed: 0.08,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getAllCards(deck: DeckData) {
+  return [...deck.commanders, ...deck.mainboard, ...deck.sideboard];
+}
+
+/**
+ * Count the number of cards in the deck that have at least one of the given tags.
+ * Each unique card name counts once (regardless of quantity).
+ */
+export function countTaggedCards(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>,
+  tags: string[]
+): number {
+  const tagSet = new Set(tags);
+  const allCards = getAllCards(deck);
+  let count = 0;
+
+  for (const card of allCards) {
+    const enriched = cardMap[card.name];
+    if (!enriched) continue;
+    const cardTags = generateTags(enriched);
+    if (cardTags.some((t) => tagSet.has(t))) {
+      count += card.quantity;
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Count the number of fast mana cards in the deck (by name match).
+ * Works even without enrichment data.
+ */
+export function countFastMana(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>
+): number {
+  const allCards = getAllCards(deck);
+  let count = 0;
+
+  for (const card of allCards) {
+    if (FAST_MANA_NAMES.has(card.name)) {
+      count += card.quantity;
+    }
+    // Also check flavor names if enriched
+    const enriched = cardMap[card.name];
+    if (enriched && enriched.flavorName && FAST_MANA_NAMES.has(enriched.flavorName)) {
+      count += card.quantity;
+    }
+  }
+
+  return count;
+}
+
+// ---------------------------------------------------------------------------
+// Individual factor scorers
+// ---------------------------------------------------------------------------
+
+/**
+ * Score tutor density. Breakpoints:
+ * 0 → 0, 1-2 → 30, 3-4 → 55, 5-6 → 75, 7+ → 100
+ */
+export function scoreTutorDensity(count: number): { score: number; explanation: string } {
+  let score: number;
+  if (count === 0) score = 0;
+  else if (count <= 2) score = 30;
+  else if (count <= 4) score = 55;
+  else if (count <= 6) score = 75;
+  else score = 100;
+
+  const explanation =
+    count === 0
+      ? "No tutors detected — limited consistency finding key pieces."
+      : count <= 2
+      ? `${count} tutor${count > 1 ? "s" : ""} detected — some ability to find win conditions.`
+      : count <= 4
+      ? `${count} tutors detected — solid tutor package for reliable consistency.`
+      : count <= 6
+      ? `${count} tutors detected — heavy tutoring enables multiple win lines.`
+      : `${count} tutors detected — maximum tutor density for cEDH-level consistency.`;
+
+  return { score, explanation };
+}
+
+/**
+ * Score fast mana count. Breakpoints:
+ * 0 → 0, 1 → 25, 2 → 45, 3-4 → 70, 5+ → 100
+ */
+export function scoreFastMana(count: number): { score: number; explanation: string } {
+  let score: number;
+  if (count === 0) score = 0;
+  else if (count === 1) score = 25;
+  else if (count === 2) score = 45;
+  else if (count <= 4) score = 70;
+  else score = 100;
+
+  const explanation =
+    count === 0
+      ? "No fast mana detected — limited acceleration beyond land drops."
+      : count === 1
+      ? `${count} fast mana piece (${count <= 1 ? "Sol Ring" : "fast mana"}) — minor acceleration.`
+      : count === 2
+      ? `${count} fast mana pieces — noticeable acceleration above curve.`
+      : count <= 4
+      ? `${count} fast mana pieces — strong mana acceleration common in high-power decks.`
+      : `${count} fast mana pieces — maximum acceleration for explosive starts.`;
+
+  return { score, explanation };
+}
+
+/**
+ * Score average CMC with continuous linear interpolation.
+ * ≤1.8 → 100, ≥4.0 → 0, linear between.
+ * Lower CMC is better (faster deck).
+ */
+export function scoreAverageCmc(avgCmc: number): { score: number; explanation: string } {
+  const LOW = 1.8;
+  const HIGH = 4.0;
+
+  let score: number;
+  if (avgCmc <= LOW) {
+    score = 100;
+  } else if (avgCmc >= HIGH) {
+    score = 0;
+  } else {
+    // Linear interpolation: 100 at LOW, 0 at HIGH
+    score = Math.round(100 * (1 - (avgCmc - LOW) / (HIGH - LOW)));
+  }
+
+  const label =
+    avgCmc <= 1.8 ? "very low" :
+    avgCmc <= 2.3 ? "low" :
+    avgCmc <= 2.8 ? "moderate" :
+    avgCmc <= 3.5 ? "high" : "very high";
+
+  const explanation =
+    avgCmc === 0
+      ? "No non-land cards found — average CMC cannot be computed."
+      : `Average CMC of ${avgCmc.toFixed(2)} is ${label} — ${
+          avgCmc <= 2.3
+            ? "efficient curve for fast gameplay."
+            : avgCmc <= 3.0
+            ? "moderate curve with reasonable tempo."
+            : "high curve that slows down win conditions."
+        }`;
+
+  return { score, explanation };
+}
+
+/**
+ * Score interaction density (Removal + Counterspell + Board Wipe). Breakpoints:
+ * 0-2 → 0, 3-5 → 25, 6-8 → 45, 9-12 → 65, 13-16 → 80, 17+ → 100
+ */
+export function scoreInteractionDensity(count: number): { score: number; explanation: string } {
+  let score: number;
+  if (count <= 2) score = 0;
+  else if (count <= 5) score = 25;
+  else if (count <= 8) score = 45;
+  else if (count <= 12) score = 65;
+  else if (count <= 16) score = 80;
+  else score = 100;
+
+  const explanation =
+    count <= 2
+      ? `${count} interaction piece${count !== 1 ? "s" : ""} — very few answers to threats.`
+      : count <= 5
+      ? `${count} interaction pieces — minimal interaction, vulnerable to opponent combos.`
+      : count <= 8
+      ? `${count} interaction pieces — modest interaction package.`
+      : count <= 12
+      ? `${count} interaction pieces — solid interaction density.`
+      : count <= 16
+      ? `${count} interaction pieces — high interaction for disrupting opponents.`
+      : `${count} interaction pieces — maximum interaction density.`;
+
+  return { score, explanation };
+}
+
+/**
+ * Score infinite combo count (filtered to infinite/wincon types only).
+ * 0 → 0, 1 → 50, 2 → 75, 3+ → 100
+ */
+export function scoreInfiniteCombos(combos: KnownCombo[]): { score: number; explanation: string } {
+  const relevant = combos.filter(
+    (c) => c.type === "infinite" || c.type === "wincon"
+  );
+  const count = relevant.length;
+
+  let score: number;
+  if (count === 0) score = 0;
+  else if (count === 1) score = 50;
+  else if (count === 2) score = 75;
+  else score = 100;
+
+  const explanation =
+    count === 0
+      ? "No infinite combos or win conditions detected."
+      : count === 1
+      ? `${count} infinite combo/win condition detected — a single dedicated win line.`
+      : count === 2
+      ? `${count} infinite combos/win conditions detected — redundant win lines.`
+      : `${count} infinite combos/win conditions detected — multiple redundant win lines for consistency.`;
+
+  return { score, explanation };
+}
+
+/**
+ * Score mana base quality — direct passthrough of land base efficiency score (0-100).
+ */
+export function scoreManaBaseQuality(landEfficiencyScore: number): { score: number; explanation: string } {
+  const score = Math.max(0, Math.min(100, Math.round(landEfficiencyScore)));
+
+  const label =
+    score >= 80 ? "excellent" :
+    score >= 60 ? "good" :
+    score >= 40 ? "fair" :
+    score >= 20 ? "below average" : "poor";
+
+  const explanation = `Mana base quality is ${label} (${score}/100) based on untapped lands, color coverage, and fixing.`;
+
+  return { score, explanation };
+}
+
+/**
+ * Score card draw density (Card Draw + Card Advantage tags). Breakpoints:
+ * 0-3 → 0, 4-6 → 30, 7-9 → 55, 10-12 → 75, 13+ → 100
+ */
+export function scoreCardDrawDensity(count: number): { score: number; explanation: string } {
+  let score: number;
+  if (count <= 3) score = 0;
+  else if (count <= 6) score = 30;
+  else if (count <= 9) score = 55;
+  else if (count <= 12) score = 75;
+  else score = 100;
+
+  const explanation =
+    count <= 3
+      ? `${count} card draw piece${count !== 1 ? "s" : ""} — very limited draw, deck may stall.`
+      : count <= 6
+      ? `${count} card draw pieces — minimal card advantage.`
+      : count <= 9
+      ? `${count} card draw pieces — decent draw to maintain hand quality.`
+      : count <= 12
+      ? `${count} card draw pieces — strong card advantage engine.`
+      : `${count} card draw pieces — exceptional card draw for maximum consistency.`;
+
+  return { score, explanation };
+}
+
+/**
+ * Score win condition speed based on average CMC of combo pieces.
+ * Lower CMC combo pieces = faster wins = higher score.
+ * Falls back to overall average CMC if no combos found.
+ */
+export function scoreWinConditionSpeed(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>,
+  combos: KnownCombo[]
+): { score: number; explanation: string } {
+  const relevantCombos = combos.filter(
+    (c) => c.type === "infinite" || c.type === "wincon"
+  );
+
+  if (relevantCombos.length > 0) {
+    // Collect all unique combo piece names
+    const comboPieceNames = new Set<string>();
+    for (const combo of relevantCombos) {
+      for (const card of combo.cards) {
+        comboPieceNames.add(card);
+      }
+    }
+
+    // Average the CMC of combo pieces that are enriched
+    let totalCmc = 0;
+    let count = 0;
+    for (const name of comboPieceNames) {
+      const enriched = cardMap[name];
+      if (enriched) {
+        totalCmc += enriched.cmc;
+        count++;
+      }
+    }
+
+    if (count > 0) {
+      const avgComboCmc = totalCmc / count;
+      // Invert the CMC scale: CMC ≤2 → 100, CMC ≥6 → 0, linear between
+      const LOW = 2;
+      const HIGH = 6;
+      let score: number;
+      if (avgComboCmc <= LOW) score = 100;
+      else if (avgComboCmc >= HIGH) score = 0;
+      else score = Math.round(100 * (1 - (avgComboCmc - LOW) / (HIGH - LOW)));
+
+      const explanation = `Average CMC of combo pieces is ${avgComboCmc.toFixed(1)} — ${
+        avgComboCmc <= 3 ? "low-cost, fast win condition." :
+        avgComboCmc <= 4.5 ? "moderate-cost combo pieces." :
+        "high-cost combo pieces that take longer to assemble."
+      }`;
+
+      return { score, explanation };
+    }
+  }
+
+  // No combo pieces found — fall back to overall CMC assessment
+  const metrics = computeManaBaseMetrics(deck, cardMap);
+  const avgCmc = metrics.averageCmc;
+
+  if (avgCmc === 0) {
+    return {
+      score: 0,
+      explanation: "No win conditions or combo pieces detected.",
+    };
+  }
+
+  // Lower curve = faster threats
+  const LOW = 2;
+  const HIGH = 5;
+  let score: number;
+  if (avgCmc <= LOW) score = 70;
+  else if (avgCmc >= HIGH) score = 0;
+  else score = Math.round(70 * (1 - (avgCmc - LOW) / (HIGH - LOW)));
+
+  return {
+    score,
+    explanation: `No known combo pieces found. Deck curve of ${avgCmc.toFixed(1)} suggests ${
+      avgCmc <= 3 ? "efficient threats." : avgCmc <= 4 ? "moderate-speed threats." : "slow win conditions."
+    }`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Raw score to power level mapping
+// ---------------------------------------------------------------------------
+
+interface PowerLevelBand {
+  powerLevel: number;
+  bandLabel: string;
+  bandDescription: string;
+}
+
+/**
+ * Map a raw 0-100 score to a power level 1-10 with band label and description.
+ * Each 10-point band maps to one power level.
+ * Clamps values below 0 to power 1 and above 100 to power 10.
+ */
+export function rawScoreToPowerLevel(rawScore: number): PowerLevelBand {
+  const clamped = Math.max(0, Math.min(100, rawScore));
+  // Map 0-9 → 1, 10-19 → 2, ..., 90-100 → 10
+  const powerLevel = clamped >= 100 ? 10 : Math.floor(clamped / 10) + 1;
+
+  const bandLabel =
+    powerLevel <= 3 ? "Casual" :
+    powerLevel <= 5 ? "Focused" :
+    powerLevel <= 7 ? "Optimized" :
+    powerLevel <= 9 ? "High Power" : "cEDH";
+
+  const bandDescription =
+    powerLevel <= 3
+      ? "Precon-level or jank. No tutors, no fast mana, high curve, minimal interaction."
+      : powerLevel <= 5
+      ? "Clear strategy with some optimization. A few tutors, moderate curve, possibly 1 combo."
+      : powerLevel <= 7
+      ? "Efficient curve, multiple tutors, consistent game plan, 1-2 combos, solid interaction."
+      : powerLevel <= 9
+      ? "Fast mana, efficient tutors, multiple win lines, low curve, high interaction density."
+      : "Fully optimized for speed. Maximum tutors, fast mana, redundant combo lines, turn 3-5 wins.";
+
+  return { powerLevel, bandLabel, bandDescription };
+}
+
+// ---------------------------------------------------------------------------
+// Main computation
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the power level score for a deck with full factor breakdown.
+ */
+export function computePowerLevel(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>
+): PowerLevelResult {
+  // Gather inputs
+  const allCards = getAllCards(deck);
+  const cardNames = allCards.map((c) => c.name);
+  const combos = findCombosInDeck(cardNames);
+  const metrics = computeManaBaseMetrics(deck, cardMap);
+  const landEfficiency = computeLandBaseEfficiency(deck, cardMap);
+
+  // Count factors
+  const tutorCount = countTaggedCards(deck, cardMap, ["Tutor"]);
+  const fastManaCount = countFastMana(deck, cardMap);
+  const interactionCount = countTaggedCards(deck, cardMap, [
+    "Removal",
+    "Counterspell",
+    "Board Wipe",
+  ]);
+  const cardDrawCount = countTaggedCards(deck, cardMap, [
+    "Card Draw",
+    "Card Advantage",
+  ]);
+
+  // Score each factor
+  const tutorResult = scoreTutorDensity(tutorCount);
+  const fastManaResult = scoreFastMana(fastManaCount);
+  const cmcResult = scoreAverageCmc(metrics.averageCmc);
+  const interactionResult = scoreInteractionDensity(interactionCount);
+  const comboResult = scoreInfiniteCombos(combos);
+  const manaBaseResult = scoreManaBaseQuality(landEfficiency.overallScore);
+  const cardDrawResult = scoreCardDrawDensity(cardDrawCount);
+  const winSpeedResult = scoreWinConditionSpeed(deck, cardMap, combos);
+
+  // Build factor array
+  const factors: PowerLevelFactor[] = [
+    {
+      id: "tutor-density",
+      name: "Tutor Density",
+      rawValue: tutorCount,
+      score: tutorResult.score,
+      weight: FACTOR_WEIGHTS.tutorDensity,
+      maxRawValue: 99,
+      explanation: tutorResult.explanation,
+    },
+    {
+      id: "fast-mana",
+      name: "Fast Mana",
+      rawValue: fastManaCount,
+      score: fastManaResult.score,
+      weight: FACTOR_WEIGHTS.fastMana,
+      maxRawValue: 17,
+      explanation: fastManaResult.explanation,
+    },
+    {
+      id: "average-cmc",
+      name: "Average CMC",
+      rawValue: Math.round(metrics.averageCmc * 100) / 100,
+      score: cmcResult.score,
+      weight: FACTOR_WEIGHTS.averageCmc,
+      maxRawValue: 10,
+      explanation: cmcResult.explanation,
+    },
+    {
+      id: "interaction-density",
+      name: "Interaction Density",
+      rawValue: interactionCount,
+      score: interactionResult.score,
+      weight: FACTOR_WEIGHTS.interactionDensity,
+      maxRawValue: 99,
+      explanation: interactionResult.explanation,
+    },
+    {
+      id: "infinite-combos",
+      name: "Infinite Combos",
+      rawValue: combos.filter((c) => c.type === "infinite" || c.type === "wincon").length,
+      score: comboResult.score,
+      weight: FACTOR_WEIGHTS.infiniteCombos,
+      maxRawValue: 10,
+      explanation: comboResult.explanation,
+    },
+    {
+      id: "mana-base-quality",
+      name: "Mana Base Quality",
+      rawValue: landEfficiency.overallScore,
+      score: manaBaseResult.score,
+      weight: FACTOR_WEIGHTS.manaBaseQuality,
+      maxRawValue: 100,
+      explanation: manaBaseResult.explanation,
+    },
+    {
+      id: "card-draw-density",
+      name: "Card Draw Density",
+      rawValue: cardDrawCount,
+      score: cardDrawResult.score,
+      weight: FACTOR_WEIGHTS.cardDrawDensity,
+      maxRawValue: 99,
+      explanation: cardDrawResult.explanation,
+    },
+    {
+      id: "win-condition-speed",
+      name: "Win Condition Speed",
+      rawValue: metrics.averageCmc,
+      score: winSpeedResult.score,
+      weight: FACTOR_WEIGHTS.winConditionSpeed,
+      maxRawValue: 10,
+      explanation: winSpeedResult.explanation,
+    },
+  ];
+
+  // Weighted sum → raw score
+  const rawScore = Math.round(
+    factors.reduce((sum, f) => sum + f.score * f.weight, 0)
+  );
+
+  const { powerLevel, bandLabel, bandDescription } = rawScoreToPowerLevel(rawScore);
+
+  return {
+    powerLevel,
+    rawScore,
+    bandLabel,
+    bandDescription,
+    factors,
+  };
+}

--- a/tests/unit/power-level.spec.ts
+++ b/tests/unit/power-level.spec.ts
@@ -1,0 +1,612 @@
+import { test, expect } from "@playwright/test";
+import {
+  FAST_MANA_NAMES,
+  FACTOR_WEIGHTS,
+  countFastMana,
+  scoreTutorDensity,
+  scoreFastMana,
+  scoreAverageCmc,
+  scoreInteractionDensity,
+  scoreInfiniteCombos,
+  rawScoreToPowerLevel,
+  computePowerLevel,
+} from "../../src/lib/power-level";
+import type { DeckData, EnrichedCard } from "../../src/lib/types";
+import type { KnownCombo } from "../../src/lib/known-combos";
+
+// ---------------------------------------------------------------------------
+// Test helpers (mirroring synergy-engine.spec.ts pattern)
+// ---------------------------------------------------------------------------
+
+function mockCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
+  return {
+    name: "Test Card",
+    manaCost: "",
+    cmc: 0,
+    colorIdentity: [],
+    colors: [],
+    typeLine: "Creature",
+    supertypes: [],
+    subtypes: [],
+    oracleText: "",
+    keywords: [],
+    power: null,
+    toughness: null,
+    loyalty: null,
+    rarity: "common",
+    imageUris: null,
+    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
+    producedMana: [],
+    flavorName: null,
+    ...overrides,
+  };
+}
+
+function mockDeck(
+  mainboard: string[],
+  commanders: string[] = []
+): DeckData {
+  return {
+    name: "Test Deck",
+    source: "text",
+    url: "",
+    commanders: commanders.map((name) => ({ name, quantity: 1 })),
+    mainboard: mainboard.map((name) => ({ name, quantity: 1 })),
+    sideboard: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// FAST_MANA_NAMES
+// ---------------------------------------------------------------------------
+
+test.describe("FAST_MANA_NAMES", () => {
+  test("contains expected fast mana cards", () => {
+    expect(FAST_MANA_NAMES.has("Sol Ring")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Mana Crypt")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Mana Vault")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Chrome Mox")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Mox Diamond")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Jeweled Lotus")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Mox Opal")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Lotus Petal")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Mox Amber")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Lion's Eye Diamond")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Dark Ritual")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Cabal Ritual")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Simian Spirit Guide")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Elvish Spirit Guide")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Rite of Flame")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Pyretic Ritual")).toBe(true);
+    expect(FAST_MANA_NAMES.has("Desperate Ritual")).toBe(true);
+  });
+
+  test("has exactly 17 entries", () => {
+    expect(FAST_MANA_NAMES.size).toBe(17);
+  });
+
+  test("excludes non-fast-mana cards", () => {
+    expect(FAST_MANA_NAMES.has("Forest")).toBe(false);
+    expect(FAST_MANA_NAMES.has("Lightning Bolt")).toBe(false);
+    expect(FAST_MANA_NAMES.has("Command Tower")).toBe(false);
+    expect(FAST_MANA_NAMES.has("Arcane Signet")).toBe(false);
+    expect(FAST_MANA_NAMES.has("Birds of Paradise")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FACTOR_WEIGHTS
+// ---------------------------------------------------------------------------
+
+test.describe("FACTOR_WEIGHTS", () => {
+  test("all weights sum to 1.0", () => {
+    const sum = Object.values(FACTOR_WEIGHTS).reduce((a, b) => a + b, 0);
+    expect(sum).toBeCloseTo(1.0, 10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countFastMana
+// ---------------------------------------------------------------------------
+
+test.describe("countFastMana", () => {
+  test("returns 0 for deck with no fast mana", () => {
+    const deck = mockDeck(["Lightning Bolt", "Forest", "Counterspell"]);
+    const cardMap: Record<string, EnrichedCard> = {};
+    expect(countFastMana(deck, cardMap)).toBe(0);
+  });
+
+  test("returns correct count for Sol Ring + Mana Crypt", () => {
+    const deck = mockDeck(["Sol Ring", "Mana Crypt", "Lightning Bolt"]);
+    const cardMap: Record<string, EnrichedCard> = {};
+    expect(countFastMana(deck, cardMap)).toBe(2);
+  });
+
+  test("returns correct count for all 17 fast mana cards", () => {
+    const deck = mockDeck([...FAST_MANA_NAMES]);
+    const cardMap: Record<string, EnrichedCard> = {};
+    expect(countFastMana(deck, cardMap)).toBe(17);
+  });
+
+  test("counts fast mana in commanders zone", () => {
+    const deck = mockDeck(["Lightning Bolt"], ["Sol Ring"]);
+    const cardMap: Record<string, EnrichedCard> = {};
+    expect(countFastMana(deck, cardMap)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreTutorDensity
+// ---------------------------------------------------------------------------
+
+test.describe("scoreTutorDensity", () => {
+  test("returns 0 for zero tutors", () => {
+    const { score } = scoreTutorDensity(0);
+    expect(score).toBe(0);
+  });
+
+  test("returns 30 for 1 tutor", () => {
+    const { score } = scoreTutorDensity(1);
+    expect(score).toBe(30);
+  });
+
+  test("returns 30 for 2 tutors", () => {
+    const { score } = scoreTutorDensity(2);
+    expect(score).toBe(30);
+  });
+
+  test("returns 55 for 3 tutors", () => {
+    const { score } = scoreTutorDensity(3);
+    expect(score).toBe(55);
+  });
+
+  test("returns 55 for 4 tutors", () => {
+    const { score } = scoreTutorDensity(4);
+    expect(score).toBe(55);
+  });
+
+  test("returns 75 for 5 tutors", () => {
+    const { score } = scoreTutorDensity(5);
+    expect(score).toBe(75);
+  });
+
+  test("returns 75 for 6 tutors", () => {
+    const { score } = scoreTutorDensity(6);
+    expect(score).toBe(75);
+  });
+
+  test("returns 100 for 7+ tutors", () => {
+    expect(scoreTutorDensity(7).score).toBe(100);
+    expect(scoreTutorDensity(10).score).toBe(100);
+    expect(scoreTutorDensity(99).score).toBe(100);
+  });
+
+  test("returns non-empty explanation", () => {
+    const { explanation } = scoreTutorDensity(3);
+    expect(explanation.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreFastMana
+// ---------------------------------------------------------------------------
+
+test.describe("scoreFastMana", () => {
+  test("returns 0 for zero fast mana", () => {
+    expect(scoreFastMana(0).score).toBe(0);
+  });
+
+  test("returns 25 for 1 fast mana", () => {
+    expect(scoreFastMana(1).score).toBe(25);
+  });
+
+  test("returns 45 for 2 fast mana", () => {
+    expect(scoreFastMana(2).score).toBe(45);
+  });
+
+  test("returns 70 for 3 fast mana", () => {
+    expect(scoreFastMana(3).score).toBe(70);
+  });
+
+  test("returns 70 for 4 fast mana", () => {
+    expect(scoreFastMana(4).score).toBe(70);
+  });
+
+  test("returns 100 for 5+ fast mana", () => {
+    expect(scoreFastMana(5).score).toBe(100);
+    expect(scoreFastMana(10).score).toBe(100);
+  });
+
+  test("returns non-empty explanation", () => {
+    expect(scoreFastMana(2).explanation.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreAverageCmc
+// ---------------------------------------------------------------------------
+
+test.describe("scoreAverageCmc", () => {
+  test("returns 100 for avg CMC ≤ 1.8", () => {
+    expect(scoreAverageCmc(0).score).toBe(100);
+    expect(scoreAverageCmc(1.0).score).toBe(100);
+    expect(scoreAverageCmc(1.5).score).toBe(100);
+    expect(scoreAverageCmc(1.8).score).toBe(100);
+  });
+
+  test("returns 0 for avg CMC ≥ 4.0", () => {
+    expect(scoreAverageCmc(4.0).score).toBe(0);
+    expect(scoreAverageCmc(4.5).score).toBe(0);
+    expect(scoreAverageCmc(6.0).score).toBe(0);
+  });
+
+  test("returns mid-range score for avg CMC 2.9 (continuous interpolation)", () => {
+    // 2.9 is between 1.8 and 4.0 — should be between 0 and 100, roughly middle
+    const { score } = scoreAverageCmc(2.9);
+    expect(score).toBeGreaterThan(0);
+    expect(score).toBeLessThan(100);
+    // Linear: score = 100 * (1 - (2.9 - 1.8) / (4.0 - 1.8)) = 100 * (1 - 1.1/2.2) ≈ 50
+    expect(score).toBeGreaterThanOrEqual(45);
+    expect(score).toBeLessThanOrEqual(55);
+  });
+
+  test("score is strictly decreasing as CMC increases between bounds", () => {
+    const score1 = scoreAverageCmc(2.0).score;
+    const score2 = scoreAverageCmc(2.5).score;
+    const score3 = scoreAverageCmc(3.0).score;
+    const score4 = scoreAverageCmc(3.5).score;
+    expect(score1).toBeGreaterThan(score2);
+    expect(score2).toBeGreaterThan(score3);
+    expect(score3).toBeGreaterThan(score4);
+  });
+
+  test("returns non-empty explanation", () => {
+    expect(scoreAverageCmc(2.5).explanation.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreInteractionDensity
+// ---------------------------------------------------------------------------
+
+test.describe("scoreInteractionDensity", () => {
+  test("returns 0 for 0-2 interaction pieces", () => {
+    expect(scoreInteractionDensity(0).score).toBe(0);
+    expect(scoreInteractionDensity(1).score).toBe(0);
+    expect(scoreInteractionDensity(2).score).toBe(0);
+  });
+
+  test("returns 25 for 3-5 pieces", () => {
+    expect(scoreInteractionDensity(3).score).toBe(25);
+    expect(scoreInteractionDensity(5).score).toBe(25);
+  });
+
+  test("returns 45 for 6-8 pieces", () => {
+    expect(scoreInteractionDensity(6).score).toBe(45);
+    expect(scoreInteractionDensity(8).score).toBe(45);
+  });
+
+  test("returns 65 for 9-12 pieces", () => {
+    expect(scoreInteractionDensity(9).score).toBe(65);
+    expect(scoreInteractionDensity(12).score).toBe(65);
+  });
+
+  test("returns 80 for 13-16 pieces", () => {
+    expect(scoreInteractionDensity(13).score).toBe(80);
+    expect(scoreInteractionDensity(16).score).toBe(80);
+  });
+
+  test("returns 100 for 17+ pieces", () => {
+    expect(scoreInteractionDensity(17).score).toBe(100);
+    expect(scoreInteractionDensity(25).score).toBe(100);
+  });
+
+  test("returns non-empty explanation", () => {
+    expect(scoreInteractionDensity(5).explanation.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scoreInfiniteCombos
+// ---------------------------------------------------------------------------
+
+const mockInfiniteCombo: KnownCombo = {
+  cards: ["Card A", "Card B"],
+  description: "Infinite mana",
+  type: "infinite",
+};
+
+const mockWinconCombo: KnownCombo = {
+  cards: ["Card C", "Card D"],
+  description: "Win with Oracle",
+  type: "wincon",
+};
+
+const mockValueCombo: KnownCombo = {
+  cards: ["Card E", "Card F"],
+  description: "Draw engine",
+  type: "value",
+};
+
+const mockLockCombo: KnownCombo = {
+  cards: ["Card G", "Card H"],
+  description: "Hard lock",
+  type: "lock",
+};
+
+test.describe("scoreInfiniteCombos", () => {
+  test("returns 0 for no combos", () => {
+    expect(scoreInfiniteCombos([]).score).toBe(0);
+  });
+
+  test("returns 0 for value-only combos (non-infinite)", () => {
+    expect(scoreInfiniteCombos([mockValueCombo]).score).toBe(0);
+  });
+
+  test("returns 0 for lock-only combos (non-infinite)", () => {
+    expect(scoreInfiniteCombos([mockLockCombo]).score).toBe(0);
+  });
+
+  test("returns 50 for 1 infinite combo", () => {
+    expect(scoreInfiniteCombos([mockInfiniteCombo]).score).toBe(50);
+  });
+
+  test("returns 50 for 1 wincon combo", () => {
+    expect(scoreInfiniteCombos([mockWinconCombo]).score).toBe(50);
+  });
+
+  test("returns 75 for 2 infinite/wincon combos", () => {
+    expect(scoreInfiniteCombos([mockInfiniteCombo, mockWinconCombo]).score).toBe(75);
+  });
+
+  test("returns 100 for 3+ infinite/wincon combos", () => {
+    const threeCombo: KnownCombo = {
+      cards: ["X", "Y"],
+      description: "Another",
+      type: "infinite",
+    };
+    expect(
+      scoreInfiniteCombos([mockInfiniteCombo, mockWinconCombo, threeCombo]).score
+    ).toBe(100);
+  });
+
+  test("ignores value-type combos in count", () => {
+    // 1 infinite + 1 value = still counted as 1
+    expect(scoreInfiniteCombos([mockInfiniteCombo, mockValueCombo]).score).toBe(50);
+  });
+
+  test("returns non-empty explanation", () => {
+    expect(scoreInfiniteCombos([mockInfiniteCombo]).explanation.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rawScoreToPowerLevel
+// ---------------------------------------------------------------------------
+
+test.describe("rawScoreToPowerLevel", () => {
+  test("maps 0-9 → power level 1", () => {
+    expect(rawScoreToPowerLevel(0).powerLevel).toBe(1);
+    expect(rawScoreToPowerLevel(5).powerLevel).toBe(1);
+    expect(rawScoreToPowerLevel(9).powerLevel).toBe(1);
+  });
+
+  test("maps 10-19 → power level 2", () => {
+    expect(rawScoreToPowerLevel(10).powerLevel).toBe(2);
+    expect(rawScoreToPowerLevel(15).powerLevel).toBe(2);
+    expect(rawScoreToPowerLevel(19).powerLevel).toBe(2);
+  });
+
+  test("maps 50-59 → power level 6", () => {
+    expect(rawScoreToPowerLevel(50).powerLevel).toBe(6);
+    expect(rawScoreToPowerLevel(55).powerLevel).toBe(6);
+    expect(rawScoreToPowerLevel(59).powerLevel).toBe(6);
+  });
+
+  test("maps 90-100 → power level 10", () => {
+    expect(rawScoreToPowerLevel(90).powerLevel).toBe(10);
+    expect(rawScoreToPowerLevel(95).powerLevel).toBe(10);
+    expect(rawScoreToPowerLevel(100).powerLevel).toBe(10);
+  });
+
+  test("clamps negative values to power level 1", () => {
+    expect(rawScoreToPowerLevel(-5).powerLevel).toBe(1);
+    expect(rawScoreToPowerLevel(-100).powerLevel).toBe(1);
+  });
+
+  test("clamps values above 100 to power level 10", () => {
+    expect(rawScoreToPowerLevel(150).powerLevel).toBe(10);
+    expect(rawScoreToPowerLevel(200).powerLevel).toBe(10);
+  });
+
+  test("returns correct band labels", () => {
+    expect(rawScoreToPowerLevel(5).bandLabel).toBe("Casual");
+    expect(rawScoreToPowerLevel(15).bandLabel).toBe("Casual");
+    expect(rawScoreToPowerLevel(25).bandLabel).toBe("Casual");
+    expect(rawScoreToPowerLevel(35).bandLabel).toBe("Focused");
+    expect(rawScoreToPowerLevel(45).bandLabel).toBe("Focused");
+    expect(rawScoreToPowerLevel(55).bandLabel).toBe("Optimized");
+    expect(rawScoreToPowerLevel(65).bandLabel).toBe("Optimized");
+    expect(rawScoreToPowerLevel(75).bandLabel).toBe("High Power");
+    expect(rawScoreToPowerLevel(85).bandLabel).toBe("High Power");
+    expect(rawScoreToPowerLevel(95).bandLabel).toBe("cEDH");
+  });
+
+  test("returns non-empty band description", () => {
+    expect(rawScoreToPowerLevel(50).bandDescription.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePowerLevel
+// ---------------------------------------------------------------------------
+
+test.describe("computePowerLevel", () => {
+  test("returns valid structure for empty deck", () => {
+    const deck = mockDeck([]);
+    const cardMap: Record<string, EnrichedCard> = {};
+    const result = computePowerLevel(deck, cardMap);
+
+    expect(result.powerLevel).toBeGreaterThanOrEqual(1);
+    expect(result.powerLevel).toBeLessThanOrEqual(10);
+    expect(result.rawScore).toBeGreaterThanOrEqual(0);
+    expect(result.rawScore).toBeLessThanOrEqual(100);
+    expect(result.bandLabel).toBeTruthy();
+    expect(result.bandDescription).toBeTruthy();
+    expect(Array.isArray(result.factors)).toBe(true);
+    expect(result.factors.length).toBe(8);
+  });
+
+  test("empty deck returns power level 2 (avg CMC=0 gives CMC score=100, weighted = 12)", () => {
+    // Empty deck: all factors 0 except avgCmc (0 → score 100).
+    // rawScore = 0.12 * 100 = 12 → power level 2
+    const deck = mockDeck([]);
+    const cardMap: Record<string, EnrichedCard> = {};
+    const result = computePowerLevel(deck, cardMap);
+    expect(result.powerLevel).toBe(2);
+  });
+
+  test("all factors have scores in 0-100 range", () => {
+    const deck = mockDeck(["Sol Ring", "Counterspell", "Lightning Bolt"]);
+    const cardMap: Record<string, EnrichedCard> = {
+      "Sol Ring": mockCard({
+        name: "Sol Ring",
+        cmc: 1,
+        typeLine: "Artifact",
+        oracleText: "{T}: Add {C}{C}.",
+        producedMana: ["C"],
+      }),
+      "Counterspell": mockCard({
+        name: "Counterspell",
+        cmc: 2,
+        typeLine: "Instant",
+        oracleText: "Counter target spell.",
+      }),
+      "Lightning Bolt": mockCard({
+        name: "Lightning Bolt",
+        cmc: 1,
+        typeLine: "Instant",
+        oracleText: "Lightning Bolt deals 3 damage to any target.",
+      }),
+    };
+    const result = computePowerLevel(deck, cardMap);
+
+    for (const factor of result.factors) {
+      expect(factor.score).toBeGreaterThanOrEqual(0);
+      expect(factor.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  test("all factors have non-empty explanation strings", () => {
+    const deck = mockDeck(["Sol Ring"]);
+    const cardMap: Record<string, EnrichedCard> = {};
+    const result = computePowerLevel(deck, cardMap);
+
+    for (const factor of result.factors) {
+      expect(factor.explanation.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("returns low power (1-3) for precon-style deck", () => {
+    // Precon: high CMC, no tutors, no fast mana, minimal interaction
+    const deck = mockDeck([
+      "Forest",
+      "Plains",
+      "Island",
+      "Swamp",
+      "Mountain",
+      "Siege Rhino",     // 4 CMC
+      "Serra Angel",     // 5 CMC
+      "Air Elemental",   // 5 CMC
+    ]);
+    const cardMap: Record<string, EnrichedCard> = {
+      "Siege Rhino": mockCard({ name: "Siege Rhino", cmc: 4, typeLine: "Creature" }),
+      "Serra Angel": mockCard({ name: "Serra Angel", cmc: 5, typeLine: "Creature" }),
+      "Air Elemental": mockCard({ name: "Air Elemental", cmc: 5, typeLine: "Creature" }),
+      "Forest": mockCard({ name: "Forest", cmc: 0, typeLine: "Basic Land — Forest", producedMana: ["G"] }),
+      "Plains": mockCard({ name: "Plains", cmc: 0, typeLine: "Basic Land — Plains", producedMana: ["W"] }),
+      "Island": mockCard({ name: "Island", cmc: 0, typeLine: "Basic Land — Island", producedMana: ["U"] }),
+      "Swamp": mockCard({ name: "Swamp", cmc: 0, typeLine: "Basic Land — Swamp", producedMana: ["B"] }),
+      "Mountain": mockCard({ name: "Mountain", cmc: 0, typeLine: "Basic Land — Mountain", producedMana: ["R"] }),
+    };
+    const result = computePowerLevel(deck, cardMap);
+    expect(result.powerLevel).toBeGreaterThanOrEqual(1);
+    expect(result.powerLevel).toBeLessThanOrEqual(4);
+    expect(result.bandLabel).toBe("Casual");
+  });
+
+  test("returns higher power for optimized deck with fast mana and tutors", () => {
+    // Optimized: low CMC, fast mana, tutors, interaction
+    const deckNames = [
+      "Sol Ring",
+      "Mana Crypt",
+      "Demonic Tutor",
+      "Vampiric Tutor",
+      "Counterspell",
+      "Force of Will",
+      "Lightning Bolt",
+      "Path to Exile",
+      "Thassa's Oracle",
+      "Demonic Consultation",
+    ];
+    const deck = mockDeck(deckNames);
+    const cardMap: Record<string, EnrichedCard> = {
+      "Sol Ring": mockCard({
+        name: "Sol Ring", cmc: 1, typeLine: "Artifact",
+        oracleText: "{T}: Add {C}{C}.",
+      }),
+      "Mana Crypt": mockCard({
+        name: "Mana Crypt", cmc: 0, typeLine: "Artifact",
+        oracleText: "At the beginning of your upkeep, flip a coin. If you lose the flip, Mana Crypt deals 3 damage to you. {T}: Add {C}{C}.",
+      }),
+      "Demonic Tutor": mockCard({
+        name: "Demonic Tutor", cmc: 2, typeLine: "Sorcery",
+        oracleText: "Search your library for a card, put that card into your hand, then shuffle.",
+      }),
+      "Vampiric Tutor": mockCard({
+        name: "Vampiric Tutor", cmc: 1, typeLine: "Instant",
+        oracleText: "Search your library for a card, then shuffle and put that card on top. You lose 2 life.",
+      }),
+      "Counterspell": mockCard({
+        name: "Counterspell", cmc: 2, typeLine: "Instant",
+        oracleText: "Counter target spell.",
+      }),
+      "Force of Will": mockCard({
+        name: "Force of Will", cmc: 5, typeLine: "Instant",
+        oracleText: "You may pay 1 life and exile a blue card from your hand rather than pay this spell's mana cost.\nCounter target spell.",
+      }),
+      "Lightning Bolt": mockCard({
+        name: "Lightning Bolt", cmc: 1, typeLine: "Instant",
+        oracleText: "Lightning Bolt deals 3 damage to any target.",
+      }),
+      "Path to Exile": mockCard({
+        name: "Path to Exile", cmc: 1, typeLine: "Instant",
+        oracleText: "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
+      }),
+      "Thassa's Oracle": mockCard({
+        name: "Thassa's Oracle", cmc: 2, typeLine: "Creature",
+        oracleText: "When Thassa's Oracle enters the battlefield, look at the top X cards of your library, where X is your devotion to blue. If X is greater than or equal to the number of cards in your library, you win the game.",
+      }),
+      "Demonic Consultation": mockCard({
+        name: "Demonic Consultation", cmc: 1, typeLine: "Instant",
+        oracleText: "Name a card. Exile the top six cards of your library, then reveal cards from the top of your library until you reveal the named card. Put that card into your hand and exile all other cards revealed this way.",
+      }),
+    };
+    const result = computePowerLevel(deck, cardMap);
+    // Optimized deck should score higher than a precon
+    expect(result.powerLevel).toBeGreaterThan(4);
+  });
+
+  test("deck with Thassa's Oracle + Demonic Consultation combo gets higher combo score", () => {
+    const deck = mockDeck(["Thassa's Oracle", "Demonic Consultation"]);
+    const cardMap: Record<string, EnrichedCard> = {
+      "Thassa's Oracle": mockCard({ name: "Thassa's Oracle", cmc: 2, typeLine: "Creature" }),
+      "Demonic Consultation": mockCard({ name: "Demonic Consultation", cmc: 1, typeLine: "Instant" }),
+    };
+    const result = computePowerLevel(deck, cardMap);
+
+    const comboFactor = result.factors.find((f) => f.id === "infinite-combos");
+    expect(comboFactor).toBeDefined();
+    expect(comboFactor!.score).toBe(50); // 1 wincon combo = 50
+  });
+});


### PR DESCRIPTION
## Summary

- Adds transparent, explainable power level scoring (1-10) for Commander decks
- 8 weighted heuristic factors with full breakdown: tutor density, fast mana, average CMC, interaction density, infinite combos, mana base quality, card draw density, win condition speed
- Color-coded power bands (Casual/Focused/Optimized/High Power/cEDH) with human-readable descriptions
- Full unit test coverage (60 tests) and e2e tests (7 tests)

## Details

**`src/lib/power-level.ts`** — Core scoring logic
- `FAST_MANA_NAMES`: curated Set of 17 fast mana card names
- `FACTOR_WEIGHTS`: 8 weights summing to 1.0 (tutor 18%, fast mana 16%, avg CMC 12%, interaction 14%, infinite combos 14%, mana base 10%, card draw 8%, win speed 8%)
- Individual factor scorers with breakpoint or continuous interpolation mapping
- `computePowerLevel(deck, cardMap)` → `PowerLevelResult` with per-factor breakdown

**`src/components/PowerLevelEstimator.tsx`** — UI component
- Large power level number with color coding by band
- Band label badge and description subtitle
- Raw score (0-100) with progress bar
- Factor breakdown rows with weights, scores, progress bars, and explanations
- Full `data-testid` attributes and `aria-labelledby` structure

**`src/components/DeckAnalysis.tsx`** — Integration
- `computePowerLevel` memoized via `useMemo`
- `<PowerLevelEstimator>` rendered as first section before Mana Curve

## Test plan

- [x] 60 unit tests pass (`tests/unit/power-level.spec.ts`)
- [x] Build passes with no TypeScript errors (`npm run build`)
- [ ] E2E tests pass (`e2e/deck-analysis.spec.ts`)
- [ ] Manual: import precon → power 1-3; import optimized deck → power 6-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)