### PR TITLE
feat: add budget analysis with price tracking and spending breakdowns

### DIFF
--- a/e2e/api-deck-enrich.spec.ts
+++ b/e2e/api-deck-enrich.spec.ts
@@ -55,6 +55,12 @@ test.describe("POST /api/deck-enrich", () => {
     expect(solRing.rarity).toBeTruthy();
     expect(solRing.manaPips).toBeDefined();
 
+    // Prices object should be present with usd, usdFoil, eur fields
+    expect(solRing.prices).toBeDefined();
+    expect(solRing.prices).toHaveProperty("usd");
+    expect(solRing.prices).toHaveProperty("usdFoil");
+    expect(solRing.prices).toHaveProperty("eur");
+
     // Command Tower should be found
     const tower = body.cards["Command Tower"];
     expect(tower).toBeDefined();

--- a/e2e/collapsible-panels.spec.ts
+++ b/e2e/collapsible-panels.spec.ts
@@ -21,6 +21,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Counterspell: {
       name: "Counterspell",
@@ -41,6 +42,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Cultivate: {
       name: "Cultivate",
@@ -62,6 +64,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -83,6 +86,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/deck-analysis.spec.ts
+++ b/e2e/deck-analysis.spec.ts
@@ -22,6 +22,7 @@ const MOCK_ANALYSIS_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: 1.5, usdFoil: 5.0, eur: 1.2 },
     },
     "Counterspell": {
       name: "Counterspell",
@@ -42,6 +43,7 @@ const MOCK_ANALYSIS_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 1.25, usdFoil: 3.0, eur: 1.0 },
     },
     "Cultivate": {
       name: "Cultivate",
@@ -63,6 +65,7 @@ const MOCK_ANALYSIS_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 0.35, usdFoil: 1.0, eur: 0.3 },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -84,6 +87,7 @@ const MOCK_ANALYSIS_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: 0.25, usdFoil: 0.75, eur: 0.2 },
     },
   },
   notFound: [],
@@ -111,6 +115,7 @@ const MOCK_COMMANDER_RESPONSE = {
       manaPips: { W: 0, U: 1, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 2.5, usdFoil: 8.0, eur: 2.0 },
     },
     "Sol Ring": {
       name: "Sol Ring",
@@ -131,6 +136,7 @@ const MOCK_COMMANDER_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: 1.5, usdFoil: 5.0, eur: 1.2 },
     },
     "Counterspell": {
       name: "Counterspell",
@@ -151,6 +157,7 @@ const MOCK_COMMANDER_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 1.25, usdFoil: 3.0, eur: 1.0 },
     },
     "Cultivate": {
       name: "Cultivate",
@@ -172,6 +179,7 @@ const MOCK_COMMANDER_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 0.35, usdFoil: 1.0, eur: 0.3 },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -193,6 +201,7 @@ const MOCK_COMMANDER_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: 0.25, usdFoil: 0.75, eur: 0.2 },
     },
     "Breeding Pool": {
       name: "Breeding Pool",
@@ -213,6 +222,7 @@ const MOCK_COMMANDER_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["G", "U"],
       flavorName: null,
+      prices: { usd: 18.0, usdFoil: 25.0, eur: 15.0 },
     },
   },
   notFound: [],
@@ -800,6 +810,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: 1.5, usdFoil: 5.0, eur: 1.2 },
     },
     "Cultivate": {
       name: "Cultivate",
@@ -821,6 +832,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 0.35, usdFoil: 1.0, eur: 0.3 },
     },
     // Card Draw
     "Rhystic Study": {
@@ -843,6 +855,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 1, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 35.0, usdFoil: 45.0, eur: 30.0 },
     },
     // Removal
     "Swords to Plowshares": {
@@ -864,6 +877,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 1, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 2.5, usdFoil: 6.0, eur: 2.0 },
     },
     // Board Wipe (also counts as Removal)
     "Wrath of God": {
@@ -885,6 +899,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 2, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 3.0, usdFoil: 8.0, eur: 2.5 },
     },
     // Counterspell
     "Counterspell": {
@@ -906,6 +921,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 1.25, usdFoil: 3.0, eur: 1.0 },
     },
     // Recursion
     "Regrowth": {
@@ -927,6 +943,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 4.0, usdFoil: 10.0, eur: 3.5 },
     },
     // Protection
     "Heroic Intervention": {
@@ -949,6 +966,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 8.0, usdFoil: 15.0, eur: 7.0 },
     },
     // Untagged vanilla creature
     "Grizzly Bears": {
@@ -970,6 +988,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: 0.1, usdFoil: 0.5, eur: 0.08 },
     },
     // Land
     "Command Tower": {
@@ -992,6 +1011,7 @@ const MOCK_SCORECARD_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: 0.25, usdFoil: 0.75, eur: 0.2 },
     },
   },
   notFound: [],
@@ -1338,5 +1358,130 @@ test.describe("Deck Analysis — Deck Classification", () => {
     expect(classBound).not.toBeNull();
     expect(manaBound).not.toBeNull();
     expect(classBound!.y).toBeLessThan(manaBound!.y);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Budget Analysis
+// ---------------------------------------------------------------------------
+
+test.describe("Deck Analysis — Budget Analysis", () => {
+  test.beforeEach(async ({ deckPage }) => {
+    const { page } = deckPage;
+    await page.route("**/api/deck-enrich", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(MOCK_ANALYSIS_RESPONSE),
+      })
+    );
+    await deckPage.goto();
+    await deckPage.fillDecklist(
+      "1 Sol Ring\n1 Counterspell\n1 Cultivate\n1 Command Tower"
+    );
+    await deckPage.submitImport();
+    await deckPage.waitForDeckDisplay();
+
+    await expect(
+      page.locator('[aria-label="Mana cost: 1 generic"]')
+    ).toBeVisible({ timeout: 10_000 });
+
+    await deckPage.selectDeckViewTab("Analysis");
+    await deckPage.expandAnalysisSection("budget");
+  });
+
+  test("Budget Analysis panel visible on Analysis tab", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    await expect(page.getByTestId("panel-budget")).toBeVisible();
+    // Panel header button contains the title text
+    await expect(page.getByTestId("panel-budget")).toContainText("Budget Analysis");
+  });
+
+  test("displays total deck cost in panel summary", async ({ deckPage }) => {
+    const { page } = deckPage;
+    const panel = page.getByTestId("panel-budget");
+    // The summary is in the panel header button as text
+    // Sol Ring $1.50 + Counterspell $1.25 + Cultivate $0.35 + Command Tower $0.25 = $3.35
+    await expect(panel).toContainText("$3.35");
+  });
+
+  test("displays total cost, avg price, and median price stat cards", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    await expect(page.getByTestId("budget-total-cost")).toBeVisible();
+    await expect(page.getByTestId("budget-avg-price")).toBeVisible();
+    await expect(page.getByTestId("budget-median-price")).toBeVisible();
+
+    // Total cost: $3.35
+    await expect(page.getByTestId("budget-total-cost")).toContainText("$3.35");
+  });
+
+  test("displays price distribution chart with accessible label", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    const chart = page.locator(
+      '[role="img"][aria-label="Price distribution chart"]'
+    );
+    await expect(chart).toBeVisible();
+  });
+
+  test("displays top expensive cards table with correct ranking", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    const table = page.getByTestId("budget-top-expensive");
+    await expect(table).toBeVisible();
+
+    // Sol Ring ($1.50) should be first (most expensive)
+    const firstRow = table.locator("tbody tr").first();
+    await expect(firstRow).toContainText("Sol Ring");
+    await expect(firstRow).toContainText("$1.50");
+  });
+
+  test("displays spending by card type chart", async ({ deckPage }) => {
+    const { page } = deckPage;
+    const chart = page.getByTestId("budget-by-type");
+    await expect(chart).toBeVisible();
+    await expect(chart).toContainText("Spending by Card Type");
+  });
+
+  test("displays spending by role chart with overlap disclaimer", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    const chart = page.getByTestId("budget-by-role");
+    await expect(chart).toBeVisible();
+    await expect(chart).toContainText("Spending by Role");
+    await expect(chart).toContainText(
+      "Cards with multiple roles are counted in each category"
+    );
+  });
+
+  test("budget section appears after Draw Probability", async ({
+    deckPage,
+  }) => {
+    const { page } = deckPage;
+    await deckPage.expandAnalysisSection("hypergeometric");
+
+    const hyperPanel = page.getByTestId("panel-hypergeometric");
+    const budgetPanel = page.getByTestId("panel-budget");
+    await expect(hyperPanel).toBeVisible();
+    await expect(budgetPanel).toBeVisible();
+
+    const hyperBound = await hyperPanel.boundingBox();
+    const budgetBound = await budgetPanel.boundingBox();
+    expect(hyperBound).not.toBeNull();
+    expect(budgetBound).not.toBeNull();
+    expect(hyperBound!.y).toBeLessThan(budgetBound!.y);
+  });
+
+  test("section nav includes Budget chip", async ({ deckPage }) => {
+    const { page } = deckPage;
+    const sectionNav = page.getByTestId("section-nav");
+    await expect(sectionNav).toContainText("Budget");
   });
 });

--- a/e2e/deck-enrichment.spec.ts
+++ b/e2e/deck-enrichment.spec.ts
@@ -22,6 +22,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -43,6 +44,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],
@@ -340,6 +342,7 @@ const MOCK_TAGS_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Swords to Plowshares": {
       name: "Swords to Plowshares",
@@ -361,6 +364,7 @@ const MOCK_TAGS_RESPONSE = {
       manaPips: { W: 1, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Counterspell: {
       name: "Counterspell",
@@ -381,6 +385,7 @@ const MOCK_TAGS_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -402,6 +407,7 @@ const MOCK_TAGS_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/hand-analysis.spec.ts
+++ b/e2e/hand-analysis.spec.ts
@@ -27,6 +27,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -52,6 +53,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Arcane Signet": {
       name: "Arcane Signet",
@@ -77,6 +79,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Swords to Plowshares": {
       name: "Swords to Plowshares",
@@ -102,6 +105,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 1, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Counterspell: {
       name: "Counterspell",
@@ -126,6 +130,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Atraxa, Praetors' Voice": {
       name: "Atraxa, Praetors' Voice",
@@ -151,6 +156,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 1, U: 1, B: 1, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/hypergeometric-ui.spec.ts
+++ b/e2e/hypergeometric-ui.spec.ts
@@ -26,6 +26,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 1, U: 1, B: 1, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Sol Ring": {
       name: "Sol Ring",
@@ -46,6 +47,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -66,6 +68,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Arcane Signet": {
       name: "Arcane Signet",
@@ -86,6 +89,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Swords to Plowshares": {
       name: "Swords to Plowshares",
@@ -107,6 +111,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 1, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Counterspell: {
       name: "Counterspell",
@@ -127,6 +132,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/land-base-efficiency-ui.spec.ts
+++ b/e2e/land-base-efficiency-ui.spec.ts
@@ -26,6 +26,7 @@ const MOCK_LAND_EFFICIENCY_RESPONSE = {
       manaPips: { W: 0, U: 1, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Sol Ring": {
       name: "Sol Ring",
@@ -46,6 +47,7 @@ const MOCK_LAND_EFFICIENCY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Counterspell: {
       name: "Counterspell",
@@ -66,6 +68,7 @@ const MOCK_LAND_EFFICIENCY_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Forest: {
       name: "Forest",
@@ -86,6 +89,7 @@ const MOCK_LAND_EFFICIENCY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Island: {
       name: "Island",
@@ -106,6 +110,7 @@ const MOCK_LAND_EFFICIENCY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["U"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Breeding Pool": {
       name: "Breeding Pool",
@@ -127,6 +132,7 @@ const MOCK_LAND_EFFICIENCY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["G", "U"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -148,6 +154,7 @@ const MOCK_LAND_EFFICIENCY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/mana-recommendations.spec.ts
+++ b/e2e/mana-recommendations.spec.ts
@@ -28,6 +28,7 @@ const MOCK_RESPONSE = {
       manaPips: { W: 0, U: 1, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Sol Ring": {
       name: "Sol Ring",
@@ -48,6 +49,7 @@ const MOCK_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Counterspell: {
       name: "Counterspell",
@@ -68,6 +70,7 @@ const MOCK_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Forest: {
       name: "Forest",
@@ -88,6 +91,7 @@ const MOCK_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Island: {
       name: "Island",
@@ -108,6 +112,7 @@ const MOCK_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["U"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Breeding Pool": {
       name: "Breeding Pool",
@@ -129,6 +134,7 @@ const MOCK_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["G", "U"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -150,6 +156,7 @@ const MOCK_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/opening-hand-ui.spec.ts
+++ b/e2e/opening-hand-ui.spec.ts
@@ -26,6 +26,7 @@ const MOCK_HAND_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -51,6 +52,7 @@ const MOCK_HAND_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Arcane Signet": {
       name: "Arcane Signet",
@@ -76,6 +78,7 @@ const MOCK_HAND_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Swords to Plowshares": {
       name: "Swords to Plowshares",
@@ -101,6 +104,7 @@ const MOCK_HAND_ENRICH_RESPONSE = {
       manaPips: { W: 1, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Counterspell: {
       name: "Counterspell",
@@ -125,6 +129,7 @@ const MOCK_HAND_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Atraxa, Praetors' Voice": {
       name: "Atraxa, Praetors' Voice",
@@ -150,6 +155,7 @@ const MOCK_HAND_ENRICH_RESPONSE = {
       manaPips: { W: 1, U: 1, B: 1, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/spellbook-combos.spec.ts
+++ b/e2e/spellbook-combos.spec.ts
@@ -29,6 +29,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Demonic Consultation": {
       name: "Demonic Consultation",
@@ -54,6 +55,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 1, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Dramatic Reversal": {
       name: "Dramatic Reversal",
@@ -78,6 +80,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 1, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Sol Ring": {
       name: "Sol Ring",
@@ -98,6 +101,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["C"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -119,6 +123,7 @@ const MOCK_ENRICH_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/e2e/synergy-ui.spec.ts
+++ b/e2e/synergy-ui.spec.ts
@@ -32,6 +32,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Walking Ballista": {
       name: "Walking Ballista",
@@ -57,6 +58,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Doubling Season": {
       name: "Doubling Season",
@@ -82,6 +84,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 1, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     Reanimate: {
       name: "Reanimate",
@@ -107,6 +110,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 1, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Rest in Peace": {
       name: "Rest in Peace",
@@ -132,6 +136,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 1, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Thassa's Oracle": {
       name: "Thassa's Oracle",
@@ -157,6 +162,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 0, U: 2, B: 0, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Demonic Consultation": {
       name: "Demonic Consultation",
@@ -182,6 +188,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 1, R: 0, G: 0, C: 0 },
       producedMana: [],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
     "Command Tower": {
       name: "Command Tower",
@@ -203,6 +210,7 @@ const MOCK_SYNERGY_RESPONSE = {
       manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
       producedMana: ["W", "U", "B", "R", "G"],
       flavorName: null,
+      prices: { usd: null, usdFoil: null, eur: null },
     },
   },
   notFound: [],

--- a/src/components/BudgetStats.tsx
+++ b/src/components/BudgetStats.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import type { BudgetAnalysisResult } from "@/lib/budget-analysis";
+import { formatUSD } from "@/lib/budget-analysis";
+
+interface BudgetStatsProps {
+  result: BudgetAnalysisResult;
+}
+
+export default function BudgetStats({ result }: BudgetStatsProps) {
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-3 gap-3">
+        <div
+          className="rounded-lg border border-slate-700 bg-slate-800/50 px-4 py-3"
+          data-testid="budget-total-cost"
+        >
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-400">
+            Total Cost
+          </p>
+          <p className="mt-1 text-lg font-semibold text-white">
+            {result.totalCostFormatted}
+          </p>
+        </div>
+        <div
+          className="rounded-lg border border-slate-700 bg-slate-800/50 px-4 py-3"
+          data-testid="budget-avg-price"
+        >
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-400">
+            Avg Price/Card
+          </p>
+          <p className="mt-1 text-lg font-semibold text-white">
+            {formatUSD(result.averagePricePerCard)}
+          </p>
+        </div>
+        <div
+          className="rounded-lg border border-slate-700 bg-slate-800/50 px-4 py-3"
+          data-testid="budget-median-price"
+        >
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-400">
+            Median Price
+          </p>
+          <p className="mt-1 text-lg font-semibold text-white">
+            {formatUSD(result.medianPricePerCard)}
+          </p>
+        </div>
+      </div>
+      {result.unknownPriceCount > 0 && (
+        <p className="text-xs text-slate-400">
+          {result.unknownPriceCount} card{result.unknownPriceCount === 1 ? "" : "s"} without price data
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/DeckAnalysis.tsx
+++ b/src/components/DeckAnalysis.tsx
@@ -19,6 +19,7 @@ import { computePowerLevel } from "@/lib/power-level";
 import { computeBracketEstimate } from "@/lib/bracket-estimator";
 import { STATIC_CEDH_STAPLES } from "@/lib/cedh-staples";
 import type { SpellbookCombo } from "@/lib/commander-spellbook";
+import { computeBudgetAnalysis } from "@/lib/budget-analysis";
 import ManaCurveChart from "@/components/ManaCurveChart";
 import TypeFilterBar from "@/components/TypeFilterBar";
 import ColorDistributionChart from "@/components/ColorDistributionChart";
@@ -30,6 +31,10 @@ import HypergeometricCalculator from "@/components/HypergeometricCalculator";
 import DeckClassification from "@/components/DeckClassification";
 import CollapsiblePanel from "@/components/CollapsiblePanel";
 import SectionNav from "@/components/SectionNav";
+import BudgetStats from "@/components/BudgetStats";
+import PriceDistributionChart from "@/components/PriceDistributionChart";
+import TopExpensiveCardsTable from "@/components/TopExpensiveCardsTable";
+import PriceByCategoryChart from "@/components/PriceByCategoryChart";
 
 const ANALYSIS_SECTIONS = [
   { id: "commander", label: "Commander" },
@@ -39,6 +44,7 @@ const ANALYSIS_SECTIONS = [
   { id: "color-distribution", label: "Color Dist." },
   { id: "land-efficiency", label: "Land Efficiency" },
   { id: "hypergeometric", label: "Draw Odds" },
+  { id: "budget", label: "Budget" },
 ] as const;
 
 interface DeckAnalysisProps {
@@ -128,6 +134,11 @@ export default function DeckAnalysis({
         spellbookCombos?.exactCombos ?? null
       ),
     [deck, cardMap, powerLevel, spellbookCombos]
+  );
+
+  const budgetAnalysis = useMemo(
+    () => computeBudgetAnalysis(deck, cardMap),
+    [deck, cardMap]
   );
 
   const filteredSpells = curveData.reduce(
@@ -270,6 +281,21 @@ export default function DeckAnalysis({
         onToggle={() => onToggleSection("hypergeometric")}
       >
         <HypergeometricCalculator deck={deck} cardMap={cardMap} />
+      </CollapsiblePanel>
+
+      <CollapsiblePanel
+        id="budget"
+        title="Budget Analysis"
+        summary={budgetAnalysis.totalCostFormatted}
+        expanded={expandedSections.has("budget")}
+        onToggle={() => onToggleSection("budget")}
+      >
+        <div className="space-y-6">
+          <BudgetStats result={budgetAnalysis} />
+          <PriceDistributionChart data={budgetAnalysis.distribution} />
+          <TopExpensiveCardsTable cards={budgetAnalysis.mostExpensive} />
+          <PriceByCategoryChart byType={budgetAnalysis.byType} byRole={budgetAnalysis.byRole} />
+        </div>
       </CollapsiblePanel>
     </div>
   );

--- a/src/components/EnrichedCardRow.tsx
+++ b/src/components/EnrichedCardRow.tsx
@@ -5,6 +5,7 @@ import type { EnrichedCard } from "@/lib/types";
 import ManaCost from "@/components/ManaCost";
 import CardTags from "@/components/CardTags";
 import OracleText from "@/components/OracleText";
+import { formatUSD } from "@/lib/budget-analysis";
 
 interface EnrichedCardRowProps {
   card: EnrichedCard;
@@ -100,6 +101,9 @@ export default function EnrichedCardRow({
                   <span>Keywords: {card.keywords.join(", ")}</span>
                 )}
                 <span className="capitalize">Rarity: {card.rarity}</span>
+                {card.prices.usd != null && (
+                  <span data-testid="card-price">Price: {formatUSD(card.prices.usd)}</span>
+                )}
               </div>
             </div>
           </td>

--- a/src/components/PriceByCategoryChart.tsx
+++ b/src/components/PriceByCategoryChart.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts";
+import ChartContainer from "@/components/ChartContainer";
+import type { TypePriceSummary, RolePriceSummary } from "@/lib/budget-analysis";
+import { formatUSD } from "@/lib/budget-analysis";
+
+interface PriceByCategoryChartProps {
+  byType: TypePriceSummary[];
+  byRole: RolePriceSummary[];
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: { value: number }[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const cost = payload[0].value;
+  if (cost === 0) return null;
+  return (
+    <div className="rounded-lg border border-slate-600 bg-slate-800 px-3 py-2 text-sm shadow-lg">
+      <p className="text-slate-300">{label}</p>
+      <p className="font-semibold text-purple-300">{formatUSD(cost)}</p>
+    </div>
+  );
+}
+
+export default function PriceByCategoryChart({
+  byType,
+  byRole,
+}: PriceByCategoryChartProps) {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mql.matches);
+    const handler = (e: MediaQueryListEvent) =>
+      setPrefersReducedMotion(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  const typeData = byType.map((t) => ({ name: t.type, totalCost: t.totalCost }));
+  const roleData = byRole.map((r) => ({ name: r.tag, totalCost: r.totalCost }));
+
+  return (
+    <div className="space-y-6">
+      {typeData.length > 0 && (
+        <div data-testid="budget-by-type">
+          <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+            Spending by Card Type
+          </h4>
+          <ChartContainer
+            height={Math.max(160, typeData.length * 32 + 40)}
+            ariaLabel="Spending by card type chart"
+          >
+            <BarChart
+              data={typeData}
+              layout="vertical"
+              margin={{ top: 5, right: 30, left: 80, bottom: 5 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="#334155"
+                horizontal={false}
+              />
+              <XAxis
+                type="number"
+                tick={{ fill: "#94a3b8", fontSize: 12 }}
+                tickLine={false}
+                axisLine={{ stroke: "#334155" }}
+                tickFormatter={(v: number) => formatUSD(v)}
+              />
+              <YAxis
+                type="category"
+                dataKey="name"
+                tick={{ fill: "#94a3b8", fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+                width={75}
+              />
+              <Tooltip
+                content={<CustomTooltip />}
+                cursor={{ fill: "rgba(148, 163, 184, 0.1)" }}
+              />
+              <Bar
+                dataKey="totalCost"
+                fill="#9333ea"
+                radius={[0, 3, 3, 0]}
+                isAnimationActive={!prefersReducedMotion}
+              />
+            </BarChart>
+          </ChartContainer>
+        </div>
+      )}
+
+      {roleData.length > 0 && (
+        <div data-testid="budget-by-role">
+          <h4 className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+            Spending by Role
+          </h4>
+          <p className="mb-2 text-xs text-slate-500">
+            Cards with multiple roles are counted in each category
+          </p>
+          <ChartContainer
+            height={Math.max(160, roleData.length * 32 + 40)}
+            ariaLabel="Spending by role chart"
+          >
+            <BarChart
+              data={roleData}
+              layout="vertical"
+              margin={{ top: 5, right: 30, left: 100, bottom: 5 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke="#334155"
+                horizontal={false}
+              />
+              <XAxis
+                type="number"
+                tick={{ fill: "#94a3b8", fontSize: 12 }}
+                tickLine={false}
+                axisLine={{ stroke: "#334155" }}
+                tickFormatter={(v: number) => formatUSD(v)}
+              />
+              <YAxis
+                type="category"
+                dataKey="name"
+                tick={{ fill: "#94a3b8", fontSize: 12 }}
+                tickLine={false}
+                axisLine={false}
+                width={95}
+              />
+              <Tooltip
+                content={<CustomTooltip />}
+                cursor={{ fill: "rgba(148, 163, 184, 0.1)" }}
+              />
+              <Bar
+                dataKey="totalCost"
+                fill="#c084fc"
+                radius={[0, 3, 3, 0]}
+                isAnimationActive={!prefersReducedMotion}
+              />
+            </BarChart>
+          </ChartContainer>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/PriceDistributionChart.tsx
+++ b/src/components/PriceDistributionChart.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from "recharts";
+import ChartContainer from "@/components/ChartContainer";
+import type { PriceDistributionBucket } from "@/lib/budget-analysis";
+
+interface PriceDistributionChartProps {
+  data: PriceDistributionBucket[];
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+}: {
+  active?: boolean;
+  payload?: { value: number }[];
+  label?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  const count = payload[0].value;
+  if (count === 0) return null;
+  return (
+    <div className="rounded-lg border border-slate-600 bg-slate-800 px-3 py-2 text-sm shadow-lg">
+      <p className="text-slate-300">{label}</p>
+      <p className="font-semibold text-purple-300">
+        {count} {count === 1 ? "card" : "cards"}
+      </p>
+    </div>
+  );
+}
+
+export default function PriceDistributionChart({
+  data,
+}: PriceDistributionChartProps) {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mql.matches);
+    const handler = (e: MediaQueryListEvent) =>
+      setPrefersReducedMotion(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  return (
+    <ChartContainer
+      height={200}
+      ariaLabel="Price distribution chart"
+    >
+      <BarChart
+        data={data}
+        margin={{ top: 10, right: 10, left: -10, bottom: 0 }}
+      >
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke="#334155"
+          vertical={false}
+        />
+        <XAxis
+          dataKey="label"
+          tick={{ fill: "#94a3b8", fontSize: 12 }}
+          tickLine={false}
+          axisLine={{ stroke: "#334155" }}
+        />
+        <YAxis
+          allowDecimals={false}
+          tick={{ fill: "#94a3b8", fontSize: 12 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          content={<CustomTooltip />}
+          cursor={{ fill: "rgba(148, 163, 184, 0.1)" }}
+        />
+        <Bar
+          dataKey="count"
+          fill="#9333ea"
+          radius={[3, 3, 0, 0]}
+          isAnimationActive={!prefersReducedMotion}
+        />
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/src/components/TopExpensiveCardsTable.tsx
+++ b/src/components/TopExpensiveCardsTable.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import type { CardPriceEntry } from "@/lib/budget-analysis";
+import { formatUSD } from "@/lib/budget-analysis";
+
+interface TopExpensiveCardsTableProps {
+  cards: CardPriceEntry[];
+}
+
+const DEFAULT_SHOW = 10;
+
+export default function TopExpensiveCardsTable({
+  cards,
+}: TopExpensiveCardsTableProps) {
+  const [showAll, setShowAll] = useState(false);
+
+  if (cards.length === 0) {
+    return (
+      <p className="text-sm text-slate-400">No cards with price data.</p>
+    );
+  }
+
+  const visible = showAll ? cards : cards.slice(0, DEFAULT_SHOW);
+  const hasMore = cards.length > DEFAULT_SHOW;
+
+  return (
+    <div data-testid="budget-top-expensive">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-slate-700 text-xs uppercase tracking-wide text-slate-400">
+            <th scope="col" className="py-2 pr-2 text-right">#</th>
+            <th scope="col" className="py-2 px-2 text-left">Card Name</th>
+            <th scope="col" className="py-2 px-2 text-right">Qty</th>
+            <th scope="col" className="py-2 px-2 text-right">Unit Price</th>
+            <th scope="col" className="py-2 pl-2 text-right">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visible.map((entry, i) => (
+            <tr
+              key={entry.name}
+              className={`border-b border-slate-700/50 ${
+                i % 2 === 1 ? "bg-slate-800/30" : ""
+              }`}
+            >
+              <td className="py-1.5 pr-2 text-right font-mono text-slate-500">
+                {i + 1}
+              </td>
+              <td className="py-1.5 px-2 text-slate-200">{entry.name}</td>
+              <td className="py-1.5 px-2 text-right font-mono text-slate-400">
+                {entry.quantity}
+              </td>
+              <td className="py-1.5 px-2 text-right font-mono text-slate-400">
+                {formatUSD(entry.unitPrice)}
+              </td>
+              <td className="py-1.5 pl-2 text-right font-mono text-white">
+                {formatUSD(entry.totalPrice)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {hasMore && (
+        <button
+          type="button"
+          onClick={() => setShowAll(!showAll)}
+          className="mt-2 text-xs text-purple-400 hover:text-purple-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 rounded-sm"
+          data-testid="budget-show-all-toggle"
+        >
+          {showAll
+            ? "Show top 10"
+            : `Show all ${cards.length} cards`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/lib/budget-analysis.ts
+++ b/src/lib/budget-analysis.ts
@@ -1,0 +1,286 @@
+import type { DeckData, EnrichedCard } from "./types";
+import { parseTypeLine } from "./mana";
+import { generateTags } from "./card-tags";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CardPriceEntry {
+  name: string;
+  quantity: number;
+  unitPrice: number;
+  totalPrice: number;
+}
+
+export interface PriceDistributionBucket {
+  label: string;
+  min: number;
+  max: number;
+  count: number;
+}
+
+export interface TypePriceSummary {
+  type: string;
+  totalCost: number;
+  cardCount: number;
+  averagePrice: number;
+}
+
+export interface RolePriceSummary {
+  tag: string;
+  totalCost: number;
+  cardCount: number;
+  averagePrice: number;
+}
+
+export interface BudgetAnalysisResult {
+  totalCost: number;
+  totalCostFormatted: string;
+  averagePricePerCard: number;
+  medianPricePerCard: number;
+  unknownPriceCount: number;
+  mostExpensive: CardPriceEntry[];
+  distribution: PriceDistributionBucket[];
+  byType: TypePriceSummary[];
+  byRole: RolePriceSummary[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+export const PRICE_BUCKETS: { label: string; min: number; max: number }[] = [
+  { label: "$0-1", min: 0, max: 1 },
+  { label: "$1-5", min: 1, max: 5 },
+  { label: "$5-10", min: 5, max: 10 },
+  { label: "$10-25", min: 10, max: 25 },
+  { label: "$25-50", min: 25, max: 50 },
+  { label: "$50+", min: 50, max: Infinity },
+];
+
+const CARD_TYPES = [
+  "Creature",
+  "Land",
+  "Artifact",
+  "Enchantment",
+  "Instant",
+  "Sorcery",
+  "Planeswalker",
+  "Battle",
+  "Kindred",
+];
+
+// ---------------------------------------------------------------------------
+// Core functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Determines the mutually exclusive type bucket for a card.
+ * Priority: Creature > Land > leftmost card type.
+ */
+export function getCardTypeBucket(typeLine: string): string {
+  const { cardType } = parseTypeLine(typeLine);
+  const types = cardType.split(/\s+/).filter(Boolean);
+
+  if (types.includes("Creature")) return "Creature";
+  if (types.includes("Land")) return "Land";
+
+  for (const t of types) {
+    if (CARD_TYPES.includes(t)) return t;
+  }
+
+  return "Other";
+}
+
+/**
+ * Builds a sorted list of cards with prices (sorted by totalPrice desc).
+ * Cards without USD prices are excluded.
+ */
+export function buildCardPriceList(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>
+): CardPriceEntry[] {
+  const allCards = [...deck.commanders, ...deck.mainboard, ...deck.sideboard];
+  const entries: CardPriceEntry[] = [];
+
+  for (const card of allCards) {
+    const enriched = cardMap[card.name];
+    if (!enriched || enriched.prices.usd == null) continue;
+
+    entries.push({
+      name: card.name,
+      quantity: card.quantity,
+      unitPrice: enriched.prices.usd,
+      totalPrice: enriched.prices.usd * card.quantity,
+    });
+  }
+
+  entries.sort((a, b) => b.totalPrice - a.totalPrice);
+  return entries;
+}
+
+/**
+ * Assigns cards into price distribution buckets by unit price.
+ */
+export function computePriceDistribution(
+  priceList: CardPriceEntry[]
+): PriceDistributionBucket[] {
+  const buckets: PriceDistributionBucket[] = PRICE_BUCKETS.map((b) => ({
+    ...b,
+    count: 0,
+  }));
+
+  for (const entry of priceList) {
+    for (const bucket of buckets) {
+      if (
+        entry.unitPrice >= bucket.min &&
+        (bucket.max === Infinity || entry.unitPrice < bucket.max)
+      ) {
+        bucket.count += entry.quantity;
+        break;
+      }
+    }
+  }
+
+  return buckets;
+}
+
+/**
+ * Computes spending by card type (mutually exclusive).
+ */
+export function computePriceByType(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>
+): TypePriceSummary[] {
+  const allCards = [...deck.commanders, ...deck.mainboard, ...deck.sideboard];
+  const typeMap = new Map<string, { totalCost: number; cardCount: number }>();
+
+  for (const card of allCards) {
+    const enriched = cardMap[card.name];
+    if (!enriched || enriched.prices.usd == null) continue;
+
+    const bucket = getCardTypeBucket(enriched.typeLine);
+    const existing = typeMap.get(bucket) ?? { totalCost: 0, cardCount: 0 };
+    existing.totalCost += enriched.prices.usd * card.quantity;
+    existing.cardCount += card.quantity;
+    typeMap.set(bucket, existing);
+  }
+
+  const result: TypePriceSummary[] = [];
+  for (const [type, data] of typeMap) {
+    if (data.totalCost > 0) {
+      result.push({
+        type,
+        totalCost: data.totalCost,
+        cardCount: data.cardCount,
+        averagePrice: data.totalCost / data.cardCount,
+      });
+    }
+  }
+
+  result.sort((a, b) => b.totalCost - a.totalCost);
+  return result;
+}
+
+/**
+ * Computes spending by role (tag-based, cards can overlap).
+ */
+export function computePriceByRole(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>
+): RolePriceSummary[] {
+  const allCards = [...deck.commanders, ...deck.mainboard, ...deck.sideboard];
+  const roleMap = new Map<string, { totalCost: number; cardCount: number }>();
+
+  for (const card of allCards) {
+    const enriched = cardMap[card.name];
+    if (!enriched || enriched.prices.usd == null) continue;
+
+    const tags = generateTags(enriched);
+    if (tags.length === 0) continue;
+
+    for (const tag of tags) {
+      const existing = roleMap.get(tag) ?? { totalCost: 0, cardCount: 0 };
+      existing.totalCost += enriched.prices.usd * card.quantity;
+      existing.cardCount += card.quantity;
+      roleMap.set(tag, existing);
+    }
+  }
+
+  const result: RolePriceSummary[] = [];
+  for (const [tag, data] of roleMap) {
+    if (data.totalCost > 0) {
+      result.push({
+        tag,
+        totalCost: data.totalCost,
+        cardCount: data.cardCount,
+        averagePrice: data.totalCost / data.cardCount,
+      });
+    }
+  }
+
+  result.sort((a, b) => b.totalCost - a.totalCost);
+  return result;
+}
+
+/**
+ * Computes the median unit price from a price list.
+ */
+export function computeMedianPrice(priceList: CardPriceEntry[]): number {
+  if (priceList.length === 0) return 0;
+
+  const sorted = [...priceList].sort((a, b) => a.unitPrice - b.unitPrice);
+  const mid = Math.floor(sorted.length / 2);
+
+  if (sorted.length % 2 === 0) {
+    return (sorted[mid - 1].unitPrice + sorted[mid].unitPrice) / 2;
+  }
+
+  return sorted[mid].unitPrice;
+}
+
+/**
+ * Formats a number as USD currency.
+ */
+export function formatUSD(amount: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amount);
+}
+
+/**
+ * Orchestrates all budget analysis sub-functions.
+ */
+export function computeBudgetAnalysis(
+  deck: DeckData,
+  cardMap: Record<string, EnrichedCard>
+): BudgetAnalysisResult {
+  const priceList = buildCardPriceList(deck, cardMap);
+  const totalCost = priceList.reduce((sum, e) => sum + e.totalPrice, 0);
+
+  // Count cards without price data
+  const allCards = [...deck.commanders, ...deck.mainboard, ...deck.sideboard];
+  let unknownPriceCount = 0;
+  for (const card of allCards) {
+    const enriched = cardMap[card.name];
+    if (!enriched || enriched.prices.usd == null) {
+      unknownPriceCount += card.quantity;
+    }
+  }
+
+  const pricedCardCount = priceList.reduce((sum, e) => sum + e.quantity, 0);
+
+  return {
+    totalCost,
+    totalCostFormatted: formatUSD(totalCost),
+    averagePricePerCard: pricedCardCount > 0 ? totalCost / pricedCardCount : 0,
+    medianPricePerCard: computeMedianPrice(priceList),
+    unknownPriceCount,
+    mostExpensive: priceList,
+    distribution: computePriceDistribution(priceList),
+    byType: computePriceByType(deck, cardMap),
+    byRole: computePriceByRole(deck, cardMap),
+  };
+}

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -39,6 +39,7 @@ export interface ScryfallCard {
   produced_mana?: string[];
   flavor_name?: string;
   game_changer?: boolean;
+  prices?: { usd: string | null; usd_foil: string | null; eur: string | null };
 }
 
 export async function fetchCardByName(
@@ -184,6 +185,12 @@ async function fetchBatchWithRetry(
   throw lastError ?? new Error("Scryfall API error: retries exhausted");
 }
 
+function parsePrice(val: string | null | undefined): number | null {
+  if (!val) return null;
+  const n = parseFloat(val);
+  return isNaN(n) || n < 0 ? null : n;
+}
+
 /**
  * Normalizes a Scryfall card response into our EnrichedCard type.
  * Handles DFCs by falling back to card_faces[0] when top-level fields are undefined.
@@ -221,5 +228,10 @@ export function normalizeToEnrichedCard(card: ScryfallCard): EnrichedCard {
     producedMana: card.produced_mana ?? frontFace?.produced_mana ?? [],
     flavorName: card.flavor_name ?? null,
     isGameChanger: card.game_changer ?? false,
+    prices: {
+      usd: parsePrice(card.prices?.usd),
+      usdFoil: parsePrice(card.prices?.usd_foil),
+      eur: parsePrice(card.prices?.eur),
+    },
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -24,6 +24,12 @@ export interface ArchidektApiResponse {
   cards: ArchidektCard[];
 }
 
+export interface CardPrices {
+  usd: number | null;
+  usdFoil: number | null;
+  eur: number | null;
+}
+
 // Enriched card data (from Scryfall)
 export interface ManaPips {
   W: number;
@@ -54,6 +60,7 @@ export interface EnrichedCard {
   producedMana: string[];
   flavorName: string | null;
   isGameChanger: boolean;
+  prices: CardPrices;
 }
 
 // Synergy analysis types

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,39 @@
+import type { EnrichedCard, DeckData } from "../src/lib/types";
+
+export function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
+  return {
+    name: "Test Card",
+    manaCost: "",
+    cmc: 0,
+    colorIdentity: [],
+    colors: [],
+    typeLine: "Creature",
+    supertypes: [],
+    subtypes: [],
+    oracleText: "",
+    keywords: [],
+    power: null,
+    toughness: null,
+    loyalty: null,
+    rarity: "common",
+    imageUris: null,
+    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
+    producedMana: [],
+    flavorName: null,
+    isGameChanger: false,
+    prices: { usd: null, usdFoil: null, eur: null },
+    ...overrides,
+  };
+}
+
+export function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
+  return {
+    name: "Test Deck",
+    source: "text",
+    url: "",
+    commanders: [],
+    mainboard: [],
+    sideboard: [],
+    ...overrides,
+  };
+}

--- a/tests/unit/bracket-estimator.spec.ts
+++ b/tests/unit/bracket-estimator.spec.ts
@@ -39,6 +39,7 @@ function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
     producedMana: [],
     flavorName: null,
     isGameChanger: false,
+    prices: { usd: null, usdFoil: null, eur: null },
     ...overrides,
   };
 }

--- a/tests/unit/budget-analysis.spec.ts
+++ b/tests/unit/budget-analysis.spec.ts
@@ -1,0 +1,403 @@
+import { test, expect } from "@playwright/test";
+import {
+  getCardTypeBucket,
+  buildCardPriceList,
+  computePriceDistribution,
+  computePriceByType,
+  computePriceByRole,
+  computeMedianPrice,
+  computeBudgetAnalysis,
+  formatUSD,
+  PRICE_BUCKETS,
+} from "../../src/lib/budget-analysis";
+import { makeCard, makeDeck } from "../helpers";
+
+// ---------------------------------------------------------------------------
+// getCardTypeBucket
+// ---------------------------------------------------------------------------
+
+test.describe("getCardTypeBucket", () => {
+  test('"Legendary Creature — Human Wizard" → "Creature"', () => {
+    expect(getCardTypeBucket("Legendary Creature — Human Wizard")).toBe("Creature");
+  });
+
+  test('"Artifact Creature — Golem" → "Creature" (Creature priority)', () => {
+    expect(getCardTypeBucket("Artifact Creature — Golem")).toBe("Creature");
+  });
+
+  test('"Artifact Land" → "Land" (Land priority over leftmost)', () => {
+    expect(getCardTypeBucket("Artifact Land")).toBe("Land");
+  });
+
+  test('"Enchantment Artifact" → "Enchantment" (leftmost wins)', () => {
+    expect(getCardTypeBucket("Enchantment Artifact")).toBe("Enchantment");
+  });
+
+  test('"Basic Land — Island" → "Land"', () => {
+    expect(getCardTypeBucket("Basic Land — Island")).toBe("Land");
+  });
+
+  test('"Instant" → "Instant"', () => {
+    expect(getCardTypeBucket("Instant")).toBe("Instant");
+  });
+
+  test('"Legendary Planeswalker — Jace" → "Planeswalker"', () => {
+    expect(getCardTypeBucket("Legendary Planeswalker — Jace")).toBe("Planeswalker");
+  });
+
+  test('"Battle" → "Battle"', () => {
+    expect(getCardTypeBucket("Battle")).toBe("Battle");
+  });
+
+  test('unknown/empty → "Other"', () => {
+    expect(getCardTypeBucket("")).toBe("Other");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCardPriceList
+// ---------------------------------------------------------------------------
+
+test.describe("buildCardPriceList", () => {
+  test("returns list sorted by totalPrice desc", () => {
+    const deck = makeDeck({
+      mainboard: [
+        { name: "Cheap Card", quantity: 1 },
+        { name: "Expensive Card", quantity: 1 },
+      ],
+    });
+    const cardMap = {
+      "Cheap Card": makeCard({ name: "Cheap Card", prices: { usd: 0.5, usdFoil: null, eur: null } }),
+      "Expensive Card": makeCard({ name: "Expensive Card", prices: { usd: 10.0, usdFoil: null, eur: null } }),
+    };
+    const list = buildCardPriceList(deck, cardMap);
+    expect(list[0].name).toBe("Expensive Card");
+    expect(list[0].totalPrice).toBe(10.0);
+    expect(list[1].name).toBe("Cheap Card");
+    expect(list[1].totalPrice).toBe(0.5);
+  });
+
+  test("quantity multiplication: 4x card at $2.00 → totalPrice 8.00", () => {
+    const deck = makeDeck({
+      mainboard: [{ name: "Sol Ring", quantity: 4 }],
+    });
+    const cardMap = {
+      "Sol Ring": makeCard({ name: "Sol Ring", prices: { usd: 2.0, usdFoil: null, eur: null } }),
+    };
+    const list = buildCardPriceList(deck, cardMap);
+    expect(list[0].totalPrice).toBe(8.0);
+    expect(list[0].unitPrice).toBe(2.0);
+    expect(list[0].quantity).toBe(4);
+  });
+
+  test("null price cards are excluded from the list", () => {
+    const deck = makeDeck({
+      mainboard: [
+        { name: "Priced Card", quantity: 1 },
+        { name: "No Price Card", quantity: 1 },
+      ],
+    });
+    const cardMap = {
+      "Priced Card": makeCard({ name: "Priced Card", prices: { usd: 1.0, usdFoil: null, eur: null } }),
+      "No Price Card": makeCard({ name: "No Price Card", prices: { usd: null, usdFoil: null, eur: null } }),
+    };
+    const list = buildCardPriceList(deck, cardMap);
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe("Priced Card");
+  });
+
+  test("includes commanders and sideboard", () => {
+    const deck = makeDeck({
+      commanders: [{ name: "Commander", quantity: 1 }],
+      mainboard: [{ name: "Spell", quantity: 1 }],
+      sideboard: [{ name: "Side Card", quantity: 1 }],
+    });
+    const cardMap = {
+      Commander: makeCard({ name: "Commander", prices: { usd: 5.0, usdFoil: null, eur: null } }),
+      Spell: makeCard({ name: "Spell", prices: { usd: 1.0, usdFoil: null, eur: null } }),
+      "Side Card": makeCard({ name: "Side Card", prices: { usd: 2.0, usdFoil: null, eur: null } }),
+    };
+    const list = buildCardPriceList(deck, cardMap);
+    expect(list).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePriceDistribution
+// ---------------------------------------------------------------------------
+
+test.describe("computePriceDistribution", () => {
+  test("assigns to correct buckets", () => {
+    const list = [
+      { name: "A", quantity: 1, unitPrice: 0.25, totalPrice: 0.25 },
+      { name: "B", quantity: 1, unitPrice: 3.5, totalPrice: 3.5 },
+      { name: "C", quantity: 1, unitPrice: 50, totalPrice: 50 },
+    ];
+    const buckets = computePriceDistribution(list);
+    // $0.25 → $0-1 bucket
+    const bucket01 = buckets.find((b) => b.label === "$0-1");
+    expect(bucket01?.count).toBe(1);
+    // $3.50 → $1-5 bucket
+    const bucket15 = buckets.find((b) => b.label === "$1-5");
+    expect(bucket15?.count).toBe(1);
+    // $50 → $50+ bucket
+    const bucket50 = buckets.find((b) => b.label === "$50+");
+    expect(bucket50?.count).toBe(1);
+  });
+
+  test("empty list returns all-zero buckets", () => {
+    const buckets = computePriceDistribution([]);
+    expect(buckets).toHaveLength(PRICE_BUCKETS.length);
+    for (const b of buckets) {
+      expect(b.count).toBe(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePriceByType
+// ---------------------------------------------------------------------------
+
+test.describe("computePriceByType", () => {
+  test("mutually exclusive bucketing with Creature priority", () => {
+    const deck = makeDeck({
+      mainboard: [
+        { name: "Artifact Creature", quantity: 1 },
+        { name: "Pure Artifact", quantity: 1 },
+      ],
+    });
+    const cardMap = {
+      "Artifact Creature": makeCard({
+        name: "Artifact Creature",
+        typeLine: "Artifact Creature — Golem",
+        prices: { usd: 5.0, usdFoil: null, eur: null },
+      }),
+      "Pure Artifact": makeCard({
+        name: "Pure Artifact",
+        typeLine: "Artifact",
+        prices: { usd: 3.0, usdFoil: null, eur: null },
+      }),
+    };
+    const result = computePriceByType(deck, cardMap);
+    const creature = result.find((r) => r.type === "Creature");
+    const artifact = result.find((r) => r.type === "Artifact");
+    expect(creature?.totalCost).toBe(5.0);
+    expect(creature?.cardCount).toBe(1);
+    expect(artifact?.totalCost).toBe(3.0);
+    expect(artifact?.cardCount).toBe(1);
+  });
+
+  test("Land priority over leftmost", () => {
+    const deck = makeDeck({
+      mainboard: [{ name: "Artifact Land", quantity: 1 }],
+    });
+    const cardMap = {
+      "Artifact Land": makeCard({
+        name: "Artifact Land",
+        typeLine: "Artifact Land",
+        prices: { usd: 2.0, usdFoil: null, eur: null },
+      }),
+    };
+    const result = computePriceByType(deck, cardMap);
+    const land = result.find((r) => r.type === "Land");
+    expect(land?.totalCost).toBe(2.0);
+    const artifact = result.find((r) => r.type === "Artifact");
+    expect(artifact).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computePriceByRole
+// ---------------------------------------------------------------------------
+
+test.describe("computePriceByRole", () => {
+  test("tag-based grouping via generateTags(), overlap for multi-tagged", () => {
+    const deck = makeDeck({
+      mainboard: [{ name: "Wrath of God", quantity: 1 }],
+    });
+    const cardMap = {
+      "Wrath of God": makeCard({
+        name: "Wrath of God",
+        typeLine: "Sorcery",
+        oracleText: "Destroy all creatures.",
+        prices: { usd: 10.0, usdFoil: null, eur: null },
+      }),
+    };
+    const result = computePriceByRole(deck, cardMap);
+    // Wrath of God should be tagged as both Board Wipe and Removal
+    const boardWipe = result.find((r) => r.tag === "Board Wipe");
+    const removal = result.find((r) => r.tag === "Removal");
+    expect(boardWipe?.totalCost).toBe(10.0);
+    expect(removal?.totalCost).toBe(10.0);
+  });
+
+  test("cards with no tags are excluded", () => {
+    const deck = makeDeck({
+      mainboard: [{ name: "Grizzly Bears", quantity: 1 }],
+    });
+    const cardMap = {
+      "Grizzly Bears": makeCard({
+        name: "Grizzly Bears",
+        typeLine: "Creature — Bear",
+        oracleText: "",
+        prices: { usd: 0.1, usdFoil: null, eur: null },
+      }),
+    };
+    const result = computePriceByRole(deck, cardMap);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeMedianPrice
+// ---------------------------------------------------------------------------
+
+test.describe("computeMedianPrice", () => {
+  test("odd count", () => {
+    const list = [
+      { name: "A", quantity: 1, unitPrice: 1, totalPrice: 1 },
+      { name: "B", quantity: 1, unitPrice: 3, totalPrice: 3 },
+      { name: "C", quantity: 1, unitPrice: 5, totalPrice: 5 },
+    ];
+    expect(computeMedianPrice(list)).toBe(3);
+  });
+
+  test("even count", () => {
+    const list = [
+      { name: "A", quantity: 1, unitPrice: 1, totalPrice: 1 },
+      { name: "B", quantity: 1, unitPrice: 3, totalPrice: 3 },
+      { name: "C", quantity: 1, unitPrice: 5, totalPrice: 5 },
+      { name: "D", quantity: 1, unitPrice: 7, totalPrice: 7 },
+    ];
+    expect(computeMedianPrice(list)).toBe(4);
+  });
+
+  test("empty list returns 0", () => {
+    expect(computeMedianPrice([])).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatUSD
+// ---------------------------------------------------------------------------
+
+test.describe("formatUSD", () => {
+  test('0 → "$0.00"', () => {
+    expect(formatUSD(0)).toBe("$0.00");
+  });
+
+  test('1.5 → "$1.50"', () => {
+    expect(formatUSD(1.5)).toBe("$1.50");
+  });
+
+  test('1234.99 → "$1,234.99"', () => {
+    expect(formatUSD(1234.99)).toBe("$1,234.99");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeBudgetAnalysis (end-to-end)
+// ---------------------------------------------------------------------------
+
+test.describe("computeBudgetAnalysis", () => {
+  test("empty deck returns zero totals", () => {
+    const result = computeBudgetAnalysis(makeDeck(), {});
+    expect(result.totalCost).toBe(0);
+    expect(result.averagePricePerCard).toBe(0);
+    expect(result.medianPricePerCard).toBe(0);
+    expect(result.totalCostFormatted).toBe("$0.00");
+    expect(result.unknownPriceCount).toBe(0);
+    expect(result.mostExpensive).toHaveLength(0);
+  });
+
+  test("3-card deck with mixed prices", () => {
+    const deck = makeDeck({
+      mainboard: [
+        { name: "A", quantity: 1 },
+        { name: "B", quantity: 1 },
+        { name: "C", quantity: 1 },
+      ],
+    });
+    const cardMap = {
+      A: makeCard({ name: "A", typeLine: "Creature", prices: { usd: 1.0, usdFoil: null, eur: null } }),
+      B: makeCard({ name: "B", typeLine: "Instant", prices: { usd: 5.0, usdFoil: null, eur: null } }),
+      C: makeCard({ name: "C", typeLine: "Sorcery", prices: { usd: 3.0, usdFoil: null, eur: null } }),
+    };
+    const result = computeBudgetAnalysis(deck, cardMap);
+    expect(result.totalCost).toBe(9.0);
+    expect(result.averagePricePerCard).toBe(3.0);
+    expect(result.medianPricePerCard).toBe(3.0);
+    expect(result.totalCostFormatted).toBe("$9.00");
+    expect(result.unknownPriceCount).toBe(0);
+    expect(result.mostExpensive[0].name).toBe("B");
+  });
+
+  test("all-null prices", () => {
+    const deck = makeDeck({
+      mainboard: [
+        { name: "A", quantity: 1 },
+        { name: "B", quantity: 1 },
+      ],
+    });
+    const cardMap = {
+      A: makeCard({ name: "A", prices: { usd: null, usdFoil: null, eur: null } }),
+      B: makeCard({ name: "B", prices: { usd: null, usdFoil: null, eur: null } }),
+    };
+    const result = computeBudgetAnalysis(deck, cardMap);
+    expect(result.totalCost).toBe(0);
+    expect(result.unknownPriceCount).toBe(2);
+    expect(result.mostExpensive).toHaveLength(0);
+  });
+
+  test("quantity: 4x card at $2.00 contributes $8 to totals", () => {
+    const deck = makeDeck({
+      mainboard: [{ name: "Sol Ring", quantity: 4 }],
+    });
+    const cardMap = {
+      "Sol Ring": makeCard({ name: "Sol Ring", prices: { usd: 2.0, usdFoil: null, eur: null } }),
+    };
+    const result = computeBudgetAnalysis(deck, cardMap);
+    expect(result.totalCost).toBe(8.0);
+    expect(result.mostExpensive[0].totalPrice).toBe(8.0);
+  });
+
+  test("single card deck", () => {
+    const deck = makeDeck({
+      mainboard: [{ name: "A", quantity: 1 }],
+    });
+    const cardMap = {
+      A: makeCard({ name: "A", prices: { usd: 5.0, usdFoil: null, eur: null } }),
+    };
+    const result = computeBudgetAnalysis(deck, cardMap);
+    expect(result.totalCost).toBe(5.0);
+    expect(result.averagePricePerCard).toBe(5.0);
+    expect(result.medianPricePerCard).toBe(5.0);
+  });
+
+  test("distribution, byType, and byRole are populated", () => {
+    const deck = makeDeck({
+      mainboard: [
+        { name: "Sol Ring", quantity: 1 },
+        { name: "Counterspell", quantity: 1 },
+      ],
+    });
+    const cardMap = {
+      "Sol Ring": makeCard({
+        name: "Sol Ring",
+        typeLine: "Artifact",
+        oracleText: "{T}: Add {C}{C}.",
+        prices: { usd: 1.5, usdFoil: null, eur: null },
+      }),
+      Counterspell: makeCard({
+        name: "Counterspell",
+        typeLine: "Instant",
+        oracleText: "Counter target spell.",
+        prices: { usd: 1.25, usdFoil: null, eur: null },
+      }),
+    };
+    const result = computeBudgetAnalysis(deck, cardMap);
+    expect(result.distribution.length).toBe(PRICE_BUCKETS.length);
+    expect(result.byType.length).toBeGreaterThan(0);
+    expect(result.byRole.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -1,31 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { generateTags } from "../../src/lib/card-tags";
-import type { EnrichedCard } from "../../src/lib/types";
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import { makeCard } from "../helpers";
 
 test.describe("generateTags — Ramp", () => {
   test("Sol Ring (tap to add mana) → Ramp", () => {

--- a/tests/unit/cedh-staples.spec.ts
+++ b/tests/unit/cedh-staples.spec.ts
@@ -28,6 +28,7 @@ function mockCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
     producedMana: [],
     flavorName: null,
     isGameChanger: false,
+    prices: { usd: null, usdFoil: null, eur: null },
     ...overrides,
   };
 }

--- a/tests/unit/color-distribution.spec.ts
+++ b/tests/unit/color-distribution.spec.ts
@@ -5,44 +5,8 @@ import {
   resolveCommanderIdentity,
   MTG_COLORS,
 } from "../../src/lib/color-distribution";
-import type { DeckData, EnrichedCard } from "../../src/lib/types";
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import type { EnrichedCard } from "../../src/lib/types";
+import { makeCard, makeDeck } from "../helpers";
 
 const ZERO_COUNTS = { W: 0, U: 0, B: 0, R: 0, G: 0 };
 

--- a/tests/unit/commander-validation.spec.ts
+++ b/tests/unit/commander-validation.spec.ts
@@ -9,44 +9,8 @@ import {
   buildEdhrecUrl,
   BASIC_LAND_NAMES,
 } from "../../src/lib/commander-validation";
-import type { DeckData, EnrichedCard } from "../../src/lib/types";
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
+import type { EnrichedCard } from "../../src/lib/types";
+import { makeCard, makeDeck } from "../helpers";
 
 // --- isSingletonExempt ---
 

--- a/tests/unit/deck-composition.spec.ts
+++ b/tests/unit/deck-composition.spec.ts
@@ -5,48 +5,8 @@ import {
   TEMPLATE_COMMAND_ZONE,
   AVAILABLE_TEMPLATES,
 } from "../../src/lib/deck-composition";
-import type { DeckData, EnrichedCard } from "../../src/lib/types";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import type { EnrichedCard } from "../../src/lib/types";
+import { makeCard, makeDeck } from "../helpers";
 
 // A vanilla creature — no tags, not a land
 const VANILLA_BEAR = makeCard({

--- a/tests/unit/hypergeometric.spec.ts
+++ b/tests/unit/hypergeometric.spec.ts
@@ -10,48 +10,8 @@ import {
   computePrecomputedQueries,
   getAvailableCategories,
 } from "../../src/lib/hypergeometric";
-import type { DeckData, EnrichedCard } from "../../src/lib/types";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import type { EnrichedCard } from "../../src/lib/types";
+import { makeCard, makeDeck } from "../helpers";
 
 // ---------------------------------------------------------------------------
 // logChoose

--- a/tests/unit/land-base-efficiency.spec.ts
+++ b/tests/unit/land-base-efficiency.spec.ts
@@ -9,48 +9,8 @@ import {
   computeLandBaseEfficiency,
   type LandClassification,
 } from "../../src/lib/land-base-efficiency";
-import type { DeckData, EnrichedCard, ManaPips } from "../../src/lib/types";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import type { EnrichedCard, ManaPips } from "../../src/lib/types";
+import { makeCard, makeDeck } from "../helpers";
 
 const ZERO_PIPS: ManaPips = { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 };
 

--- a/tests/unit/mana-curve.spec.ts
+++ b/tests/unit/mana-curve.spec.ts
@@ -1,43 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { computeManaCurve, extractCardType } from "../../src/lib/mana-curve";
-import type { DeckData, EnrichedCard } from "../../src/lib/types";
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import type { EnrichedCard } from "../../src/lib/types";
+import { makeCard, makeDeck } from "../helpers";
 
 const EXPECTED_BUCKETS = ["0", "1", "2", "3", "4", "5", "6", "7+"];
 

--- a/tests/unit/mana-recommendations.spec.ts
+++ b/tests/unit/mana-recommendations.spec.ts
@@ -5,48 +5,9 @@ import {
   type ManaBaseRecommendationsResult,
 } from "../../src/lib/mana-recommendations";
 import type { DeckData, EnrichedCard, ManaPips } from "../../src/lib/types";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
+import { makeCard, makeDeck } from "../helpers";
 
 const ZERO_PIPS: ManaPips = { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 };
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { ...ZERO_PIPS },
-    producedMana: [],
-    flavorName: null,
-    ...overrides,
-  };
-}
 
 /** Build a simple commander deck with lands and non-land cards */
 function buildDeck(opts: {

--- a/tests/unit/opening-hand.spec.ts
+++ b/tests/unit/opening-hand.spec.ts
@@ -9,44 +9,8 @@ import {
   findTopHands,
 } from "../../src/lib/opening-hand";
 import type { HandCard } from "../../src/lib/opening-hand";
-import type { DeckData, EnrichedCard } from "../../src/lib/types";
-
-function makeDeck(overrides: Partial<DeckData> = {}): DeckData {
-  return {
-    name: "Test Deck",
-    source: "text",
-    url: "",
-    commanders: [],
-    mainboard: [],
-    sideboard: [],
-    ...overrides,
-  };
-}
-
-function makeCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import type { EnrichedCard } from "../../src/lib/types";
+import { makeCard, makeDeck } from "../helpers";
 
 // ---------------------------------------------------------------------------
 // buildPool

--- a/tests/unit/power-level.spec.ts
+++ b/tests/unit/power-level.spec.ts
@@ -13,35 +13,7 @@ import {
 } from "../../src/lib/power-level";
 import type { DeckData, EnrichedCard } from "../../src/lib/types";
 import type { KnownCombo } from "../../src/lib/known-combos";
-
-// ---------------------------------------------------------------------------
-// Test helpers (mirroring synergy-engine.spec.ts pattern)
-// ---------------------------------------------------------------------------
-
-function mockCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import { makeCard as mockCard } from "../helpers";
 
 function mockDeck(
   mainboard: string[],

--- a/tests/unit/synergy-axes.spec.ts
+++ b/tests/unit/synergy-axes.spec.ts
@@ -1,32 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { SYNERGY_AXES, getAxisById } from "../../src/lib/synergy-axes";
-import type { EnrichedCard } from "../../src/lib/types";
-
-/** Helper to build a minimal EnrichedCard for testing axis detectors */
-function mockCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import { makeCard as mockCard } from "../helpers";
 
 test.describe("Synergy Axes", () => {
   test("exports a non-empty array of axes", () => {

--- a/tests/unit/synergy-engine.spec.ts
+++ b/tests/unit/synergy-engine.spec.ts
@@ -1,32 +1,7 @@
 import { test, expect } from "@playwright/test";
 import { analyzeDeckSynergy } from "../../src/lib/synergy-engine";
 import type { DeckData, EnrichedCard } from "../../src/lib/types";
-
-/** Helper to build a minimal EnrichedCard */
-function mockCard(overrides: Partial<EnrichedCard> = {}): EnrichedCard {
-  return {
-    name: "Test Card",
-    manaCost: "",
-    cmc: 0,
-    colorIdentity: [],
-    colors: [],
-    typeLine: "Creature",
-    supertypes: [],
-    subtypes: [],
-    oracleText: "",
-    keywords: [],
-    power: null,
-    toughness: null,
-    loyalty: null,
-    rarity: "common",
-    imageUris: null,
-    manaPips: { W: 0, U: 0, B: 0, R: 0, G: 0, C: 0 },
-    producedMana: [],
-    flavorName: null,
-    isGameChanger: false,
-    ...overrides,
-  };
-}
+import { makeCard as mockCard } from "../helpers";
 
 function mockDeck(
   mainboard: string[],


### PR DESCRIPTION
## Summary
- Captures Scryfall price data (USD, USD foil, EUR) during card enrichment and stores on `EnrichedCard`
- Adds **Budget Analysis** section to the Analysis tab with total deck cost, price distribution chart, top expensive cards table, and spending breakdowns by card type and functional role
- Displays per-card price in expanded card detail rows
- Centralizes 12 duplicate `makeCard`/`makeDeck` test helpers into shared `tests/helpers.ts`

## What's Included

### Core (`src/lib/`)
- `CardPrices` interface and `prices` field on `EnrichedCard`
- `parsePrice()` in `scryfall.ts` with NaN/negative guard
- `budget-analysis.ts` — pure computation module with `computeBudgetAnalysis()`, price distribution buckets, mutually-exclusive type bucketing (Creature > Land > leftmost), tag-based role bucketing, median price, `formatUSD()`

### Components (`src/components/`)
- `BudgetStats` — 3-stat grid (total cost, avg price/card, median price) with unknown-price warning
- `PriceDistributionChart` — Recharts bar chart of 6 price buckets ($0-1 through $50+)
- `TopExpensiveCardsTable` — ranked table with "Show all" toggle (default top 10)
- `PriceByCategoryChart` — dual horizontal bar charts (by type + by role with overlap disclaimer)
- Budget panel wired into `DeckAnalysis.tsx` as last section with total cost in collapsed summary

### Tests
- 31 unit tests in `tests/unit/budget-analysis.spec.ts`
- 9 e2e tests covering panel visibility, stat cards, charts, table, section ordering
- Prices assertion added to `e2e/api-deck-enrich.spec.ts`
- All existing mock objects updated with `prices` field across 10 e2e files

## Test plan
- [x] `npm run test:unit` — 661 passed
- [x] `npm run test:e2e` — 220 passed
- [x] `npm run build` — no TypeScript errors
- [ ] Manual: import a Commander deck → Analysis tab → Budget Analysis section renders with all sub-components

🤖 Generated with [Claude Code](https://claude.com/claude-code)