### PR TITLE
feat: classify asymmetric board wipes so they skip token anti-synergy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1239,7 +1238,6 @@
       "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.56.1"
       },
@@ -1728,7 +1726,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1794,7 +1791,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -2307,7 +2303,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2657,7 +2652,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3467,7 +3461,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3653,7 +3646,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5973,7 +5965,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5983,7 +5974,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5995,15 +5985,13 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -6056,8 +6044,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -6788,7 +6775,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6951,7 +6937,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7274,7 +7259,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -64,9 +64,11 @@ const BOARD_WIPE_RE =
 const BOARD_WIPE_BOUNCE_RE = /\breturn all\b.+?\bto their owners' hands\b/i;
 const BOARD_WIPE_MINUS_RE = /\ball creatures get -\d+\/-\d+/i;
 // --- Asymmetric (one-sided) wipe patterns ---
-// Universal: "creatures you don't control", "permanents an opponent controls", etc.
+// Universal: "all <modifier?> creatures/permanents/planeswalkers you don't control" etc.
+// Anchored to "all" so single-target clauses ("target creature you don't control") on modal
+// cards don't falsely flag a symmetric wipe mode as asymmetric.
 const ASYMMETRIC_OPPONENT_RE =
-  /\b(?:creatures?|permanents?|planeswalkers?)\s+(?:you don't control|an opponent controls|your opponents control)\b/i;
+  /\ball\s+(?:\S+\s+){0,3}?(?:creatures?|permanents?|planeswalkers?)\s+(?:you don't control|an opponent controls|your opponents control)\b/i;
 // Tribal: "that aren't of the chosen type" (Kindred Dominance)
 const ASYMMETRIC_CHOSEN_TYPE_RE = /\bthat aren't of the chosen (?:type|creature type)\b/i;
 // Tribal: "that don't share a creature type with" (Patriarch's Bidding-style)

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -1,6 +1,6 @@
 import type { EnrichedCard } from "./types";
 import { CONDITIONAL_PATTERNS } from "./land-base-efficiency";
-import { CREATURE_TYPE_PATTERN } from "./creature-types";
+import { CREATURE_TYPE_PATTERN, NON_TYPE_RE } from "./creature-types";
 
 export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   Ramp: { bg: "bg-emerald-500/20", text: "text-emerald-300" },
@@ -8,6 +8,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   "Card Advantage": { bg: "bg-sky-500/20", text: "text-sky-300" },
   Removal: { bg: "bg-red-500/20", text: "text-red-300" },
   "Board Wipe": { bg: "bg-orange-500/20", text: "text-orange-300" },
+  "Asymmetric Wipe": { bg: "bg-amber-500/20", text: "text-amber-300" },
   Counterspell: { bg: "bg-cyan-500/20", text: "text-cyan-300" },
   Tutor: { bg: "bg-yellow-500/20", text: "text-yellow-300" },
   "Cost Reduction": { bg: "bg-amber-500/20", text: "text-amber-300" },
@@ -62,6 +63,40 @@ const BOARD_WIPE_RE =
   /\b(?:destroy|exile)\s+all\b/i;
 const BOARD_WIPE_BOUNCE_RE = /\breturn all\b.+?\bto their owners' hands\b/i;
 const BOARD_WIPE_MINUS_RE = /\ball creatures get -\d+\/-\d+/i;
+// --- Asymmetric (one-sided) wipe patterns ---
+// Universal: "creatures you don't control", "permanents an opponent controls", etc.
+const ASYMMETRIC_OPPONENT_RE =
+  /\b(?:creatures?|permanents?|planeswalkers?)\s+(?:you don't control|an opponent controls|your opponents control)\b/i;
+// Tribal: "that aren't of the chosen type" (Kindred Dominance)
+const ASYMMETRIC_CHOSEN_TYPE_RE = /\bthat aren't of the chosen (?:type|creature type)\b/i;
+// Tribal: "that don't share a creature type with" (Patriarch's Bidding-style)
+const ASYMMETRIC_SHARED_TYPE_RE = /\bthat don't share a (?:creature )?type with\b/i;
+// Note: NON_TYPE_RE (imported from creature-types) catches "non-Elf creatures" etc.
+// It has the /g flag; callers must reset lastIndex before .test().
+
+/**
+ * Sub-classification of an asymmetric wipe so callers can decide exemption context:
+ * - `opponentSided`: always one-sided regardless of deck (In Garruk's Wake, Plague Wind).
+ * - `chosenType`: references a creature type chosen at resolution (Kindred Dominance); asymmetric
+ *   only when the deck has any tribal anchor the caster can name.
+ * - `specificType`: references a fixed creature type (e.g. "non-Elf"); asymmetric only when that
+ *   type matches a deck anchor (caller uses `extractReferencedTypes` to get the type names).
+ * Returns `null` for wipes that have no asymmetric pattern.
+ */
+export type AsymmetricWipeKind = "opponentSided" | "chosenType" | "specificType";
+
+export function classifyAsymmetricWipe(oracleText: string): AsymmetricWipeKind | null {
+  if (ASYMMETRIC_OPPONENT_RE.test(oracleText)) return "opponentSided";
+  if (
+    ASYMMETRIC_CHOSEN_TYPE_RE.test(oracleText) ||
+    ASYMMETRIC_SHARED_TYPE_RE.test(oracleText)
+  ) {
+    return "chosenType";
+  }
+  NON_TYPE_RE.lastIndex = 0;
+  if (NON_TYPE_RE.test(oracleText)) return "specificType";
+  return null;
+}
 const COUNTER_RE = /\bcounter target\b.+?\bspell\b/i;
 const TUTOR_RE = /\bsearch your library\b/i;
 const TUTOR_LAND_EXCLUSION_RE = /search your library for.+?(?:land|Forest|Plains|Island|Swamp|Mountain)\b/i;
@@ -241,6 +276,12 @@ export function generateTags(card: EnrichedCard): string[] {
   ) {
     tags.add("Board Wipe");
     tags.add("Removal");
+
+    // Asymmetric (one-sided) wipes: In Garruk's Wake, Plague Wind, Kindred Dominance, etc.
+    // Only applied when the card already matched a board-wipe pattern above.
+    if (classifyAsymmetricWipe(text) !== null) {
+      tags.add("Asymmetric Wipe");
+    }
   }
 
   // Single-target Removal

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -78,8 +78,13 @@ const ASYMMETRIC_SHARED_TYPE_RE = /\bthat don't share a (?:creature )?type with\
 // creature subtypes are handled by NON_TYPE_RE from creature-types.
 const ASYMMETRIC_NON_CARDTYPE_RE =
   /\bnon-?(artifact|enchantment|planeswalker|legendary|snow|basic)\b/gi;
-// Note: NON_TYPE_RE (imported from creature-types) catches "non-Elf creatures" etc.
-// Both NON_TYPE_RE and ASYMMETRIC_NON_CARDTYPE_RE have /g flag — reset lastIndex before use.
+// "destroy all permanents except for <list>" / "other than <list>" (Scourglass, Cataclysmic
+// Gearhulk-style clauses). Captures the list; a second pass pulls spared card types out of it.
+const ASYMMETRIC_EXCEPT_FOR_RE = /\b(?:except for|other than)\s+([^.]*)/i;
+const SPARED_TYPE_TOKENS_RE =
+  /\b(artifact|enchantment|planeswalker|land|legendary|snow|basic)s?\b/gi;
+// Note: NON_TYPE_RE (imported from creature-types), ASYMMETRIC_NON_CARDTYPE_RE, and
+// SPARED_TYPE_TOKENS_RE all have /g flag — reset lastIndex before use.
 
 /**
  * Sub-classification of an asymmetric wipe so callers can decide exemption context:
@@ -123,6 +128,15 @@ export function classifyAsymmetricWipe(
   let m: RegExpExecArray | null;
   while ((m = ASYMMETRIC_NON_CARDTYPE_RE.exec(oracleText)) !== null) {
     cardTypeMatches.add(m[1].toLowerCase());
+  }
+  // Also check "except for <list>" syntax (Scourglass: "except for artifacts and lands").
+  const exceptMatch = ASYMMETRIC_EXCEPT_FOR_RE.exec(oracleText);
+  if (exceptMatch) {
+    SPARED_TYPE_TOKENS_RE.lastIndex = 0;
+    let t: RegExpExecArray | null;
+    while ((t = SPARED_TYPE_TOKENS_RE.exec(exceptMatch[1])) !== null) {
+      cardTypeMatches.add(t[1].toLowerCase());
+    }
   }
   if (cardTypeMatches.size > 0) {
     return { kind: "cardTypeRestricted", excludedTypes: [...cardTypeMatches] };

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -71,30 +71,64 @@ const ASYMMETRIC_OPPONENT_RE =
 const ASYMMETRIC_CHOSEN_TYPE_RE = /\bthat aren't of the chosen (?:type|creature type)\b/i;
 // Tribal: "that don't share a creature type with" (Patriarch's Bidding-style)
 const ASYMMETRIC_SHARED_TYPE_RE = /\bthat don't share a (?:creature )?type with\b/i;
+// "non-<cardtype-or-supertype>" — broad exclusion patterns like "nonartifact creatures"
+// (Organic Extinction), "nonlegendary creatures", etc. Card types and supertypes only;
+// creature subtypes are handled by NON_TYPE_RE from creature-types.
+const ASYMMETRIC_NON_CARDTYPE_RE =
+  /\bnon-?(artifact|enchantment|planeswalker|legendary|snow|basic)\b/gi;
 // Note: NON_TYPE_RE (imported from creature-types) catches "non-Elf creatures" etc.
-// It has the /g flag; callers must reset lastIndex before .test().
+// Both NON_TYPE_RE and ASYMMETRIC_NON_CARDTYPE_RE have /g flag — reset lastIndex before use.
 
 /**
  * Sub-classification of an asymmetric wipe so callers can decide exemption context:
  * - `opponentSided`: always one-sided regardless of deck (In Garruk's Wake, Plague Wind).
  * - `chosenType`: references a creature type chosen at resolution (Kindred Dominance); asymmetric
  *   only when the deck has any tribal anchor the caster can name.
- * - `specificType`: references a fixed creature type (e.g. "non-Elf"); asymmetric only when that
- *   type matches a deck anchor (caller uses `extractReferencedTypes` to get the type names).
+ * - `specificType`: references a fixed creature subtype (e.g. "non-Elf"); asymmetric only when
+ *   that subtype matches a deck anchor. `excludedTypes` is empty because creature subtypes are
+ *   recovered by callers via `extractReferencedTypes`.
+ * - `cardTypeRestricted`: spares a card type or supertype (e.g. "nonartifact", "nonlegendary");
+ *   `excludedTypes` holds the lowercased spared names (e.g. `["artifact"]`). Asymmetric only
+ *   when the deck's composition aligns with the spared category.
  * Returns `null` for wipes that have no asymmetric pattern.
  */
-export type AsymmetricWipeKind = "opponentSided" | "chosenType" | "specificType";
+export type AsymmetricWipeKind =
+  | "opponentSided"
+  | "chosenType"
+  | "specificType"
+  | "cardTypeRestricted";
 
-export function classifyAsymmetricWipe(oracleText: string): AsymmetricWipeKind | null {
-  if (ASYMMETRIC_OPPONENT_RE.test(oracleText)) return "opponentSided";
+export interface AsymmetricWipeClassification {
+  kind: AsymmetricWipeKind;
+  excludedTypes: string[];
+}
+
+export function classifyAsymmetricWipe(
+  oracleText: string
+): AsymmetricWipeClassification | null {
+  if (ASYMMETRIC_OPPONENT_RE.test(oracleText)) {
+    return { kind: "opponentSided", excludedTypes: [] };
+  }
   if (
     ASYMMETRIC_CHOSEN_TYPE_RE.test(oracleText) ||
     ASYMMETRIC_SHARED_TYPE_RE.test(oracleText)
   ) {
-    return "chosenType";
+    return { kind: "chosenType", excludedTypes: [] };
+  }
+  // Collect all non-<cardtype> matches (a single wipe could reference multiple).
+  ASYMMETRIC_NON_CARDTYPE_RE.lastIndex = 0;
+  const cardTypeMatches = new Set<string>();
+  let m: RegExpExecArray | null;
+  while ((m = ASYMMETRIC_NON_CARDTYPE_RE.exec(oracleText)) !== null) {
+    cardTypeMatches.add(m[1].toLowerCase());
+  }
+  if (cardTypeMatches.size > 0) {
+    return { kind: "cardTypeRestricted", excludedTypes: [...cardTypeMatches] };
   }
   NON_TYPE_RE.lastIndex = 0;
-  if (NON_TYPE_RE.test(oracleText)) return "specificType";
+  if (NON_TYPE_RE.test(oracleText)) {
+    return { kind: "specificType", excludedTypes: [] };
+  }
   return null;
 }
 const COUNTER_RE = /\bcounter target\b.+?\bspell\b/i;

--- a/src/lib/creature-types.ts
+++ b/src/lib/creature-types.ts
@@ -172,7 +172,7 @@ const TYPE_CONTEXT_RE = new RegExp(
 );
 
 /** "non-TYPE creatures" pattern for asymmetric wipes */
-const NON_TYPE_RE = new RegExp(
+export const NON_TYPE_RE = new RegExp(
   `\\bnon-(?:${CREATURE_TYPE_PATTERN})\\b`,
   "gi"
 );

--- a/src/lib/synergy-engine.ts
+++ b/src/lib/synergy-engine.ts
@@ -220,10 +220,23 @@ function getCardAxisIntent(
 // Patterns identifying token producers whose tokens would SURVIVE a wipe that spares a given card type.
 // Used for per-pair exemption: only the token producer whose tokens match the spared category is
 // exempt — unrelated token producers in the same deck still trigger the anti-synergy.
+// Only consulted for cards already classified on the tokens axis, so patterns don't need to
+// separately prove the card creates tokens.
 const TOKEN_SURVIVES_PATTERNS: Record<string, RegExp> = {
-  // Explicit "artifact creature token" phrasing plus common artifact-creature token subtype names.
-  artifact:
-    /\bartifact creature tokens?\b|\b(?:Thopter|Servo|Construct|Myr|Golem|Scion|Powerstone|Drone|Assembly-Worker)\b/i,
+  artifact: new RegExp(
+    [
+      // Explicit "artifact creature token" phrasing (Breya, Thopter Spy Network, Pia and Kiran Nalaar).
+      String.raw`\bartifact creature tokens?\b`,
+      // Known artifact-token subtype names (creatures and non-creature artifact tokens).
+      String.raw`\b(?:Thopter|Servo|Construct|Myr|Golem|Scion|Powerstone|Drone|Assembly-Worker|Treasure|Clue|Food|Blood|Gold|Junk|Map)\b`,
+      // "Token that's a copy of ... artifact" (Mirrorworks, Saheeli's Artistry's artifact mode).
+      String.raw`\bcop(?:y|ies) of (?:that |the |an? )?(?:nontoken )?artifact\b`,
+      // Imprint restricted to an artifact card — any resulting token copy is always an artifact
+      // (Prototype Portal, Soul Foundry when imprinted with an artifact creature).
+      String.raw`\bexile an? artifact card\b`,
+    ].join("|"),
+    "i"
+  ),
   enchantment: /\benchantment (?:creature )?tokens?\b/i,
   legendary: /\blegendary (?:creature )?tokens?\b/i,
 };

--- a/src/lib/synergy-engine.ts
+++ b/src/lib/synergy-engine.ts
@@ -9,12 +9,13 @@ import type {
 } from "./types";
 import { SYNERGY_AXES, extractReferencedKeywords } from "./synergy-axes";
 import { findCombosInDeck } from "./known-combos";
-import { getTagsCached } from "./card-tags";
+import { getTagsCached, classifyAsymmetricWipe } from "./card-tags";
 import {
   identifyTribalAnchors,
   getCreatureSubtypes,
   getCommanderTypes,
   isChangeling,
+  extractReferencedTypes,
 } from "./creature-types";
 import {
   identifySupertypeAnchors,
@@ -220,6 +221,7 @@ function generateAntiSynergyPairs(
   cardNames: string[],
   axisScores: Map<string, CardAxisScore[]>,
   cardMap: Record<string, EnrichedCard>,
+  tribalAnchorTypes: Set<string>,
   tagCache?: Map<string, string[]>
 ): SynergyPair[] {
   const pairs: SynergyPair[] = [];
@@ -266,28 +268,56 @@ function generateAntiSynergyPairs(
   }
 
   // Board wipe vs tokens anti-synergy (tag-based)
+  // Asymmetric (one-sided) wipes are exempt according to their sub-classification:
+  //   - opponentSided (In Garruk's Wake): always exempt.
+  //   - chosenType (Kindred Dominance): exempt when the deck has any tribal anchor to name.
+  //   - specificType ("non-Elf" wipes): exempt when the referenced type matches a deck anchor.
   const tokenCardNames: string[] = [];
-  const boardWipeCardNames: string[] = [];
+  type WipeInfo = {
+    name: string;
+    kind: ReturnType<typeof classifyAsymmetricWipe>;
+    referencedTypes: string[];
+  };
+  const boardWipes: WipeInfo[] = [];
 
   for (const name of cardNames) {
     const card = cardMap[name];
     if (!card) continue;
     const tags = getTagsCached(card, tagCache);
-    if (tags.includes("Board Wipe")) boardWipeCardNames.push(name);
+    if (tags.includes("Board Wipe")) {
+      const kind = tags.includes("Asymmetric Wipe")
+        ? classifyAsymmetricWipe(card.oracleText)
+        : null;
+      const referencedTypes =
+        kind === "specificType" ? extractReferencedTypes(card.oracleText) : [];
+      boardWipes.push({ name, kind, referencedTypes });
+    }
     const tokenAxes = axisScores.get(name) ?? [];
     if (tokenAxes.some((a) => a.axisId === "tokens" && a.relevance >= AXIS_RELEVANCE_THRESHOLD)) {
       tokenCardNames.push(name);
     }
   }
 
-  for (const wipeName of boardWipeCardNames) {
+  for (const wipe of boardWipes) {
+    // Opponent-sided wipes are always exempt (favor the caster regardless of deck).
+    if (wipe.kind === "opponentSided") continue;
+    // Chosen-type wipes are exempt whenever the deck has any tribal anchor the caster can name.
+    if (wipe.kind === "chosenType" && tribalAnchorTypes.size > 0) continue;
+    // Specific-type wipes ("non-Elf") are exempt only if the named type matches an anchor.
+    if (
+      wipe.kind === "specificType" &&
+      wipe.referencedTypes.some((t) => tribalAnchorTypes.has(t))
+    ) {
+      continue;
+    }
+
     for (const tokenName of tokenCardNames) {
-      const key = `anti:${[wipeName, tokenName].sort().join("|")}:boardwipe-tokens`;
+      const key = `anti:${[wipe.name, tokenName].sort().join("|")}:boardwipe-tokens`;
       if (seen.has(key)) continue;
       seen.add(key);
 
       pairs.push({
-        cards: [wipeName, tokenName],
+        cards: [wipe.name, tokenName],
         axisId: "tokens",
         type: "anti-synergy",
         strength: 0.6,
@@ -696,8 +726,23 @@ export function analyzeDeckSynergy(
   // Step 4: Generate heuristic synergy pairs (with optional intent filtering)
   const synergyPairs = generateSynergyPairs(cardNames, axisScores, intentSummaries);
 
-  // Step 5: Generate anti-synergy pairs
-  const antiSynergyPairs = generateAntiSynergyPairs(cardNames, axisScores, cardMap, tagCache);
+  // Step 5a: Resolve commanders and tribal anchors (needed by anti-synergy and theme detection)
+  const commanders: EnrichedCard[] = [];
+  for (const cmd of deck.commanders) {
+    const card = cardMap[cmd.name];
+    if (card) commanders.push(card);
+  }
+  const tribalAnchors = identifyTribalAnchors(commanders, cardNames, cardMap);
+  const tribalAnchorTypes = new Set(tribalAnchors);
+
+  // Step 5b: Generate anti-synergy pairs (asymmetric wipes exempt when they protect the tribal theme)
+  const antiSynergyPairs = generateAntiSynergyPairs(
+    cardNames,
+    axisScores,
+    cardMap,
+    tribalAnchorTypes,
+    tagCache
+  );
 
   // Step 6: Compute per-card scores
   const cardScores = computeCardScores(
@@ -709,13 +754,7 @@ export function analyzeDeckSynergy(
     comboPairs
   );
 
-  // Step 7: Identify deck themes (pass tribal anchors for labeling)
-  const commanders: EnrichedCard[] = [];
-  for (const cmd of deck.commanders) {
-    const card = cardMap[cmd.name];
-    if (card) commanders.push(card);
-  }
-  const tribalAnchors = identifyTribalAnchors(commanders, cardNames, cardMap);
+  // Step 7: Identify deck themes (reuses tribal anchors resolved above)
   const deckThemes = identifyDeckThemes(axisScores, tribalAnchors, supertypeAnchors, keywordAnchors);
 
   // Step 8: Sort and return

--- a/src/lib/synergy-engine.ts
+++ b/src/lib/synergy-engine.ts
@@ -217,48 +217,26 @@ function getCardAxisIntent(
   return undefined;
 }
 
-/** Count deck cards whose type line includes the given MTG type token (case-insensitive, word-boundary). */
-function countCardsByType(
-  cardNames: string[],
-  cardMap: Record<string, EnrichedCard>,
-  typeName: string
-): number {
-  const re = new RegExp(`\\b${typeName}\\b`, "i");
-  let count = 0;
-  for (const name of cardNames) {
-    const card = cardMap[name];
-    if (card && re.test(card.typeLine)) count++;
-  }
-  return count;
-}
-
-// Thresholds for treating a deck as "themed" around a spared card type. A nonartifact wipe
-// (Organic Extinction) is asymmetric when the caster is playing ≥10 artifacts; same bar for
-// enchantments; planeswalkers use a lower bar since superfriends decks run fewer walkers.
-const CARD_TYPE_THEME_THRESHOLD: Record<string, number> = {
-  artifact: 10,
-  enchantment: 10,
-  planeswalker: 4,
+// Patterns identifying token producers whose tokens would SURVIVE a wipe that spares a given card type.
+// Used for per-pair exemption: only the token producer whose tokens match the spared category is
+// exempt — unrelated token producers in the same deck still trigger the anti-synergy.
+const TOKEN_SURVIVES_PATTERNS: Record<string, RegExp> = {
+  // Explicit "artifact creature token" phrasing plus common artifact-creature token subtype names.
+  artifact:
+    /\bartifact creature tokens?\b|\b(?:Thopter|Servo|Construct|Myr|Golem|Scion|Powerstone|Drone|Assembly-Worker)\b/i,
+  enchantment: /\benchantment (?:creature )?tokens?\b/i,
+  legendary: /\blegendary (?:creature )?tokens?\b/i,
 };
 
-/** Whether the deck aligns with any of the spared categories of a cardTypeRestricted wipe. */
-function deckMatchesSparedCardType(
-  excludedTypes: string[],
-  cardNames: string[],
-  cardMap: Record<string, EnrichedCard>,
-  supertypeAnchors: string[]
+/** Whether this token producer's tokens survive a wipe that spares the given card-type categories. */
+function tokensSurviveCardTypeWipe(
+  producer: EnrichedCard,
+  sparedTypes: string[]
 ): boolean {
-  for (const type of excludedTypes) {
-    // Supertypes ("legendary", "snow", "basic") route through the existing supertype anchor detector.
-    if (type === "legendary" || type === "snow" || type === "basic") {
-      if (supertypeAnchors.includes(type)) return true;
-      continue;
-    }
-    // Card types (artifact, enchantment, planeswalker) — count cards by type line.
-    const threshold = CARD_TYPE_THEME_THRESHOLD[type];
-    if (threshold === undefined) continue;
-    const typeTitle = type[0].toUpperCase() + type.slice(1);
-    if (countCardsByType(cardNames, cardMap, typeTitle) >= threshold) return true;
+  const text = producer.oracleText;
+  for (const spared of sparedTypes) {
+    const pattern = TOKEN_SURVIVES_PATTERNS[spared];
+    if (pattern?.test(text)) return true;
   }
   return false;
 }
@@ -269,7 +247,6 @@ function generateAntiSynergyPairs(
   axisScores: Map<string, CardAxisScore[]>,
   cardMap: Record<string, EnrichedCard>,
   tribalAnchorTypes: Set<string>,
-  supertypeAnchors: string[],
   tagCache?: Map<string, string[]>
 ): SynergyPair[] {
   const pairs: SynergyPair[] = [];
@@ -317,11 +294,12 @@ function generateAntiSynergyPairs(
 
   // Board wipe vs tokens anti-synergy (tag-based)
   // Asymmetric (one-sided) wipes are exempt according to their sub-classification:
-  //   - opponentSided (In Garruk's Wake): always exempt.
+  //   - opponentSided (In Garruk's Wake): always exempt — the wipe never hits the caster's board.
   //   - chosenType (Kindred Dominance): exempt when the deck has any tribal anchor to name.
   //   - specificType ("non-Elf" wipes): exempt when the referenced subtype matches a deck anchor.
-  //   - cardTypeRestricted ("nonartifact", "nonlegendary"): exempt when the deck is themed
-  //     around the spared card type / supertype (Organic Extinction in an artifact deck, etc.).
+  //   - cardTypeRestricted (Organic Extinction's "nonartifact creatures"): exempt PER PAIR —
+  //     only when the specific token producer's tokens match the spared card type. An artifact
+  //     deck with Bitterblossom still loses its Faerie tokens to Organic Extinction.
   const tokenCardNames: string[] = [];
   type WipeInfo = {
     name: string;
@@ -352,7 +330,7 @@ function generateAntiSynergyPairs(
 
   for (const wipe of boardWipes) {
     const c = wipe.classification;
-    // Opponent-sided wipes are always exempt (favor the caster regardless of deck).
+    // Opponent-sided wipes never pair with tokens.
     if (c?.kind === "opponentSided") continue;
     // Chosen-type wipes are exempt whenever the deck has any tribal anchor the caster can name.
     if (c?.kind === "chosenType" && tribalAnchorTypes.size > 0) continue;
@@ -363,15 +341,18 @@ function generateAntiSynergyPairs(
     ) {
       continue;
     }
-    // Card-type-restricted wipes are exempt when the deck's composition aligns with the spared category.
-    if (
-      c?.kind === "cardTypeRestricted" &&
-      deckMatchesSparedCardType(c.excludedTypes, cardNames, cardMap, supertypeAnchors)
-    ) {
-      continue;
-    }
 
     for (const tokenName of tokenCardNames) {
+      // Card-type-restricted wipes: exempt this pair only if the specific token producer's
+      // tokens survive the wipe (e.g. Thopter Spy Network makes artifact creature tokens,
+      // which survive Organic Extinction).
+      if (c?.kind === "cardTypeRestricted") {
+        const producer = cardMap[tokenName];
+        if (producer && tokensSurviveCardTypeWipe(producer, c.excludedTypes)) {
+          continue;
+        }
+      }
+
       const key = `anti:${[wipe.name, tokenName].sort().join("|")}:boardwipe-tokens`;
       if (seen.has(key)) continue;
       seen.add(key);
@@ -801,7 +782,6 @@ export function analyzeDeckSynergy(
     axisScores,
     cardMap,
     tribalAnchorTypes,
-    supertypeAnchors,
     tagCache
   );
 

--- a/src/lib/synergy-engine.ts
+++ b/src/lib/synergy-engine.ts
@@ -9,6 +9,7 @@ import type {
 } from "./types";
 import { SYNERGY_AXES, extractReferencedKeywords } from "./synergy-axes";
 import { findCombosInDeck } from "./known-combos";
+import type { AsymmetricWipeClassification } from "./card-tags";
 import { getTagsCached, classifyAsymmetricWipe } from "./card-tags";
 import {
   identifyTribalAnchors,
@@ -216,12 +217,59 @@ function getCardAxisIntent(
   return undefined;
 }
 
+/** Count deck cards whose type line includes the given MTG type token (case-insensitive, word-boundary). */
+function countCardsByType(
+  cardNames: string[],
+  cardMap: Record<string, EnrichedCard>,
+  typeName: string
+): number {
+  const re = new RegExp(`\\b${typeName}\\b`, "i");
+  let count = 0;
+  for (const name of cardNames) {
+    const card = cardMap[name];
+    if (card && re.test(card.typeLine)) count++;
+  }
+  return count;
+}
+
+// Thresholds for treating a deck as "themed" around a spared card type. A nonartifact wipe
+// (Organic Extinction) is asymmetric when the caster is playing ≥10 artifacts; same bar for
+// enchantments; planeswalkers use a lower bar since superfriends decks run fewer walkers.
+const CARD_TYPE_THEME_THRESHOLD: Record<string, number> = {
+  artifact: 10,
+  enchantment: 10,
+  planeswalker: 4,
+};
+
+/** Whether the deck aligns with any of the spared categories of a cardTypeRestricted wipe. */
+function deckMatchesSparedCardType(
+  excludedTypes: string[],
+  cardNames: string[],
+  cardMap: Record<string, EnrichedCard>,
+  supertypeAnchors: string[]
+): boolean {
+  for (const type of excludedTypes) {
+    // Supertypes ("legendary", "snow", "basic") route through the existing supertype anchor detector.
+    if (type === "legendary" || type === "snow" || type === "basic") {
+      if (supertypeAnchors.includes(type)) return true;
+      continue;
+    }
+    // Card types (artifact, enchantment, planeswalker) — count cards by type line.
+    const threshold = CARD_TYPE_THEME_THRESHOLD[type];
+    if (threshold === undefined) continue;
+    const typeTitle = type[0].toUpperCase() + type.slice(1);
+    if (countCardsByType(cardNames, cardMap, typeTitle) >= threshold) return true;
+  }
+  return false;
+}
+
 /** Generate anti-synergy pairs between cards on conflicting axes */
 function generateAntiSynergyPairs(
   cardNames: string[],
   axisScores: Map<string, CardAxisScore[]>,
   cardMap: Record<string, EnrichedCard>,
   tribalAnchorTypes: Set<string>,
+  supertypeAnchors: string[],
   tagCache?: Map<string, string[]>
 ): SynergyPair[] {
   const pairs: SynergyPair[] = [];
@@ -271,11 +319,13 @@ function generateAntiSynergyPairs(
   // Asymmetric (one-sided) wipes are exempt according to their sub-classification:
   //   - opponentSided (In Garruk's Wake): always exempt.
   //   - chosenType (Kindred Dominance): exempt when the deck has any tribal anchor to name.
-  //   - specificType ("non-Elf" wipes): exempt when the referenced type matches a deck anchor.
+  //   - specificType ("non-Elf" wipes): exempt when the referenced subtype matches a deck anchor.
+  //   - cardTypeRestricted ("nonartifact", "nonlegendary"): exempt when the deck is themed
+  //     around the spared card type / supertype (Organic Extinction in an artifact deck, etc.).
   const tokenCardNames: string[] = [];
   type WipeInfo = {
     name: string;
-    kind: ReturnType<typeof classifyAsymmetricWipe>;
+    classification: AsymmetricWipeClassification | null;
     referencedTypes: string[];
   };
   const boardWipes: WipeInfo[] = [];
@@ -285,12 +335,14 @@ function generateAntiSynergyPairs(
     if (!card) continue;
     const tags = getTagsCached(card, tagCache);
     if (tags.includes("Board Wipe")) {
-      const kind = tags.includes("Asymmetric Wipe")
+      const classification = tags.includes("Asymmetric Wipe")
         ? classifyAsymmetricWipe(card.oracleText)
         : null;
       const referencedTypes =
-        kind === "specificType" ? extractReferencedTypes(card.oracleText) : [];
-      boardWipes.push({ name, kind, referencedTypes });
+        classification?.kind === "specificType"
+          ? extractReferencedTypes(card.oracleText)
+          : [];
+      boardWipes.push({ name, classification, referencedTypes });
     }
     const tokenAxes = axisScores.get(name) ?? [];
     if (tokenAxes.some((a) => a.axisId === "tokens" && a.relevance >= AXIS_RELEVANCE_THRESHOLD)) {
@@ -299,14 +351,22 @@ function generateAntiSynergyPairs(
   }
 
   for (const wipe of boardWipes) {
+    const c = wipe.classification;
     // Opponent-sided wipes are always exempt (favor the caster regardless of deck).
-    if (wipe.kind === "opponentSided") continue;
+    if (c?.kind === "opponentSided") continue;
     // Chosen-type wipes are exempt whenever the deck has any tribal anchor the caster can name.
-    if (wipe.kind === "chosenType" && tribalAnchorTypes.size > 0) continue;
-    // Specific-type wipes ("non-Elf") are exempt only if the named type matches an anchor.
+    if (c?.kind === "chosenType" && tribalAnchorTypes.size > 0) continue;
+    // Specific-type wipes ("non-Elf") are exempt only if the named subtype matches an anchor.
     if (
-      wipe.kind === "specificType" &&
+      c?.kind === "specificType" &&
       wipe.referencedTypes.some((t) => tribalAnchorTypes.has(t))
+    ) {
+      continue;
+    }
+    // Card-type-restricted wipes are exempt when the deck's composition aligns with the spared category.
+    if (
+      c?.kind === "cardTypeRestricted" &&
+      deckMatchesSparedCardType(c.excludedTypes, cardNames, cardMap, supertypeAnchors)
     ) {
       continue;
     }
@@ -735,12 +795,13 @@ export function analyzeDeckSynergy(
   const tribalAnchors = identifyTribalAnchors(commanders, cardNames, cardMap);
   const tribalAnchorTypes = new Set(tribalAnchors);
 
-  // Step 5b: Generate anti-synergy pairs (asymmetric wipes exempt when they protect the tribal theme)
+  // Step 5b: Generate anti-synergy pairs (asymmetric wipes exempt when they protect the deck's theme)
   const antiSynergyPairs = generateAntiSynergyPairs(
     cardNames,
     axisScores,
     cardMap,
     tribalAnchorTypes,
+    supertypeAnchors,
     tagCache
   );
 

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -194,6 +194,40 @@ test.describe("generateTags — Asymmetric Wipe", () => {
     expect(tags).not.toContain("Asymmetric Wipe");
   });
 
+  test("Organic Extinction (nonartifact creatures) → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Organic Extinction",
+      typeLine: "Sorcery",
+      oracleText:
+        "Improvise (Your artifacts can help cast this spell. Each artifact you tap after you're done activating mana abilities pays for {1}.)\nDestroy all nonartifact creatures.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
+  test("hypothetical nonlegendary wipe → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Hypothetical Legendary Purge",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all nonlegendary creatures.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
+  test("symmetric artifact destruction (Shatterstorm) → Board Wipe but NOT Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Shatterstorm",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all artifacts. They can't be regenerated.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).not.toContain("Asymmetric Wipe");
+  });
+
   test("symmetric -N/-N wipe (e.g. Black Sun's Zenith) → Board Wipe but NOT Asymmetric Wipe", () => {
     const card = makeCard({
       name: "Black Sun's Zenith",

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -217,6 +217,33 @@ test.describe("generateTags — Asymmetric Wipe", () => {
     expect(tags).toContain("Asymmetric Wipe");
   });
 
+  test("Hour of Reckoning (nontoken) → Board Wipe but NOT Asymmetric Wipe", () => {
+    // 'nontoken' sweeps *token* creatures — this wipe KILLS token strategies, not spares them.
+    // Regression guard: must not be lumped into cardTypeRestricted exemption.
+    const card = makeCard({
+      name: "Hour of Reckoning",
+      typeLine: "Sorcery",
+      oracleText: "Convoke (Your creatures can help cast this spell.)\nDestroy all nontoken creatures.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).not.toContain("Asymmetric Wipe");
+  });
+
+  test("modal card with single-target 'you don't control' + symmetric wipe → not Asymmetric Wipe", () => {
+    // False-positive regression: a card with "target creature you don't control" in a non-wipe
+    // clause alongside a symmetric "destroy all creatures" must not be tagged asymmetric.
+    const card = makeCard({
+      name: "Hypothetical Modal Wipe",
+      typeLine: "Sorcery",
+      oracleText:
+        "Choose one —\n• Destroy target creature you don't control.\n• Destroy all creatures.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).not.toContain("Asymmetric Wipe");
+  });
+
   test("symmetric artifact destruction (Shatterstorm) → Board Wipe but NOT Asymmetric Wipe", () => {
     const card = makeCard({
       name: "Shatterstorm",

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -113,6 +113,109 @@ test.describe("generateTags — Board Wipe", () => {
   });
 });
 
+test.describe("generateTags — Asymmetric Wipe", () => {
+  test("Kindred Dominance (chosen-type exclusion) → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Kindred Dominance",
+      typeLine: "Kindred Sorcery",
+      oracleText:
+        "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
+  test("In Garruk's Wake (you don't control) → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "In Garruk's Wake",
+      typeLine: "Sorcery",
+      oracleText:
+        "Destroy all creatures you don't control and all planeswalkers you don't control.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
+  test("Plague Wind (you don't control) → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Plague Wind",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all creatures you don't control. They can't be regenerated.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
+  test("non-creature-type wipe → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Hypothetical Elf Purge",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all non-Elf creatures.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
+  test("Cyclonic Rift overload (opponents control) → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Cyclonic Rift",
+      typeLine: "Instant",
+      oracleText:
+        "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change its text by replacing all instances of \"target\" with \"each.\")\nReturn all nonland permanents your opponents control to their owners' hands.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
+  test("Wrath of God → Board Wipe but NOT Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Wrath of God",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all creatures. They can't be regenerated.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).not.toContain("Asymmetric Wipe");
+  });
+
+  test("Damnation → Board Wipe but NOT Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Damnation",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all creatures. They can't be regenerated.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).not.toContain("Asymmetric Wipe");
+  });
+
+  test("symmetric -N/-N wipe (e.g. Black Sun's Zenith) → Board Wipe but NOT Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Black Sun's Zenith",
+      typeLine: "Sorcery",
+      oracleText: "All creatures get -3/-3 until end of turn.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).not.toContain("Asymmetric Wipe");
+  });
+
+  test("non-Board-Wipe reference to 'non-Elf' → no Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Hypothetical Lord",
+      typeLine: "Creature",
+      oracleText: "Non-Elf creatures you control get +1/+0.",
+    });
+    const tags = generateTags(card);
+    expect(tags).not.toContain("Asymmetric Wipe");
+  });
+});
+
 test.describe("generateTags — Counterspell", () => {
   test("'Counter target spell.' → Counterspell", () => {
     const card = makeCard({ oracleText: "Counter target spell." });

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -217,6 +217,18 @@ test.describe("generateTags — Asymmetric Wipe", () => {
     expect(tags).toContain("Asymmetric Wipe");
   });
 
+  test("Scourglass (except for artifacts and lands) → Board Wipe + Asymmetric Wipe", () => {
+    const card = makeCard({
+      name: "Scourglass",
+      typeLine: "Artifact",
+      oracleText:
+        "{T}, Sacrifice Scourglass: Destroy all permanents except for artifacts and lands. Activate only during your upkeep.",
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Board Wipe");
+    expect(tags).toContain("Asymmetric Wipe");
+  });
+
   test("Hour of Reckoning (nontoken) → Board Wipe but NOT Asymmetric Wipe", () => {
     // 'nontoken' sweeps *token* creatures — this wipe KILLS token strategies, not spares them.
     // Regression guard: must not be lumped into cardTypeRestricted exemption.

--- a/tests/unit/synergy-engine.spec.ts
+++ b/tests/unit/synergy-engine.spec.ts
@@ -1238,6 +1238,91 @@ test.describe("board wipe anti-synergy — asymmetric exemption", () => {
     expect(pair).toBeDefined();
   });
 
+  test("Organic Extinction + Mirrorworks (copy-of-artifact tokens) → no anti-synergy pair", () => {
+    // Mirrorworks creates a token that's a copy of a nontoken artifact — the tokens are
+    // artifacts and survive "Destroy all nonartifact creatures".
+    const cards: Record<string, EnrichedCard> = {
+      "Organic Extinction": mockCard({
+        name: "Organic Extinction",
+        typeLine: "Sorcery",
+        oracleText: "Improvise\nDestroy all nonartifact creatures.",
+      }),
+      Mirrorworks: mockCard({
+        name: "Mirrorworks",
+        typeLine: "Artifact",
+        oracleText:
+          "Whenever another nontoken artifact enters the battlefield under your control, you may pay {2}. If you do, create a token that's a copy of that artifact.",
+      }),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Organic Extinction") &&
+        p.cards.includes("Mirrorworks")
+    );
+    expect(pair).toBeUndefined();
+  });
+
+  test("Organic Extinction + Prototype Portal (imprint-artifact + token copy) → no anti-synergy pair", () => {
+    // Prototype Portal's imprint is restricted to artifact cards, so any token it creates
+    // is always a copy of an artifact and survives "Destroy all nonartifact creatures".
+    const cards: Record<string, EnrichedCard> = {
+      "Organic Extinction": mockCard({
+        name: "Organic Extinction",
+        typeLine: "Sorcery",
+        oracleText: "Improvise\nDestroy all nonartifact creatures.",
+      }),
+      "Prototype Portal": mockCard({
+        name: "Prototype Portal",
+        typeLine: "Artifact",
+        oracleText:
+          "Imprint — When Prototype Portal enters the battlefield, you may exile an artifact card from your hand.\n{X}, {T}: Create a token that's a copy of the exiled card. X is the mana value of that card.",
+      }),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Organic Extinction") &&
+        p.cards.includes("Prototype Portal")
+    );
+    expect(pair).toBeUndefined();
+  });
+
+  test("Organic Extinction + Breya as commander (Thopter artifact creature tokens) → no anti-synergy pair", () => {
+    // Regression: Breya's ETB explicitly creates "Thopter artifact creature tokens";
+    // she should be exempt as a commander too.
+    const cards: Record<string, EnrichedCard> = {
+      "Organic Extinction": mockCard({
+        name: "Organic Extinction",
+        typeLine: "Sorcery",
+        oracleText: "Improvise\nDestroy all nonartifact creatures.",
+      }),
+      "Breya, Etherium Shaper": mockCard({
+        name: "Breya, Etherium Shaper",
+        typeLine: "Legendary Artifact Creature — Human Artificer",
+        subtypes: ["Human", "Artificer"],
+        oracleText:
+          "When Breya, Etherium Shaper enters the battlefield, create two 1/1 blue Thopter artifact creature tokens with flying.\n{2}, Sacrifice two artifacts: Choose one —\n• Breya, Etherium Shaper deals 3 damage to any target.\n• Target creature gets -4/-4 until end of turn.\n• You gain 5 life.",
+      }),
+    };
+    const deck = mockDeck(["Organic Extinction"], ["Breya, Etherium Shaper"]);
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Organic Extinction") &&
+        p.cards.includes("Breya, Etherium Shaper")
+    );
+    expect(pair).toBeUndefined();
+  });
+
   test("Organic Extinction + mixed token producers → exempt vs Thopter, pair vs Bitterblossom", () => {
     // Per-pair exemption: one producer in the same deck can be exempt while another
     // producing non-artifact tokens still triggers the penalty.

--- a/tests/unit/synergy-engine.spec.ts
+++ b/tests/unit/synergy-engine.spec.ts
@@ -1323,6 +1323,57 @@ test.describe("board wipe anti-synergy — asymmetric exemption", () => {
     expect(pair).toBeUndefined();
   });
 
+  test("Scourglass + Thopter Spy Network (artifact tokens spared) → no anti-synergy pair", () => {
+    // Scourglass destroys all permanents except artifacts and lands. Artifact creature
+    // tokens (Thopters) survive, so the pair is exempt.
+    const cards: Record<string, EnrichedCard> = {
+      Scourglass: mockCard({
+        name: "Scourglass",
+        typeLine: "Artifact",
+        oracleText:
+          "{T}, Sacrifice Scourglass: Destroy all permanents except for artifacts and lands. Activate only during your upkeep.",
+      }),
+      "Thopter Spy Network": mockCard({
+        name: "Thopter Spy Network",
+        typeLine: "Enchantment",
+        oracleText:
+          "At the beginning of combat on your turn, if you controlled an artifact this turn, create a 1/1 colorless Thopter artifact creature token with flying.",
+      }),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Scourglass") &&
+        p.cards.includes("Thopter Spy Network")
+    );
+    expect(pair).toBeUndefined();
+  });
+
+  test("Scourglass + Bitterblossom (Faerie tokens die) → anti-synergy pair present", () => {
+    const cards: Record<string, EnrichedCard> = {
+      Scourglass: mockCard({
+        name: "Scourglass",
+        typeLine: "Artifact",
+        oracleText:
+          "{T}, Sacrifice Scourglass: Destroy all permanents except for artifacts and lands. Activate only during your upkeep.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Scourglass") &&
+        p.cards.includes("Bitterblossom")
+    );
+    expect(pair).toBeDefined();
+  });
+
   test("Organic Extinction + mixed token producers → exempt vs Thopter, pair vs Bitterblossom", () => {
     // Per-pair exemption: one producer in the same deck can be exempt while another
     // producing non-artifact tokens still triggers the penalty.

--- a/tests/unit/synergy-engine.spec.ts
+++ b/tests/unit/synergy-engine.spec.ts
@@ -1189,29 +1189,21 @@ test.describe("board wipe anti-synergy — asymmetric exemption", () => {
     expect(pair).toBeDefined();
   });
 
-  function artifactCreature(name: string) {
-    return mockCard({
-      name,
-      typeLine: "Artifact Creature — Construct",
-      subtypes: ["Construct"],
-      oracleText: "",
-    });
-  }
-
-  test("Organic Extinction in artifact-heavy deck → no anti-synergy pair", () => {
-    const artifacts: Record<string, EnrichedCard> = {};
-    for (let i = 0; i < 12; i++) {
-      artifacts[`Construct ${i}`] = artifactCreature(`Construct ${i}`);
-    }
+  test("Organic Extinction + Thopter Spy Network (artifact tokens) → no anti-synergy pair", () => {
+    // Thopter Spy Network creates Thopter artifact creature tokens, which survive
+    // "Destroy all nonartifact creatures". The anti-synergy should be suppressed.
     const cards: Record<string, EnrichedCard> = {
-      ...artifacts,
       "Organic Extinction": mockCard({
         name: "Organic Extinction",
         typeLine: "Sorcery",
-        oracleText:
-          "Improvise\nDestroy all nonartifact creatures.",
+        oracleText: "Improvise\nDestroy all nonartifact creatures.",
       }),
-      Bitterblossom: tokenProducer(),
+      "Thopter Spy Network": mockCard({
+        name: "Thopter Spy Network",
+        typeLine: "Enchantment",
+        oracleText:
+          "At the beginning of combat on your turn, if you controlled an artifact this turn, create a 1/1 colorless Thopter artifact creature token with flying.\nWhenever one or more artifact creatures you control deal combat damage to a player, draw a card.",
+      }),
     };
     const deck = mockDeck(Object.keys(cards));
     const result = analyzeDeckSynergy(deck, cards);
@@ -1224,13 +1216,14 @@ test.describe("board wipe anti-synergy — asymmetric exemption", () => {
     expect(pair).toBeUndefined();
   });
 
-  test("Organic Extinction in non-artifact deck → anti-synergy pair present", () => {
+  test("Organic Extinction + Bitterblossom (Faerie tokens are creatures but NOT artifacts) → anti-synergy pair present", () => {
+    // Faerie tokens are non-artifact creatures — they die to Organic Extinction.
+    // The penalty must still fire even though the wipe is tagged Asymmetric.
     const cards: Record<string, EnrichedCard> = {
       "Organic Extinction": mockCard({
         name: "Organic Extinction",
         typeLine: "Sorcery",
-        oracleText:
-          "Improvise\nDestroy all nonartifact creatures.",
+        oracleText: "Improvise\nDestroy all nonartifact creatures.",
       }),
       Bitterblossom: tokenProducer(),
     };
@@ -1243,5 +1236,41 @@ test.describe("board wipe anti-synergy — asymmetric exemption", () => {
         p.cards.includes("Organic Extinction")
     );
     expect(pair).toBeDefined();
+  });
+
+  test("Organic Extinction + mixed token producers → exempt vs Thopter, pair vs Bitterblossom", () => {
+    // Per-pair exemption: one producer in the same deck can be exempt while another
+    // producing non-artifact tokens still triggers the penalty.
+    const cards: Record<string, EnrichedCard> = {
+      "Organic Extinction": mockCard({
+        name: "Organic Extinction",
+        typeLine: "Sorcery",
+        oracleText: "Improvise\nDestroy all nonartifact creatures.",
+      }),
+      "Thopter Spy Network": mockCard({
+        name: "Thopter Spy Network",
+        typeLine: "Enchantment",
+        oracleText:
+          "At the beginning of combat on your turn, if you controlled an artifact this turn, create a 1/1 colorless Thopter artifact creature token with flying.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const thopterPair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Organic Extinction") &&
+        p.cards.includes("Thopter Spy Network")
+    );
+    const faeriePair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Organic Extinction") &&
+        p.cards.includes("Bitterblossom")
+    );
+    expect(thopterPair).toBeUndefined();
+    expect(faeriePair).toBeDefined();
   });
 });

--- a/tests/unit/synergy-engine.spec.ts
+++ b/tests/unit/synergy-engine.spec.ts
@@ -1060,3 +1060,132 @@ test.describe("analyzeDeckSynergy", () => {
     expect(discardTheme).toBeDefined();
   });
 });
+
+test.describe("board wipe anti-synergy — asymmetric exemption", () => {
+  function tokenProducer() {
+    return mockCard({
+      name: "Bitterblossom",
+      typeLine: "Tribal Enchantment — Faerie",
+      oracleText:
+        "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie Rogue creature token with flying.",
+    });
+  }
+
+  test("Wrath of God + tokens → anti-synergy pair present (regression guard)", () => {
+    const cards: Record<string, EnrichedCard> = {
+      "Wrath of God": mockCard({
+        name: "Wrath of God",
+        typeLine: "Sorcery",
+        oracleText: "Destroy all creatures. They can't be regenerated.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Wrath of God") &&
+        p.cards.includes("Bitterblossom")
+    );
+    expect(pair).toBeDefined();
+  });
+
+  test("In Garruk's Wake + tokens (no tribal theme) → no anti-synergy pair (one-sided always exempt)", () => {
+    const cards: Record<string, EnrichedCard> = {
+      "In Garruk's Wake": mockCard({
+        name: "In Garruk's Wake",
+        typeLine: "Sorcery",
+        oracleText:
+          "Destroy all creatures you don't control and all planeswalkers you don't control.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("In Garruk's Wake")
+    );
+    expect(pair).toBeUndefined();
+  });
+
+  test("Kindred Dominance in Elf tribal deck → no anti-synergy pair", () => {
+    const cards: Record<string, EnrichedCard> = {
+      "Elvish Archdruid": mockCard({
+        name: "Elvish Archdruid",
+        typeLine: "Creature — Elf Druid",
+        subtypes: ["Elf", "Druid"],
+        oracleText:
+          "Other Elf creatures you control get +1/+1.\n{T}: Add {G} for each Elf you control.",
+      }),
+      "Llanowar Elves": mockCard({
+        name: "Llanowar Elves",
+        typeLine: "Creature — Elf Druid",
+        subtypes: ["Elf", "Druid"],
+        oracleText: "{T}: Add {G}.",
+      }),
+      "Elvish Mystic": mockCard({
+        name: "Elvish Mystic",
+        typeLine: "Creature — Elf Druid",
+        subtypes: ["Elf", "Druid"],
+        oracleText: "{T}: Add {G}.",
+      }),
+      "Priest of Titania": mockCard({
+        name: "Priest of Titania",
+        typeLine: "Creature — Elf Druid",
+        subtypes: ["Elf", "Druid"],
+        oracleText: "{T}: Add {G} for each Elf on the battlefield.",
+      }),
+      "Kindred Dominance": mockCard({
+        name: "Kindred Dominance",
+        typeLine: "Kindred Sorcery",
+        oracleText:
+          "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(
+      [
+        "Llanowar Elves",
+        "Elvish Mystic",
+        "Priest of Titania",
+        "Kindred Dominance",
+        "Bitterblossom",
+      ],
+      ["Elvish Archdruid"]
+    );
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Kindred Dominance")
+    );
+    expect(pair).toBeUndefined();
+  });
+
+  test("Kindred Dominance in non-tribal deck → anti-synergy pair present", () => {
+    const cards: Record<string, EnrichedCard> = {
+      "Kindred Dominance": mockCard({
+        name: "Kindred Dominance",
+        typeLine: "Kindred Sorcery",
+        oracleText:
+          "Choose a creature type. Destroy all creatures that aren't of the chosen type.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Kindred Dominance")
+    );
+    expect(pair).toBeDefined();
+  });
+});

--- a/tests/unit/synergy-engine.spec.ts
+++ b/tests/unit/synergy-engine.spec.ts
@@ -1188,4 +1188,60 @@ test.describe("board wipe anti-synergy — asymmetric exemption", () => {
     );
     expect(pair).toBeDefined();
   });
+
+  function artifactCreature(name: string) {
+    return mockCard({
+      name,
+      typeLine: "Artifact Creature — Construct",
+      subtypes: ["Construct"],
+      oracleText: "",
+    });
+  }
+
+  test("Organic Extinction in artifact-heavy deck → no anti-synergy pair", () => {
+    const artifacts: Record<string, EnrichedCard> = {};
+    for (let i = 0; i < 12; i++) {
+      artifacts[`Construct ${i}`] = artifactCreature(`Construct ${i}`);
+    }
+    const cards: Record<string, EnrichedCard> = {
+      ...artifacts,
+      "Organic Extinction": mockCard({
+        name: "Organic Extinction",
+        typeLine: "Sorcery",
+        oracleText:
+          "Improvise\nDestroy all nonartifact creatures.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Organic Extinction")
+    );
+    expect(pair).toBeUndefined();
+  });
+
+  test("Organic Extinction in non-artifact deck → anti-synergy pair present", () => {
+    const cards: Record<string, EnrichedCard> = {
+      "Organic Extinction": mockCard({
+        name: "Organic Extinction",
+        typeLine: "Sorcery",
+        oracleText:
+          "Improvise\nDestroy all nonartifact creatures.",
+      }),
+      Bitterblossom: tokenProducer(),
+    };
+    const deck = mockDeck(Object.keys(cards));
+    const result = analyzeDeckSynergy(deck, cards);
+
+    const pair = result.antiSynergies.find(
+      (p) =>
+        p.description === "Board wipe conflicts with token strategy" &&
+        p.cards.includes("Organic Extinction")
+    );
+    expect(pair).toBeDefined();
+  });
 });


### PR DESCRIPTION
Cards like Kindred Dominance and In Garruk's Wake were being treated
identically to symmetric wipes (Wrath of God), triggering the tokens
anti-synergy penalty even though they favor the caster's board.

- Add `Asymmetric Wipe` tag alongside `Board Wipe` for one-sided wipes,
  with a sub-classifier (opponentSided | chosenType | specificType).
- Suppress the board-wipe-vs-tokens pair when the wipe is
  opponent-sided, or type-restricted with a matching deck tribal anchor.
- Export `NON_TYPE_RE` from creature-types for shared detection.
- Add unit coverage for Kindred Dominance, In Garruk's Wake, Plague Wind,
  Cyclonic Rift overload, non-Elf variants, and regression guards for
  Wrath of God / Black Sun's Zenith style symmetric wipes.

https://claude.ai/code/session_01ATa4SfDv9TRtneZy6pZfu3