### PR TITLE
Add Secrets of Strixhaven mechanics support

### DIFF
--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -34,6 +34,16 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   "Mass Discard": { bg: "bg-neutral-600/20", text: "text-neutral-200" },
   "Self-Discard": { bg: "bg-gray-600/20", text: "text-gray-300" },
   "Discard Payoff": { bg: "bg-slate-600/20", text: "text-slate-200" },
+  // Secrets of Strixhaven (SOS) mechanics
+  Lesson: { bg: "bg-rose-500/20", text: "text-rose-200" },
+  Paradigm: { bg: "bg-fuchsia-500/20", text: "text-fuchsia-200" },
+  Opus: { bg: "bg-blue-500/20", text: "text-blue-300" },
+  Repartee: { bg: "bg-zinc-400/20", text: "text-zinc-200" },
+  Infusion: { bg: "bg-lime-500/20", text: "text-lime-300" },
+  Increment: { bg: "bg-lime-600/20", text: "text-lime-200" },
+  Prepare: { bg: "bg-cyan-500/20", text: "text-cyan-300" },
+  Book: { bg: "bg-amber-500/20", text: "text-amber-300" },
+  Converge: { bg: "bg-indigo-500/20", text: "text-indigo-300" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -251,6 +261,22 @@ const DISCARD_PAYOFF_CONDITION_RE =
   /\bif a player discarded a card this turn\b/i;
 // "unless ... discards" is NOT a payoff trigger — it's a Mass Discard choice
 const DISCARD_UNLESS_EXCLUSION_RE = /\bunless[^.]*discards?\b/i;
+
+// --- Secrets of Strixhaven (SOS) mechanics ---
+// Ability words use an em-dash on printed cards ("Opus —"); we accept either a
+// real em-dash (U+2014) or a hyphen-minus to be tolerant of paraphrased text.
+const OPUS_RE = /\bopus\s*(?:—|-)/i;
+const REPARTEE_RE = /\brepartee\s*(?:—|-)/i;
+const INFUSION_RE = /\binfusion\s*(?:—|-)/i;
+// Paradigm and Increment are keywords (also surface in card.keywords); we
+// fall back to a word-boundary regex when the keyword array is missing them.
+const PARADIGM_RE = /\bparadigm\b/i;
+const INCREMENT_RE = /\bincrement\b/i;
+// Prepare frames have a mode that says "becomes prepared" or "while ... is prepared".
+const PREPARE_RE = /\b(?:becomes? prepared|is prepared|prepare\s*\{)/i;
+// Converge: keyword from KTK; reminder text references "colors of mana spent".
+const CONVERGE_RE =
+  /\bconverge\b|\bcolors? of mana spent to cast (?:it|this spell)\b/i;
 
 const RESOURCE_DENIAL_NAMES = new Set([
   "Blood Moon",
@@ -554,6 +580,59 @@ export function generateTags(card: EnrichedCard): string[] {
         break;
       }
     }
+  }
+
+  // --- Secrets of Strixhaven mechanics ---
+
+  // Lesson — instant/sorcery subtype attached to the Paradigm cycle.
+  if (card.subtypes.includes("Lesson")) {
+    tags.add("Lesson");
+  }
+
+  // Paradigm — keyword on Lesson sorceries; exiles on first resolve and
+  // copies itself each first main phase.
+  if (card.keywords.includes("Paradigm") || PARADIGM_RE.test(text)) {
+    tags.add("Paradigm");
+  }
+
+  // Opus — Prismari ability word: triggers on instant/sorcery cast, with
+  // a 5+ mana threshold rider.
+  if (card.keywords.includes("Opus") || OPUS_RE.test(text)) {
+    tags.add("Opus");
+  }
+
+  // Repartee — Silverquill ability word: triggers on instant/sorcery cast
+  // that targets a creature.
+  if (card.keywords.includes("Repartee") || REPARTEE_RE.test(text)) {
+    tags.add("Repartee");
+  }
+
+  // Infusion — Witherbloom ability word: triggers care if you gained life
+  // this turn.
+  if (card.keywords.includes("Infusion") || INFUSION_RE.test(text)) {
+    tags.add("Infusion");
+  }
+
+  // Increment — Quandrix keyword on creatures: +1/+1 counter when you cast
+  // a spell with mana value greater than this creature's P or T.
+  if (card.keywords.includes("Increment") || INCREMENT_RE.test(text)) {
+    tags.add("Increment");
+  }
+
+  // Prepare — Adventure-style two-frame mechanic: a creature "becomes
+  // prepared" and you can cast a copy of its prepare-spell from exile.
+  if (PREPARE_RE.test(text)) {
+    tags.add("Prepare");
+  }
+
+  // Book — artifact subtype debuting in SOS.
+  if (card.subtypes.includes("Book")) {
+    tags.add("Book");
+  }
+
+  // Converge — multicolor payoff that scales with colors of mana spent.
+  if (card.keywords.includes("Converge") || CONVERGE_RE.test(text)) {
+    tags.add("Converge");
   }
 
   return Array.from(tags).sort();

--- a/src/lib/keyword-parameters.ts
+++ b/src/lib/keyword-parameters.ts
@@ -1,0 +1,25 @@
+/**
+ * Extracts the numeric parameter for a parameterized keyword (e.g. Ward 2,
+ * Connive 3, Casualty 2) from a card's oracle text.
+ *
+ * Returns null when the keyword is missing, or its argument is non-numeric
+ * (e.g. "ward {X}" or "ward — pay 2 life"). When the keyword appears multiple
+ * times with different numeric arguments, the maximum is returned.
+ *
+ * Both `{N}` (mana-brace integer) and bare `N` arguments are recognized.
+ */
+export function extractKeywordParameter(
+  text: string,
+  keyword: string,
+): number | null {
+  if (!text || !keyword) return null;
+  const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`\\b${escaped}\\b\\s*\\{?(\\d+)\\}?`, "gi");
+  let max: number | null = null;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const n = parseInt(match[1], 10);
+    if (!Number.isNaN(n) && (max === null || n > max)) max = n;
+  }
+  return max;
+}

--- a/src/lib/known-combos.ts
+++ b/src/lib/known-combos.ts
@@ -105,6 +105,26 @@ export const KNOWN_COMBOS: KnownCombo[] = [
     type: "value",
   },
 
+  // --- Secrets of Strixhaven (SOS) Combos ---
+  {
+    id: "pensive-professor-lyla",
+    cards: ["Pensive Professor", "Lyla, Holographic Assistant"],
+    description: "Infinite draw: cast a 2+ mana spell to put a +1/+1 counter on Pensive Professor (Increment), Pensive's draw trigger fires, Lyla puts another counter on Pensive when you draw, loop with any further draw or counter source",
+    type: "infinite",
+  },
+  {
+    id: "witherbloom-balancer-sprout-swarm",
+    cards: ["Witherbloom, the Balancer", "Sprout Swarm"],
+    description: "Infinite saproling tokens: Sprout Swarm's convoke pays for itself with the saproling tokens it creates; Witherbloom's affinity-for-creatures discount on instants/sorceries makes the loop net-positive",
+    type: "infinite",
+  },
+  {
+    id: "rootha-breath-of-fury",
+    cards: ["Rootha, Mastering the Moment", "Breath of Fury"],
+    description: "Infinite combats and damage: with a third creature, cast an instant/sorcery to make Rootha's flying Elemental token, attach Breath of Fury, deal damage and take additional combat steps repeatedly",
+    type: "infinite",
+  },
+
   // --- Artifact Combos ---
   {
     id: "basalt-rings",

--- a/src/lib/synergy-axes.ts
+++ b/src/lib/synergy-axes.ts
@@ -1,5 +1,6 @@
 import type { EnrichedCard } from "./types";
 import { CREATURE_TYPE_PATTERN } from "./creature-types";
+import { extractKeywordParameter } from "./keyword-parameters";
 
 export interface SynergyAxisDefinition {
   id: string;
@@ -16,6 +17,8 @@ const COUNTER_DOUBLER_RE = /twice that many.+?counter/i;
 const COUNTER_PROLIFERATE_RE = /\bproliferate\b/i;
 const COUNTER_CHARGE_RE = /charge counter/i;
 const COUNTER_MODULAR_RE = /\bmodular\b/i;
+// Quandrix keyword — every cast is a potential +1/+1 counter trigger.
+const COUNTER_INCREMENT_RE = /\bincrement\b/i;
 
 // --- Tokens ---
 const TOKEN_CREATE_RE = /\bcreate\b.+?\btoken/i;
@@ -95,6 +98,9 @@ const SPELL_COST_REDUCE_RE =
   /(?:instant|sorcery).+?(?:spells? you cast )?cost.+?less/i;
 const SPELL_COPY_RE = /\bcopy.+?(?:instant|sorcery|spell)\b/i;
 const SPELL_MAGECRAFT_RE = /\bmagecraft\b/i;
+// SOS ability words that trigger on instant/sorcery casts.
+const SPELL_OPUS_RE = /\bopus\s*(?:—|-)/i;
+const SPELL_REPARTEE_RE = /\brepartee\s*(?:—|-)/i;
 
 // --- Artifacts ---
 const ARTIFACT_TRIGGER_RE = /whenever.+?artifact.+?enters the battlefield/i;
@@ -115,6 +121,8 @@ const ENCHANTMENT_KEYWORDS = new Set(["Constellation"]);
 const LIFEGAIN_TRIGGER_RE = /whenever you gain life/i;
 const LIFEGAIN_PAYOFF_RE = /\byou gain.+?\blife\b/i;
 const LIFEGAIN_KEYWORDS = new Set(["Lifelink"]);
+// Witherbloom ability word — triggers care if you gained life this turn.
+const LIFEGAIN_INFUSION_RE = /\binfusion\s*(?:—|-)/i;
 
 // --- Discard ---
 const DISCARD_PAYOFF_RE = /\bwhenever[^.]*discards?\b/i;
@@ -237,6 +245,8 @@ export const SYNERGY_AXES: SynergyAxisDefinition[] = [
       if (COUNTER_CHARGE_RE.test(text)) score += 0.3;
       if (COUNTER_MODULAR_RE.test(text) || card.keywords.includes("Modular"))
         score += 0.4;
+      if (card.keywords.includes("Increment") || COUNTER_INCREMENT_RE.test(text))
+        score += 0.5;
       return Math.min(score, 1);
     },
     conflictsWith: [],
@@ -369,6 +379,11 @@ export const SYNERGY_AXES: SynergyAxisDefinition[] = [
       if (SPELL_COPY_RE.test(text)) score += 0.5;
       if (SPELL_MAGECRAFT_RE.test(text) || card.keywords.includes("Magecraft"))
         score += 0.6;
+      // SOS: Opus and Repartee trigger on instant/sorcery casts (parity with Magecraft).
+      if (SPELL_OPUS_RE.test(text) || card.keywords.includes("Opus"))
+        score += 0.6;
+      if (SPELL_REPARTEE_RE.test(text) || card.keywords.includes("Repartee"))
+        score += 0.6;
       return Math.min(score, 1);
     },
     conflictsWith: [],
@@ -418,6 +433,9 @@ export const SYNERGY_AXES: SynergyAxisDefinition[] = [
       if (LIFEGAIN_TRIGGER_RE.test(text)) score += 0.8;
       if (card.keywords.some((kw) => LIFEGAIN_KEYWORDS.has(kw))) score += 0.4;
       if (LIFEGAIN_PAYOFF_RE.test(text)) score += 0.3;
+      // SOS: Infusion ability word — abilities that care if you gained life this turn.
+      if (LIFEGAIN_INFUSION_RE.test(text) || card.keywords.includes("Infusion"))
+        score += 0.5;
       return Math.min(score, 1);
     },
     conflictsWith: [],
@@ -467,7 +485,11 @@ export const SYNERGY_AXES: SynergyAxisDefinition[] = [
       if (DISCARD_COST_RE.test(text)) score += 0.3;
       if (DISCARD_UNLESS_RE.test(text)) score += 0.6;
       if (card.keywords.includes("Madness")) score += 0.4;
-      if (card.keywords.includes("Connive")) score += 0.3;
+      if (card.keywords.includes("Connive")) {
+        // Scale by N: Connive 1 → 0.3, Connive 2 → 0.4, Connive 3+ → 0.5.
+        const n = extractKeywordParameter(text, "connive") ?? 1;
+        score += 0.3 + Math.min(Math.max(n - 1, 0), 2) * 0.1;
+      }
       if (card.keywords.includes("Cycling")) score += 0.3;
       return Math.min(score, 1);
     },

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2144,3 +2144,151 @@ test.describe("generateTags — Discard negative cases", () => {
     expect(tags).not.toContain("Discard Payoff");
   });
 });
+
+test.describe("generateTags — Secrets of Strixhaven mechanics", () => {
+  test("Lesson subtype → Lesson tag", () => {
+    const card = makeCard({
+      name: "Decorum Dissertation",
+      typeLine: "Sorcery — Lesson",
+      subtypes: ["Lesson"],
+      oracleText: "Target player draws two cards and loses 2 life.",
+    });
+    expect(generateTags(card)).toContain("Lesson");
+  });
+
+  test("Paradigm keyword → Paradigm tag", () => {
+    const card = makeCard({
+      name: "Restoration Seminar",
+      typeLine: "Sorcery — Lesson",
+      subtypes: ["Lesson"],
+      oracleText:
+        "Return target nonland permanent card from your graveyard to the battlefield.\nParadigm (Then exile this spell. After you first resolve a spell with this name, you may cast a copy of it from exile without paying its mana cost at the beginning of each of your first main phases.)",
+      keywords: ["Paradigm"],
+    });
+    const tags = generateTags(card);
+    expect(tags).toContain("Paradigm");
+    expect(tags).toContain("Lesson");
+  });
+
+  test("Paradigm via oracle text only (no keyword) → Paradigm tag", () => {
+    const card = makeCard({
+      typeLine: "Sorcery",
+      oracleText: "Draw two cards.\nParadigm (...)",
+    });
+    expect(generateTags(card)).toContain("Paradigm");
+  });
+
+  test("Opus ability word → Opus tag", () => {
+    const card = makeCard({
+      name: "Expressive Firedancer",
+      typeLine: "Creature — Human Wizard",
+      oracleText:
+        "Opus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn. If five or more mana was spent to cast that spell, this creature also gains double strike until end of turn.",
+      keywords: ["Opus"],
+    });
+    expect(generateTags(card)).toContain("Opus");
+  });
+
+  test("Opus via em-dash without keyword array → Opus tag", () => {
+    const card = makeCard({
+      typeLine: "Creature",
+      oracleText: "Opus — Whenever you cast an instant or sorcery spell, draw a card.",
+    });
+    expect(generateTags(card)).toContain("Opus");
+  });
+
+  test("Repartee ability word → Repartee tag", () => {
+    const card = makeCard({
+      name: "Silverquill Duelist",
+      typeLine: "Creature — Human Wizard",
+      oracleText:
+        "Repartee — Whenever you cast an instant or sorcery spell that targets a creature, put a +1/+1 counter on this creature.",
+      keywords: ["Repartee"],
+    });
+    expect(generateTags(card)).toContain("Repartee");
+  });
+
+  test("Infusion ability word → Infusion tag", () => {
+    const card = makeCard({
+      name: "Old-Growth Educator",
+      typeLine: "Creature — Treefolk Druid",
+      oracleText:
+        "Infusion — When this creature enters, put two +1/+1 counters on it if you gained life this turn.",
+      keywords: ["Infusion"],
+    });
+    expect(generateTags(card)).toContain("Infusion");
+  });
+
+  test("Increment keyword → Increment tag", () => {
+    const card = makeCard({
+      name: "Ambitious Augmenter",
+      typeLine: "Creature — Fractal",
+      oracleText:
+        "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)",
+      keywords: ["Increment"],
+    });
+    expect(generateTags(card)).toContain("Increment");
+  });
+
+  test("Prepare two-frame card → Prepare tag", () => {
+    const card = makeCard({
+      name: "Diligent Apprentice",
+      typeLine: "Creature — Human Student",
+      oracleText:
+        "When this creature enters, it becomes prepared.\nWhile this creature is prepared, you may cast a copy of its prepare spell from exile.",
+    });
+    expect(generateTags(card)).toContain("Prepare");
+  });
+
+  test("Book artifact subtype → Book tag", () => {
+    const card = makeCard({
+      name: "Codex of Forgotten Lore",
+      typeLine: "Artifact — Book",
+      subtypes: ["Book"],
+      oracleText: "{2}, {T}: Draw a card.",
+    });
+    expect(generateTags(card)).toContain("Book");
+  });
+
+  test("Converge keyword → Converge tag", () => {
+    const card = makeCard({
+      name: "Strixhaven Convergence",
+      typeLine: "Sorcery",
+      oracleText:
+        "Converge — Draw X cards, where X is the number of colors of mana spent to cast this spell.",
+      keywords: ["Converge"],
+    });
+    expect(generateTags(card)).toContain("Converge");
+  });
+
+  test("vanilla creature → no SOS tags", () => {
+    const card = makeCard({
+      name: "Grizzly Bears",
+      typeLine: "Creature — Bear",
+      oracleText: "",
+    });
+    const tags = generateTags(card);
+    expect(tags).not.toContain("Lesson");
+    expect(tags).not.toContain("Paradigm");
+    expect(tags).not.toContain("Opus");
+    expect(tags).not.toContain("Repartee");
+    expect(tags).not.toContain("Infusion");
+    expect(tags).not.toContain("Increment");
+    expect(tags).not.toContain("Prepare");
+    expect(tags).not.toContain("Book");
+    expect(tags).not.toContain("Converge");
+  });
+
+  test("Lightning Bolt (instant, no SOS keyword) → no SOS tags", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    const tags = generateTags(card);
+    expect(tags).not.toContain("Opus");
+    expect(tags).not.toContain("Repartee");
+    expect(tags).not.toContain("Infusion");
+    expect(tags).not.toContain("Increment");
+  });
+});

--- a/tests/unit/keyword-parameters.spec.ts
+++ b/tests/unit/keyword-parameters.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from "@playwright/test";
+import { extractKeywordParameter } from "../../src/lib/keyword-parameters";
+
+test.describe("extractKeywordParameter", () => {
+  test("returns N for bare integer argument (Ward 2)", () => {
+    expect(extractKeywordParameter("Flying, ward 2", "ward")).toBe(2);
+  });
+
+  test("returns N for mana-brace argument (Ward {3})", () => {
+    expect(
+      extractKeywordParameter("Flying, ward {3} (...)", "ward"),
+    ).toBe(3);
+  });
+
+  test("matches case-insensitively", () => {
+    expect(extractKeywordParameter("WARD 4", "ward")).toBe(4);
+    expect(extractKeywordParameter("ward 4", "WARD")).toBe(4);
+  });
+
+  test("works for Connive N", () => {
+    expect(
+      extractKeywordParameter(
+        "When this creature enters, connive 2.",
+        "connive",
+      ),
+    ).toBe(2);
+  });
+
+  test("works for Casualty N", () => {
+    expect(
+      extractKeywordParameter("Casualty 3 (...)", "casualty"),
+    ).toBe(3);
+  });
+
+  test("returns null when keyword is absent", () => {
+    expect(extractKeywordParameter("Flying, trample", "ward")).toBeNull();
+  });
+
+  test("returns null for non-numeric arguments (Ward {X})", () => {
+    expect(extractKeywordParameter("Ward {X}", "ward")).toBeNull();
+  });
+
+  test("returns null for life-payment ward (Ward — Pay 2 life)", () => {
+    // Ward followed by an em-dash (sentence form) — no integer to extract.
+    expect(
+      extractKeywordParameter("Ward — Pay 2 life.", "ward"),
+    ).toBeNull();
+  });
+
+  test("returns the max when keyword appears multiple times", () => {
+    // Hypothetical card with two ward instances (modal/face).
+    expect(
+      extractKeywordParameter("Ward 1. // Ward 3.", "ward"),
+    ).toBe(3);
+  });
+
+  test("returns null for empty inputs", () => {
+    expect(extractKeywordParameter("", "ward")).toBeNull();
+    expect(extractKeywordParameter("Ward 2", "")).toBeNull();
+  });
+
+  test("does not match keyword as substring of another word", () => {
+    // "rewardful" should not match "reward".
+    expect(
+      extractKeywordParameter("Rewardful enchantment 2", "reward"),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/known-combos.spec.ts
+++ b/tests/unit/known-combos.spec.ts
@@ -180,4 +180,42 @@ test.describe("findCombosInDeck", () => {
     // Panharmonicon+Sharuum, Sharuum+Closet, Skullclamp+KCI, Clock+Unwinding
     expect(found.length).toBeGreaterThanOrEqual(6);
   });
+
+  test("finds Pensive Professor + Lyla, Holographic Assistant infinite-draw combo", () => {
+    const cardNames = ["Pensive Professor", "Lyla, Holographic Assistant"];
+    const found = findCombosInDeck(cardNames);
+    const combo = found.find((c) => c.id === "pensive-professor-lyla");
+    expect(combo).toBeDefined();
+    expect(combo!.type).toBe("infinite");
+  });
+
+  test("does NOT find Pensive Professor + Lyla combo when Lyla is missing", () => {
+    const cardNames = ["Pensive Professor", "Lightning Bolt"];
+    const found = findCombosInDeck(cardNames);
+    const combo = found.find((c) => c.id === "pensive-professor-lyla");
+    expect(combo).toBeUndefined();
+  });
+
+  test("finds Witherbloom, the Balancer + Sprout Swarm infinite-token combo", () => {
+    const cardNames = ["Witherbloom, the Balancer", "Sprout Swarm"];
+    const found = findCombosInDeck(cardNames);
+    const combo = found.find((c) => c.id === "witherbloom-balancer-sprout-swarm");
+    expect(combo).toBeDefined();
+    expect(combo!.type).toBe("infinite");
+  });
+
+  test("finds Rootha, Mastering the Moment + Breath of Fury infinite-combat combo", () => {
+    const cardNames = ["Rootha, Mastering the Moment", "Breath of Fury"];
+    const found = findCombosInDeck(cardNames);
+    const combo = found.find((c) => c.id === "rootha-breath-of-fury");
+    expect(combo).toBeDefined();
+    expect(combo!.type).toBe("infinite");
+  });
+
+  test("does NOT find Rootha + Breath of Fury when Breath of Fury is missing", () => {
+    const cardNames = ["Rootha, Mastering the Moment", "Lightning Bolt"];
+    const found = findCombosInDeck(cardNames);
+    const combo = found.find((c) => c.id === "rootha-breath-of-fury");
+    expect(combo).toBeUndefined();
+  });
 });

--- a/tests/unit/synergy-axes.spec.ts
+++ b/tests/unit/synergy-axes.spec.ts
@@ -1080,3 +1080,85 @@ test.describe("Discard axis", () => {
     expect(axis.detect(card)).toBeGreaterThan(0);
   });
 });
+
+test.describe("Secrets of Strixhaven axis updates", () => {
+  test("Opus ability word boosts Spellslinger axis", () => {
+    const axis = getAxisById("spellslinger")!;
+    const card = mockCard({
+      name: "Expressive Firedancer",
+      oracleText:
+        "Opus — Whenever you cast an instant or sorcery spell, this creature gets +1/+1 until end of turn.",
+      keywords: ["Opus"],
+    });
+    expect(axis.detect(card)).toBeGreaterThan(0.4);
+  });
+
+  test("Repartee ability word boosts Spellslinger axis", () => {
+    const axis = getAxisById("spellslinger")!;
+    const card = mockCard({
+      name: "Silverquill Duelist",
+      oracleText:
+        "Repartee — Whenever you cast an instant or sorcery spell that targets a creature, put a +1/+1 counter on this creature.",
+      keywords: ["Repartee"],
+    });
+    expect(axis.detect(card)).toBeGreaterThan(0.4);
+  });
+
+  test("Infusion ability word boosts Lifegain axis", () => {
+    const axis = getAxisById("lifegain")!;
+    const card = mockCard({
+      name: "Old-Growth Educator",
+      oracleText:
+        "Infusion — When this creature enters, put two +1/+1 counters on it if you gained life this turn.",
+      keywords: ["Infusion"],
+    });
+    expect(axis.detect(card)).toBeGreaterThan(0.4);
+  });
+
+  test("Increment keyword boosts Counters axis", () => {
+    const axis = getAxisById("counters")!;
+    const card = mockCard({
+      name: "Ambitious Augmenter",
+      oracleText:
+        "Increment (Whenever you cast a spell, if the amount of mana you spent is greater than this creature's power or toughness, put a +1/+1 counter on this creature.)",
+      keywords: ["Increment"],
+    });
+    expect(axis.detect(card)).toBeGreaterThan(0.4);
+  });
+
+  test("Connive 3 yields a higher Discard score than Connive 1", () => {
+    const axis = getAxisById("discard")!;
+    const conniveOne = mockCard({
+      name: "Cheap Conniver",
+      oracleText: "When this creature enters, connive 1.",
+      keywords: ["Connive"],
+    });
+    const conniveThree = mockCard({
+      name: "Mighty Conniver",
+      oracleText: "When this creature enters, connive 3.",
+      keywords: ["Connive"],
+    });
+    expect(axis.detect(conniveThree)).toBeGreaterThan(axis.detect(conniveOne));
+  });
+
+  test("Connive without numeric parameter still scores baseline", () => {
+    const axis = getAxisById("discard")!;
+    const card = mockCard({
+      name: "Vintage Conniver",
+      oracleText: "Connive.",
+      keywords: ["Connive"],
+    });
+    expect(axis.detect(card)).toBeGreaterThan(0);
+  });
+
+  test("Vanilla creature still scores 0 on Spellslinger / Lifegain / Counters", () => {
+    const vanilla = mockCard({
+      name: "Grizzly Bears",
+      typeLine: "Creature — Bear",
+      oracleText: "",
+    });
+    expect(getAxisById("spellslinger")!.detect(vanilla)).toBe(0);
+    expect(getAxisById("lifegain")!.detect(vanilla)).toBe(0);
+    expect(getAxisById("counters")!.detect(vanilla)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for Secrets of Strixhaven (SOS) mechanics across card tagging, synergy axis detection, and known combos. It introduces a new utility function for extracting numeric keyword parameters and integrates nine new SOS-specific mechanics into the card analysis system.

## Key Changes

### Card Tags (`src/lib/card-tags.ts`)
- Added nine new SOS mechanic tags with distinct color schemes: Lesson, Paradigm, Opus, Repartee, Infusion, Increment, Prepare, Book, and Converge
- Implemented regex patterns to detect ability words (Opus, Repartee, Infusion) using em-dash or hyphen separators
- Added detection for keyword-based mechanics (Paradigm, Increment, Converge) with fallback oracle text parsing
- Implemented subtype-based detection for Lesson and Book artifacts
- Added Prepare detection via frame-specific text patterns ("becomes prepared", "is prepared")

### Synergy Axes (`src/lib/synergy-axes.ts`)
- **Counters axis**: Added Increment keyword detection (+0.5 score boost)
- **Spellslinger axis**: Added Opus and Repartee ability word detection (+0.6 score boost each, parity with Magecraft)
- **Lifegain axis**: Added Infusion ability word detection (+0.5 score boost)
- **Discard axis**: Implemented numeric parameter extraction for Connive to scale scores based on card draw quantity

### Keyword Parameters (`src/lib/keyword-parameters.ts` - new file)
- Created `extractKeywordParameter()` utility function to parse numeric arguments from parameterized keywords
- Supports both bare integers (e.g., "Ward 2") and mana-brace notation (e.g., "Ward {3}")
- Case-insensitive matching with word-boundary enforcement
- Returns maximum value when keyword appears multiple times
- Used by Discard axis to differentiate Connive N scoring

### Known Combos (`src/lib/known-combos.ts`)
- Added three new SOS-specific infinite combos:
  - Pensive Professor + Lyla, Holographic Assistant (infinite draw via Increment)
  - Witherbloom, the Balancer + Sprout Swarm (infinite tokens via convoke/affinity)
  - Rootha, Mastering the Moment + Breath of Fury (infinite combats)

### Tests
- Added 13 comprehensive unit tests for SOS card tag detection (positive and negative cases)
- Added 8 synergy axis tests validating score boosts for SOS mechanics
- Added 4 known combo detection tests
- Added 11 unit tests for the new `extractKeywordParameter()` function

https://claude.ai/code/session_01MFWDFb6k3oEQGWcjUH6VYc