### PR TITLE
Add Discord notification for production releases

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -26,3 +26,37 @@ jobs:
             exit 1
           fi
           echo "Vercel production deploy triggered (HTTP $RESPONSE)"
+
+      - name: Post release notes to Discord
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK_URL not set — skipping"
+            exit 0
+          fi
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#chore/bump-version-}"
+          TAG="v$VERSION"
+
+          RELEASE_JSON=$(gh release view "$TAG" --repo "${{ github.repository }}" --json body,url)
+          BODY=$(echo "$RELEASE_JSON" | jq -r '.body // ""')
+          URL=$(echo "$RELEASE_JSON" | jq -r '.url')
+          [ -z "$BODY" ] && BODY="See the release page for details."
+          if [ ${#BODY} -gt 4000 ]; then BODY="${BODY:0:3997}..."; fi
+
+          PAYLOAD=$(jq -n \
+            --arg title "Deck Evaluator $TAG released" \
+            --arg url   "$URL" \
+            --arg desc  "$BODY" \
+            --arg ts    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{embeds:[{title:$title, url:$url, description:$desc, color:9647338, timestamp:$ts}]}')
+
+          HTTP=$(curl -s -o /tmp/resp -w "%{http_code}" \
+            -H "Content-Type: application/json" \
+            -X POST -d "$PAYLOAD" "$DISCORD_WEBHOOK")
+          if [ "$HTTP" -lt 200 ] || [ "$HTTP" -ge 300 ]; then
+            echo "::error::Discord webhook returned HTTP $HTTP"; cat /tmp/resp; exit 1
+          fi
+          echo "Discord notified (HTTP $HTTP)"


### PR DESCRIPTION
## Summary
This change adds automatic Discord notifications when a new release is deployed to production. When a production deployment is triggered, release notes are fetched and posted to a configured Discord webhook.

## Key Changes
- Added a new workflow step that posts release notes to Discord after successful Vercel production deployment
- Extracts version information from the branch name (format: `chore/bump-version-X.Y.Z`)
- Fetches release details (body and URL) using the GitHub CLI
- Truncates release notes to 4000 characters to comply with Discord embed limits
- Formats the notification as a Discord embed with title, URL, description, and timestamp
- Gracefully skips notification if the `DISCORD_RELEASE_WEBHOOK_URL` secret is not configured
- Validates the webhook response and fails the workflow if the notification fails to send

## Implementation Details
- Uses GitHub's `gh` CLI to retrieve release information
- Constructs a Discord embed payload with release metadata
- Includes error handling for missing webhook configuration and failed HTTP requests
- Provides clear logging of success/failure status

https://claude.ai/code/session_01F9sRXCSCoxwrDixD5FFeWv