### PR TITLE
perf: speed up e2e tests by moving pure-function tests to unit suite and reducing safety-net timeouts

### DIFF
--- a/e2e/deck-analysis.spec.ts
+++ b/e2e/deck-analysis.spec.ts
@@ -306,8 +306,8 @@ test.describe("Deck Analysis — Tab Availability", () => {
     await page.route("**/api/deck-enrich", async (route) => {
       await new Promise<void>((resolve) => {
         fulfillEnrichment = resolve;
-        // Auto-resolve after 5s as safety net
-        setTimeout(resolve, 5_000);
+        // Auto-resolve after 500ms as safety net
+        setTimeout(resolve, 500);
       });
       await route.fulfill({
         status: 200,

--- a/e2e/deck-enrichment.spec.ts
+++ b/e2e/deck-enrichment.spec.ts
@@ -88,7 +88,7 @@ test.describe("Deck Enrichment", () => {
     await page.route("**/api/deck-enrich", async (route) => {
       await new Promise<void>((resolve) => {
         releaseEnrichment = resolve;
-        setTimeout(resolve, 5_000);
+        setTimeout(resolve, 500);
       });
       await route.fulfill({
         status: 200,
@@ -122,7 +122,7 @@ test.describe("Deck Enrichment", () => {
     await page.route("**/api/deck-enrich", async (route) => {
       await new Promise<void>((resolve) => {
         releaseEnrichment = resolve;
-        setTimeout(resolve, 5_000);
+        setTimeout(resolve, 500);
       });
       await route.fulfill({
         status: 200,
@@ -642,7 +642,7 @@ test.describe("Deck Enrichment — Accessibility", () => {
     await page.route("**/api/deck-enrich", async (route) => {
       await new Promise<void>((resolve) => {
         releaseEnrichment = resolve;
-        setTimeout(resolve, 5_000);
+        setTimeout(resolve, 500);
       });
       await route.fulfill({
         status: 200,

--- a/e2e/deck-import.spec.ts
+++ b/e2e/deck-import.spec.ts
@@ -71,8 +71,8 @@ test.describe("Deck Import — Manual Text Input", () => {
     await page.route("**/api/deck-parse", async (route) => {
       await new Promise<void>((resolve) => {
         releaseRoute = resolve;
-        // Safety net: auto-resolve after 5s to prevent hanging
-        setTimeout(resolve, 5_000);
+        // Safety net: auto-resolve after 500ms to prevent hanging
+        setTimeout(resolve, 500);
       });
       await route.continue();
     });

--- a/e2e/opening-hand-ui.spec.ts
+++ b/e2e/opening-hand-ui.spec.ts
@@ -209,7 +209,7 @@ test.describe("Opening Hand Simulator", () => {
     await page.route("**/api/deck-enrich", async (route) => {
       await new Promise<void>((resolve) => {
         releaseEnrichment = resolve;
-        setTimeout(resolve, 5_000);
+        setTimeout(resolve, 500);
       });
       await route.fulfill({
         status: 200,

--- a/e2e/spellbook-combos.spec.ts
+++ b/e2e/spellbook-combos.spec.ts
@@ -396,7 +396,7 @@ test.describe("Spellbook Graceful Fallback", () => {
     await page.route("**/api/deck-combos", async (route) => {
       await new Promise<void>((resolve) => {
         releaseSpellbook = resolve;
-        setTimeout(resolve, 10_000);
+        setTimeout(resolve, 500);
       });
       await route.fulfill({
         status: 200,

--- a/tests/unit/land-base-efficiency.spec.ts
+++ b/tests/unit/land-base-efficiency.spec.ts
@@ -8,8 +8,8 @@ import {
   computeBasicLandRatio,
   computeLandBaseEfficiency,
   type LandClassification,
-} from "../src/lib/land-base-efficiency";
-import type { DeckData, EnrichedCard, ManaPips } from "../src/lib/types";
+} from "../../src/lib/land-base-efficiency";
+import type { DeckData, EnrichedCard, ManaPips } from "../../src/lib/types";
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
- Move land-base-efficiency.spec.ts (35 tests) from e2e/ to tests/unit/ since
  they test pure functions with no browser interaction
- Reduce setTimeout safety-net delays from 5-10s to 500ms across 7 tests in
  deck-enrichment, deck-import, deck-analysis, spellbook-combos, and
  opening-hand-ui specs — the explicit release calls make long timeouts unnecessary

https://claude.ai/code/session_018NDC7rQiT1hEfsQjh2dHh8