### PR TITLE
feat(design-system): add Astral tokens and foundation

### DIFF
--- a/design-system/CLAUDE.md
+++ b/design-system/CLAUDE.md
@@ -1,0 +1,126 @@
+# CLAUDE.md — Astral handoff
+
+You are picking up Astral, a cosmic deck-reading app, and rebuilding it as a
+production Next.js application. This file tells you what to build, what to
+match, and what to ignore.
+
+## Source material
+
+| Path | What it is | Use as |
+|---|---|---|
+| `Astral - Journey v2.html`     | The HTML prototype (live, interactive) | **Reference for behavior + flow** |
+| `app/*.jsx`                    | Prototype React (Babel inline)         | Reference for component anatomy |
+| `app/data.js`                  | Mock deck data                         | Sample fixtures for Storybook |
+| `design-system/tokens.css`     | Canonical tokens                       | **Import into Next.js layout** |
+| `design-system/tokens.json`    | Same tokens, JSON                      | Tailwind config / native export |
+| `design-system/preview.html`   | Visual reference                       | Compare your build against this |
+| `design-system/README.md`      | Component specs + patterns             | **Read this first** |
+
+## Stack
+
+- **Next.js 14+** with App Router
+- **TypeScript** strict
+- **Tailwind** (optional — CSS variables alone are sufficient; pick what fits)
+- **No CSS-in-JS runtime** — variables + Tailwind, or CSS Modules
+- **React 19** when stable, 18 otherwise
+
+## Build order
+
+1. **Foundations**
+   - Drop `tokens.css` into `app/styles/tokens.css`, import in `app/layout.tsx`.
+   - Set up Inter, Spectral, JetBrains Mono via `next/font/google`. Map to
+     `--font-sans`, `--font-serif`, `--font-mono` (override what's in tokens.css).
+   - Base body styles: bg `--bg-base`, color `--ink-primary`, font sans 13.
+
+2. **Cosmos shell**
+   - Build the fixed background (3 radial gradients + twinkling SVG stars).
+   - Build the top nav (brand mark + tabs + right meta) — see `app/styles.css` lines 70–93.
+   - Build the responsive viewport router (desktop ≥ 768, mobile < 768).
+
+3. **Primitives** (`components/ui/`)
+   - `<Button>` — variants per spec
+   - `<Input>` / `<Textarea>`
+   - `<Card>` / `<Panel>`
+   - `<Tag>` / `<CardTag>` (tag with role-mapped color)
+   - `<Eyebrow>` — convenience for the mono uppercase pattern
+   - `<StatTile>` — mono label + big serif number
+   - `<Sheet>` — bottom drawer (mobile primary, desktop modal fallback)
+
+4. **Domain components** (`components/deck/`)
+   - `<ManaCost>` — render ["2","U","G"] as colored pips. Use `--mana-*` tokens.
+   - `<ColorPie>` — SVG donut for color distribution
+   - `<CurveConstellation>` — mana-curve viz (planet-sized circles per CMC)
+   - `<CardRow>` — list row · qty · name · cost · tag · price
+   - `<DeckHero>` — hero verdict block (eyebrow + title + tagline + power dial)
+
+5. **Screens** (`app/(routes)/`)
+   - `/` → import (paste / URL tabs)
+   - `/loading` → loader animation (~12s simulated)
+   - `/reading` → overview (the deck verdict)
+   - `/reading/cards` → full card list
+   - `/reading/goldfish` → simulation results
+   - `/reading/suggestions` → cut/add/swap recommendations
+   - `/reading/add` → candidate finder
+   - `/reading/compare` → A vs B
+   - `/reading/share` → share card
+
+   Mobile uses the same routes — responsive layouts collapse the desktop
+   side-by-side panels into single-column with a bottom sheet pattern.
+
+## Strict requirements
+
+- **Use semantic tokens, never raw values.** `var(--accent)`, not `#a78bfa`.
+  If you need a new value, add a raw scale step in `tokens.css` first, then
+  expose a semantic alias.
+- **No emoji as iconography.** The prototype uses Unicode glyphs (◯ ▤ ↳) as
+  placeholders. Replace with a real icon set (Lucide is fine) at build time.
+- **No new fonts.** Spectral / Inter / JetBrains Mono only.
+- **The eyebrow pattern is sacred.** Every section starts with a mono
+  uppercase 0.22em-tracked label in `--accent`. Don't skip it.
+- **Honor `prefers-reduced-motion`** — already wired in `tokens.css`.
+- **Mobile-first responsive** — design works at 375 wide. Don't ship anything
+  that breaks below 360.
+
+## Where the prototype takes shortcuts (you must fix)
+
+- **Hard-coded mock data** in `app/data.js`. Replace with a fixture loader and
+  a typed schema. Ultimately the deck source comes from a paste-parser or
+  Moxfield/Archidekt API.
+- **Placeholder card art** (diagonal stripe pattern). Wire to Scryfall image API
+  or a CDN; cache aggressively.
+- **No goldfish engine.** The simulation numbers are static. Build (or wire) the
+  real Monte Carlo simulator — that's a separate workstream.
+- **Tweaks panel** is a prototype-only artifact. Strip it from production.
+- **Inline styles everywhere.** The prototype uses inline styles for speed of
+  iteration. Move to Tailwind classes or CSS Modules in the production build.
+- **No accessibility audit yet.** Ensure: focus rings on every interactive,
+  ARIA labels on icon buttons, semantic landmark elements, color contrast ≥4.5.
+
+## What "done" looks like
+
+- `pnpm dev` boots, loads, every route navigates, every screen renders with
+  real data shape.
+- `pnpm test` passes — at minimum: token import smoke, primitive snapshot tests.
+- Storybook (or `/preview` route) renders every primitive in every state.
+- Lighthouse mobile ≥ 90 for Performance, Accessibility, Best Practices.
+- `prefers-reduced-motion` actually disables the cosmos animation.
+- Light theme stub'd but not active (`data-theme="light"` does nothing yet —
+  that's expected; it's TODO).
+
+## Out of scope for v1
+
+- Light theme (placeholder only)
+- Real auth / user accounts
+- Server-side simulation engine
+- Mobile native apps (web-responsive only)
+- Compare flow (it's wireframed but the diff engine isn't real)
+
+## Questions to ask before starting
+
+- Is there an existing Astral codebase, or is this greenfield?
+- Goldfish engine — wrap an existing tool, or build from scratch?
+- Auth / persistence — Supabase, Clerk, or none yet?
+- Does the team have a preferred icon set?
+- Tailwind or vanilla CSS?
+
+If unsure, default to: **greenfield · Lucide icons · Tailwind + CSS vars · no auth v1**.

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,192 @@
+# Astral · Design System
+
+> Cosmic deck-reading app. Dark, editorial, mono-eyebrows, gradient accents.
+
+This package defines the visual language for Astral. It is **definition only** —
+adopting it requires wiring `tokens.css` into your app and replacing hard-coded
+values with semantic tokens.
+
+## What's in here
+
+| File | Purpose |
+|---|---|
+| `tokens.css`     | Source of truth · CSS variables (raw scale + semantic aliases) |
+| `tokens.json`    | DTCG-style · for Tailwind / Style Dictionary / native |
+| `preview.html`   | Visual reference · every token + every component, all states |
+| `components/`    | JSX reference implementations (Button, Card, Tag, Input, Sheet, StatTile) |
+| `CLAUDE.md`      | Handoff brief — read this if you're Claude Code |
+
+## Foundations
+
+### Color
+Two layers:
+- **Raw scale** — `--violet-400`, `--ink-200`, `--space-8`. Pure values.
+- **Semantic** — `--accent`, `--ink-primary`, `--surface-1`. What components use.
+
+Always reference **semantic tokens** in components. Raw scales exist so a future
+brand variant or light theme can remap without touching component code.
+
+Brand spine: **violet 400 → aura 400** as a 135° gradient. Used only on primary
+CTAs, hero score numbers, and one-off accent moments. Don't gradient-bomb the UI.
+
+Status: `--status-ok` (green), `--status-watch` (amber), `--status-warn` (rose).
+Each has a soft fill (`-soft` suffix) at 10% opacity for filled badges.
+
+### Type
+- **Spectral** (serif) — display, page titles, hero numbers, italic pull-quotes
+- **Inter** (sans) — body, UI, buttons
+- **JetBrains Mono** — eyebrows, stat labels, prices, codes
+
+The eyebrow pattern: `font-mono · 10px · uppercase · 0.22em tracked · accent color`. It
+appears above almost every section. Don't skip it.
+
+### Space
+8-step soft scale — 2, 4, 6, 8, 10, 12, 14, 16, 20, 24, 28, 32, 40, 48, 64.
+Padding inside cards: 24. Sheet padding: 18 (mobile) / 24 (desktop).
+
+### Radius
+- 6/8 — buttons, inputs
+- 12/14 — cards, panels
+- 18 — sheets, hero cards
+- 999 — chips, tags, pills
+
+### Motion
+- Default ease: `--ease-out` (`cubic-bezier(0.2, 0.8, 0.2, 1)`)
+- Default duration: `--dur-base` (180ms)
+- Reveal entrance: `--dur-reveal` (600ms) on first paint, then never again
+- Bottom sheets: 280ms, ease-out
+- Honors `prefers-reduced-motion`
+
+## Components
+
+Each component below is specified as: **anatomy → states → reference impl** in
+`components/`. The reference is JSX with inline styles using semantic tokens.
+
+### Button
+**Variants:** `primary` · `secondary` · `ghost` · `icon`
+**States:** default, hover, focus-visible, active, disabled
+**Sizes:** sm (32h), md (40h), lg (48h)
+
+- Primary: gradient bg, `--ink-on-accent` text, glow on hover (`--glow-md`)
+- Secondary: `--surface-2` bg, `--border` outline, ink-primary
+- Ghost: transparent, accent text, no chrome
+- Icon: 32×32 square, secondary chrome, accent on hover
+
+### Input (text + textarea)
+**States:** default, focus, filled, error, disabled
+- Bg `--input-bg` (rgba black 0.40), 1px `--input-border`, radius `--input-radius`
+- Mono font for code-like content (deck lists, URLs)
+
+### Card / Panel
+**Variants:** `surface-1` (default) · `accent-soft` (highlighted) · `outline`
+**Anatomy:** optional eyebrow → optional title → content → optional footer
+**Padding:** 24 desktop / 18 mobile
+**Border:** 1px `--border` (or `--border-accent` for `accent-soft`)
+**Backdrop:** `blur(8px)` if floating over cosmos bg
+
+### Tag / Chip
+**Variants:** by status — `accent` · `cyan` · `gold` · `ok` · `warn` · `ghost`
+- Mono · 10px · 0.10em tracked · uppercase
+- Pill radius
+- Soft bg + 40% border in same hue
+
+Special: `<CardTag>` for deck roles (RAMP/DRAW/REMOVAL/WINCON/ENGINE/COMMANDER) —
+maps role to color via fixed lookup.
+
+### Sheet (bottom drawer, mobile)
+**Anatomy:** scrim → grabber → header (icon + title + close) → content → actions
+- Scrim `--surface-scrim`, blur 8px, fade 180ms
+- Sheet slides up 280ms `--ease-out`
+- Top corners `--sheet-radius` (18), bottom flush
+- Max-height 80vh, content scrolls
+
+### StatTile
+A repeated unit across overview / goldfish / share screens.
+**Anatomy:** mono label (eyebrow style) → big serif number → optional sub
+**Size:** number is `--text-h2` (28) or larger; label is `--text-caption` (9)
+**Bg:** `--surface-2` with `--border` outline, radius `--radius-xl`
+
+## Patterns (composition)
+
+These aren't components — they're recipes the app uses repeatedly.
+
+- **Eyebrow + serif title + italic tagline** — top of every screen.
+  ```
+  <Eyebrow>READING · 04.27.26</Eyebrow>
+  <h1 className="serif">Slogurk, the Overslime</h1>
+  <p className="serif italic">"A landfall engine that wins decisively."</p>
+  ```
+
+- **Cosmos background** — one fixed layer, `position: fixed; inset: 0; z-index: 0`,
+  with three radial gradients (violet TL, aura BR, cyan center) and twinkling stars.
+  Sits behind everything. Don't repeat per-screen.
+
+- **Reveal-on-mount** — all top-level sections fade in + 8px translate over 600ms,
+  staggered 60–80ms. Done once per route, not on re-renders.
+
+## Next.js usage
+
+```tsx
+// app/layout.tsx
+import "@/design-system/tokens.css";
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en" data-theme="dark">
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+```tsx
+// component example — semantic tokens only
+<button
+  style={{
+    background: "var(--accent-gradient)",
+    color: "var(--ink-on-accent)",
+    padding: "var(--space-5) var(--space-10)",
+    borderRadius: "var(--btn-radius)",
+    fontWeight: "var(--weight-semibold)",
+  }}
+>
+  Read this deck
+</button>
+```
+
+### With Tailwind
+Wire the JSON into `tailwind.config.ts` via Style Dictionary or import directly:
+
+```ts
+import tokens from "./design-system/tokens.json";
+
+export default {
+  theme: {
+    extend: {
+      colors: {
+        accent: "var(--accent)",
+        ink: { 1: "var(--ink-primary)", 2: "var(--ink-secondary)" },
+      },
+      fontFamily: {
+        serif: tokens.typography.font.serif.value.split(", "),
+        sans:  tokens.typography.font.sans.value.split(", "),
+        mono:  tokens.typography.font.mono.value.split(", "),
+      },
+    },
+  },
+};
+```
+
+## Don'ts
+- **No new colors.** If you need one, add a raw scale step first, then map it.
+- **No drop-shadow on the cosmos bg.** Use `--glow-*` for accent moments only.
+- **No emoji as iconography.** Glyphs only (◯ ▤ ↳ ✦ +) or proper SVG icons.
+- **No more than 2 gradient elements per screen.** Reserve for hero score + 1 CTA.
+- **Don't skip the eyebrow.** Every section needs one — that's the rhythm.
+
+## Roadmap
+- [ ] Light theme (stub'd in `tokens.css` — needs surface remap + shadow rework)
+- [ ] Icon set (currently glyphs as placeholder)
+- [ ] Real Mana SVG (currently CSS pip approximation)
+- [ ] Motion library (currently inline `@keyframes`)
+- [ ] Native iOS / Android token export via Style Dictionary

--- a/design-system/components/primitives.jsx
+++ b/design-system/components/primitives.jsx
@@ -1,0 +1,168 @@
+// Astral · Component reference implementations
+// Pure JSX, semantic tokens via CSS vars. Drop into a Babel-rendered host
+// or copy-port to a Next.js codebase.
+//
+// All components below assume `tokens.css` is loaded.
+
+const { useState } = React;
+
+// ─── Eyebrow ─────────────────────────────────────────────────
+function Eyebrow({ children, color }) {
+  return <div style={{
+    fontFamily: 'var(--font-mono)', fontSize: 'var(--text-eyebrow)',
+    letterSpacing: 'var(--tracking-eyebrow)', textTransform: 'uppercase',
+    color: color || 'var(--accent)', fontWeight: 'var(--weight-medium)',
+  }}>{children}</div>;
+}
+
+// ─── Button ──────────────────────────────────────────────────
+function DSButton({ variant = 'primary', size = 'md', disabled, children, onClick }) {
+  const sizes = {
+    sm: { padding: '6px 12px',  fontSize: 12, height: 32 },
+    md: { padding: '10px 20px', fontSize: 13, height: 40 },
+    lg: { padding: '14px 24px', fontSize: 14, height: 48 },
+  }[size];
+  const variants = {
+    primary: {
+      background: 'var(--accent-gradient)',
+      color: 'var(--ink-on-accent)', border: 'none',
+      boxShadow: 'var(--shadow-sm)',
+    },
+    secondary: {
+      background: 'var(--surface-2)', color: 'var(--ink-primary)',
+      border: '1px solid var(--border)',
+    },
+    ghost: {
+      background: 'transparent', color: 'var(--accent)', border: 'none',
+    },
+    danger: {
+      background: 'var(--status-warn-soft)',
+      border: '1px solid rgba(255,134,160,0.3)',
+      color: 'var(--status-warn)',
+    },
+  }[variant];
+  return (
+    <button onClick={onClick} disabled={disabled} style={{
+      ...sizes, ...variants,
+      borderRadius: 'var(--btn-radius)',
+      fontFamily: 'var(--font-sans)', fontWeight: 'var(--weight-semibold)',
+      cursor: disabled ? 'not-allowed' : 'pointer',
+      opacity: disabled ? 0.4 : 1,
+      transition: 'all var(--dur-base) var(--ease-out)',
+      display: 'inline-flex', alignItems: 'center', gap: 8,
+    }}>{children}</button>
+  );
+}
+
+// ─── Input ───────────────────────────────────────────────────
+function DSInput({ value, onChange, placeholder, mono = false, error }) {
+  const [focus, setFocus] = useState(false);
+  return (
+    <input
+      value={value} onChange={e => onChange?.(e.target.value)}
+      onFocus={() => setFocus(true)} onBlur={() => setFocus(false)}
+      placeholder={placeholder}
+      style={{
+        width: '100%', padding: 'var(--input-padding)',
+        background: 'var(--input-bg)',
+        border: '1px solid ' + (error ? 'var(--status-warn)' : focus ? 'var(--accent)' : 'var(--input-border)'),
+        borderRadius: 'var(--input-radius)',
+        fontFamily: mono ? 'var(--font-mono)' : 'var(--font-sans)',
+        fontSize: 'var(--input-font-size)', color: 'var(--ink-primary)',
+        outline: 'none', boxSizing: 'border-box',
+        transition: 'border-color var(--dur-base) var(--ease-out)',
+      }}
+    />
+  );
+}
+
+// ─── Card ────────────────────────────────────────────────────
+function DSCard({ variant = 'surface', eyebrow, title, children, padding }) {
+  const variants = {
+    surface: { background: 'var(--card-bg)', border: '1px solid var(--card-border)' },
+    accent:  { background: 'var(--accent-soft)', border: '1px solid var(--border-accent)' },
+    outline: { background: 'transparent', border: '1px solid var(--border)' },
+  }[variant];
+  return (
+    <div style={{
+      ...variants, padding: padding ?? 'var(--card-padding)',
+      borderRadius: 'var(--card-radius)',
+      backdropFilter: 'blur(var(--blur-sm))',
+    }}>
+      {eyebrow && <Eyebrow>{eyebrow}</Eyebrow>}
+      {title && <h3 className="serif" style={{ fontSize: 'var(--text-h3)', fontWeight: 'var(--weight-medium)', margin: '6px 0 14px' }}>{title}</h3>}
+      {children}
+    </div>
+  );
+}
+
+// ─── Tag ─────────────────────────────────────────────────────
+function DSTag({ variant = 'accent', children }) {
+  const variants = {
+    accent: { bg: 'var(--accent-soft)', bd: 'var(--border-accent)', fg: 'var(--accent)' },
+    cyan:   { bg: 'rgba(136,231,255,0.10)', bd: 'rgba(136,231,255,0.40)', fg: 'var(--cyan-400)' },
+    gold:   { bg: 'rgba(245,214,128,0.10)', bd: 'rgba(245,214,128,0.40)', fg: 'var(--gold-400)' },
+    ok:     { bg: 'var(--status-ok-soft)', bd: 'rgba(134,239,172,0.4)', fg: 'var(--status-ok)' },
+    warn:   { bg: 'var(--status-warn-soft)', bd: 'rgba(255,134,160,0.4)', fg: 'var(--status-warn)' },
+    ghost:  { bg: 'transparent', bd: 'var(--border-hi)', fg: 'var(--ink-tertiary)' },
+  }[variant];
+  return (
+    <span style={{
+      display: 'inline-flex', alignItems: 'center',
+      padding: 'var(--tag-padding-y) var(--tag-padding-x)',
+      borderRadius: 'var(--tag-radius)',
+      fontFamily: 'var(--font-mono)', fontSize: 'var(--tag-font-size)',
+      letterSpacing: 'var(--tag-tracking)', textTransform: 'uppercase',
+      background: variants.bg, border: '1px solid ' + variants.bd, color: variants.fg,
+      whiteSpace: 'nowrap',
+    }}>{children}</span>
+  );
+}
+
+// ─── StatTile ────────────────────────────────────────────────
+function DSStatTile({ label, value, sub, accent }) {
+  return (
+    <div style={{
+      padding: 'var(--space-7)', borderRadius: 'var(--radius-xl)',
+      background: 'var(--surface-2)', border: '1px solid var(--border)',
+    }}>
+      <div style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--text-caption)', letterSpacing: 'var(--tracking-eyebrow)', color: 'var(--ink-tertiary)', textTransform: 'uppercase' }}>{label}</div>
+      <div className="serif" style={{ fontFamily: 'var(--font-serif)', fontSize: 'var(--text-h2)', fontWeight: 'var(--weight-medium)', color: accent ? 'var(--accent)' : 'var(--ink-primary)', marginTop: 4, lineHeight: 1 }}>{value}</div>
+      {sub && <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--ink-tertiary)', marginTop: 4 }}>{sub}</div>}
+    </div>
+  );
+}
+
+// ─── Sheet (bottom drawer) ───────────────────────────────────
+function DSSheet({ open, onClose, title, children }) {
+  if (!open) return null;
+  return (
+    <>
+      <div onClick={onClose} style={{
+        position: 'fixed', inset: 0, background: 'var(--surface-scrim)',
+        backdropFilter: 'blur(var(--blur-sm))', zIndex: 50,
+        animation: 'ds-fadein var(--dur-base) var(--ease-out)',
+      }} />
+      <div style={{
+        position: 'fixed', left: 0, right: 0, bottom: 0, zIndex: 51,
+        padding: '14px 18px 28px',
+        background: 'var(--sheet-bg)',
+        borderTop: '1px solid var(--sheet-border)',
+        borderRadius: 'var(--sheet-radius) var(--sheet-radius) 0 0',
+        boxShadow: 'var(--sheet-shadow)',
+        animation: 'ds-sheet-up var(--dur-slow) var(--ease-out)',
+        maxHeight: '80vh', overflowY: 'auto',
+      }}>
+        <div style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.2)', margin: '0 auto 14px' }} />
+        {title && <h3 className="serif" style={{ fontSize: 'var(--text-h3)', fontWeight: 'var(--weight-medium)', margin: '0 0 12px' }}>{title}</h3>}
+        {children}
+      </div>
+      <style>{`
+        @keyframes ds-fadein { from { opacity: 0; } to { opacity: 1; } }
+        @keyframes ds-sheet-up { from { transform: translateY(100%); } to { transform: translateY(0); } }
+      `}</style>
+    </>
+  );
+}
+
+Object.assign(window, { Eyebrow, DSButton, DSInput, DSCard, DSTag, DSStatTile, DSSheet });

--- a/design-system/preview.html
+++ b/design-system/preview.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Astral · Design System</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Spectral:ital,wght@0,400;0,500;1,400&family=JetBrains+Mono:wght@400;500&display=swap" />
+  <link rel="stylesheet" href="tokens.css" />
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      background: var(--bg-base);
+      color: var(--ink-primary);
+      font-family: var(--font-sans);
+      font-size: var(--text-body);
+      line-height: var(--leading-body);
+      min-height: 100vh;
+    }
+    .cosmos {
+      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      background:
+        radial-gradient(ellipse 60% 50% at 15% 0%, rgba(124,58,237,0.18), transparent 60%),
+        radial-gradient(ellipse 80% 60% at 100% 100%, rgba(240,170,255,0.10), transparent 60%);
+    }
+    main { position: relative; z-index: 1; max-width: 1100px; margin: 0 auto; padding: 48px 32px 96px; }
+    .serif { font-family: var(--font-serif); }
+    .mono { font-family: var(--font-mono); }
+    .eyebrow {
+      font-family: var(--font-mono); font-size: var(--text-eyebrow);
+      letter-spacing: var(--tracking-eyebrow); text-transform: uppercase;
+      color: var(--accent); font-weight: var(--weight-medium);
+    }
+    h1.display {
+      font-family: var(--font-serif); font-size: var(--text-h1); font-weight: var(--weight-medium);
+      letter-spacing: var(--tracking-tight); margin: 6px 0 0; line-height: var(--leading-tight);
+    }
+    h2.section {
+      font-family: var(--font-serif); font-size: var(--text-h2); font-weight: var(--weight-medium);
+      letter-spacing: var(--tracking-tight); margin: 64px 0 4px;
+    }
+    h3.sub {
+      font-family: var(--font-serif); font-size: var(--text-h3); font-weight: var(--weight-medium);
+      margin: 32px 0 12px;
+    }
+    p.tagline { font-family: var(--font-serif); font-style: italic; font-size: var(--text-body-lg); color: var(--ink-secondary); margin: 12px 0 24px; max-width: 560px; }
+    .grid { display: grid; gap: 12px; }
+    .grid-3 { grid-template-columns: repeat(3, 1fr); }
+    .grid-4 { grid-template-columns: repeat(4, 1fr); }
+    .grid-6 { grid-template-columns: repeat(6, 1fr); }
+    @media (max-width: 720px) { .grid-3, .grid-4, .grid-6 { grid-template-columns: repeat(2, 1fr); } }
+
+    /* Token swatch */
+    .swatch { padding: 14px; border-radius: var(--radius-xl); background: var(--surface-2); border: 1px solid var(--border); }
+    .swatch .chip { height: 56px; border-radius: var(--radius-md); margin-bottom: 10px; border: 1px solid var(--border); }
+    .swatch .name { font-family: var(--font-mono); font-size: 11px; color: var(--ink-secondary); }
+    .swatch .val  { font-family: var(--font-mono); font-size: 10px; color: var(--ink-tertiary); margin-top: 2px; }
+
+    .panel { padding: var(--card-padding); background: var(--card-bg); border: 1px solid var(--card-border); border-radius: var(--card-radius); backdrop-filter: blur(var(--blur-sm)); }
+    .row { display: flex; gap: 12px; flex-wrap: wrap; align-items: center; }
+
+    /* Button replicas */
+    .btn { padding: 10px 20px; border-radius: var(--btn-radius); font-family: var(--font-sans); font-size: var(--text-body); font-weight: var(--weight-semibold); cursor: pointer; border: none; transition: all var(--dur-base) var(--ease-out); display: inline-flex; align-items: center; gap: 8px; }
+    .btn-primary { background: var(--accent-gradient); color: var(--ink-on-accent); }
+    .btn-primary:hover { box-shadow: var(--glow-md); transform: translateY(-1px); }
+    .btn-secondary { background: var(--surface-2); border: 1px solid var(--border); color: var(--ink-primary); }
+    .btn-secondary:hover { background: var(--surface-2-hi); border-color: var(--border-hi); }
+    .btn-ghost { background: transparent; color: var(--accent); }
+    .btn-ghost:hover { color: var(--accent-hi); }
+    .btn-icon { width: 32px; height: 32px; padding: 0; background: var(--surface-2); border: 1px solid var(--border); color: var(--ink-secondary); border-radius: var(--radius-md); display: inline-flex; align-items: center; justify-content: center; cursor: pointer; }
+    .btn[disabled] { opacity: 0.4; cursor: not-allowed; transform: none; box-shadow: none; }
+
+    /* Input replicas */
+    .input { width: 100%; padding: var(--input-padding); background: var(--input-bg); border: 1px solid var(--input-border); border-radius: var(--input-radius); color: var(--ink-primary); font-family: var(--font-sans); font-size: var(--input-font-size); outline: none; box-sizing: border-box; transition: border-color var(--dur-base) var(--ease-out); }
+    .input:focus { border-color: var(--accent); }
+    .input.mono { font-family: var(--font-mono); }
+    .input.error { border-color: var(--status-warn); }
+
+    /* Tag replicas */
+    .tag { display: inline-flex; align-items: center; padding: var(--tag-padding-y) var(--tag-padding-x); border-radius: var(--tag-radius); font-family: var(--font-mono); font-size: var(--tag-font-size); letter-spacing: 0.10em; text-transform: uppercase; white-space: nowrap; }
+    .tag.accent { background: var(--accent-soft); border: 1px solid var(--border-accent); color: var(--accent); }
+    .tag.cyan { background: rgba(136,231,255,0.10); border: 1px solid rgba(136,231,255,0.40); color: var(--cyan-400); }
+    .tag.gold { background: rgba(245,214,128,0.10); border: 1px solid rgba(245,214,128,0.40); color: var(--gold-400); }
+    .tag.ok   { background: var(--status-ok-soft); border: 1px solid rgba(134,239,172,0.4); color: var(--status-ok); }
+    .tag.warn { background: var(--status-warn-soft); border: 1px solid rgba(255,134,160,0.4); color: var(--status-warn); }
+    .tag.ghost { background: transparent; border: 1px solid var(--border-hi); color: var(--ink-tertiary); }
+
+    /* Stat tile */
+    .stat { padding: 14px; border-radius: var(--radius-xl); background: var(--surface-2); border: 1px solid var(--border); }
+    .stat .lbl { font-family: var(--font-mono); font-size: var(--text-caption); letter-spacing: var(--tracking-eyebrow); color: var(--ink-tertiary); text-transform: uppercase; }
+    .stat .num { font-family: var(--font-serif); font-size: var(--text-h2); font-weight: var(--weight-medium); margin-top: 4px; line-height: 1; }
+    .stat .num.accent { color: var(--accent); }
+
+    /* Card row */
+    .card-row { display: flex; align-items: center; gap: 12px; padding: 8px 14px; border-radius: var(--radius-lg); cursor: pointer; transition: background var(--dur-fast) var(--ease-out); }
+    .card-row:hover { background: var(--accent-soft); }
+    .card-row .qty { font-family: var(--font-mono); font-size: 11px; color: var(--ink-tertiary); width: 22px; }
+    .card-row .name { flex: 1; font-size: 13px; font-weight: var(--weight-medium); }
+    .card-row .price { font-family: var(--font-mono); font-size: 11px; color: var(--ink-tertiary); }
+
+    /* Type sample */
+    .type-row { display: grid; grid-template-columns: 140px 1fr; gap: 16px; padding: 14px 0; border-bottom: 1px solid var(--border); align-items: baseline; }
+    .type-row .label { font-family: var(--font-mono); font-size: 10px; color: var(--ink-tertiary); letter-spacing: 0.15em; text-transform: uppercase; }
+
+    /* Space scale */
+    .space-bar { background: var(--accent); height: 8px; border-radius: 2px; }
+
+    /* Radius demo */
+    .radius-demo { width: 64px; height: 64px; background: var(--accent-soft); border: 1px solid var(--border-accent); display: flex; align-items: end; justify-content: center; padding-bottom: 6px; font-family: var(--font-mono); font-size: 9px; color: var(--ink-tertiary); }
+
+    /* Shadow demo */
+    .shadow-demo { width: 100%; height: 80px; background: var(--surface-1); border: 1px solid var(--border); border-radius: var(--radius-xl); display: flex; align-items: center; justify-content: center; font-family: var(--font-mono); font-size: 10px; color: var(--ink-tertiary); }
+  </style>
+</head>
+<body>
+  <div class="cosmos"></div>
+  <main>
+    <header>
+      <div class="eyebrow">DESIGN SYSTEM · v0.1.0</div>
+      <h1 class="display">Astral.</h1>
+      <p class="tagline">"Tokens, primitives, and patterns for reading decks under starlight."</p>
+      <div class="row">
+        <span class="tag accent">DARK · CANONICAL</span>
+        <span class="tag ghost">LIGHT · TODO</span>
+        <span class="tag cyan">v0.1.0</span>
+      </div>
+    </header>
+
+    <!-- ─── COLOR ─── -->
+    <h2 class="section">Color · raw scale</h2>
+    <p class="tagline">Pure values. Components don't reference these directly.</p>
+
+    <h3 class="sub">Voids &amp; inks</h3>
+    <div class="grid grid-6">
+      <div class="swatch"><div class="chip" style="background:var(--void-950)"></div><div class="name">--void-950</div><div class="val">#0a0a18</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--void-900)"></div><div class="name">--void-900</div><div class="val">#10112a</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--void-800)"></div><div class="name">--void-800</div><div class="val">#181a3a</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--ink-100)"></div><div class="name">--ink-100</div><div class="val">#f0eaff</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--ink-200)"></div><div class="name">--ink-200</div><div class="val">#c5bce0</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--ink-400)"></div><div class="name">--ink-400</div><div class="val">#6e6890</div></div>
+    </div>
+
+    <h3 class="sub">Brand · cosmic</h3>
+    <div class="grid grid-6">
+      <div class="swatch"><div class="chip" style="background:var(--violet-300)"></div><div class="name">--violet-300</div><div class="val">#c4b5fd</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--violet-400)"></div><div class="name">--violet-400</div><div class="val">#a78bfa · primary</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--violet-500)"></div><div class="name">--violet-500</div><div class="val">#8b5cf6</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--aura-400)"></div><div class="name">--aura-400</div><div class="val">#f0aaff</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--cyan-400)"></div><div class="name">--cyan-400</div><div class="val">#88e7ff</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--gold-400)"></div><div class="name">--gold-400</div><div class="val">#f5d680</div></div>
+    </div>
+
+    <h3 class="sub">Status</h3>
+    <div class="grid grid-3">
+      <div class="swatch"><div class="chip" style="background:var(--status-ok)"></div><div class="name">--status-ok</div><div class="val">#86efac</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--status-watch)"></div><div class="name">--status-watch</div><div class="val">#fde68a</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--status-warn)"></div><div class="name">--status-warn</div><div class="val">#ff86a0</div></div>
+    </div>
+
+    <h3 class="sub">Mana · WUBRG + colorless</h3>
+    <div class="grid grid-6">
+      <div class="swatch"><div class="chip" style="background:var(--mana-w)"></div><div class="name">--mana-w</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--mana-u)"></div><div class="name">--mana-u</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--mana-b)"></div><div class="name">--mana-b</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--mana-r)"></div><div class="name">--mana-r</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--mana-g)"></div><div class="name">--mana-g</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--mana-c)"></div><div class="name">--mana-c</div></div>
+    </div>
+
+    <!-- ─── SEMANTIC ─── -->
+    <h2 class="section">Color · semantic aliases</h2>
+    <p class="tagline">Components reference these. Themes remap by changing only this layer.</p>
+    <div class="grid grid-4">
+      <div class="swatch"><div class="chip" style="background:var(--accent)"></div><div class="name">--accent</div><div class="val">→ violet-400</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--accent-hi)"></div><div class="name">--accent-hi</div><div class="val">→ aura-400</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--accent-gradient)"></div><div class="name">--accent-gradient</div><div class="val">violet → aura</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--surface-1)"></div><div class="name">--surface-1</div><div class="val">panels</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--surface-2)"></div><div class="name">--surface-2</div><div class="val">subtle fill</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--surface-overlay)"></div><div class="name">--surface-overlay</div><div class="val">sheets</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--ink-primary)"></div><div class="name">--ink-primary</div><div class="val">→ ink-100</div></div>
+      <div class="swatch"><div class="chip" style="background:var(--ink-secondary)"></div><div class="name">--ink-secondary</div><div class="val">→ ink-200</div></div>
+    </div>
+
+    <!-- ─── TYPE ─── -->
+    <h2 class="section">Typography</h2>
+    <p class="tagline">Spectral for display, Inter for UI, JetBrains Mono for codes.</p>
+
+    <div class="panel">
+      <div class="type-row"><div class="label">Display · 56</div><div class="serif" style="font-size:56px; font-weight:500; letter-spacing:-0.025em; line-height:1;">Slogurk, the Overslime</div></div>
+      <div class="type-row"><div class="label">H1 · 40</div><div class="serif" style="font-size:40px; font-weight:500; letter-spacing:-0.025em;">Read this deck.</div></div>
+      <div class="type-row"><div class="label">H2 · 28</div><div class="serif" style="font-size:28px; font-weight:500;">Composition</div></div>
+      <div class="type-row"><div class="label">H3 · 22</div><div class="serif" style="font-size:22px; font-weight:500;">The cards</div></div>
+      <div class="type-row"><div class="label">Tagline · italic</div><div class="serif" style="font-style:italic; font-size:15px; color:var(--ink-secondary);">"A landfall engine that wins decisively."</div></div>
+      <div class="type-row"><div class="label">Body · 13</div><div>Default body copy. Inter at 13px / 1.5 — the baseline for everything that isn't display.</div></div>
+      <div class="type-row"><div class="label">Small · 12</div><div style="font-size:12px;">Helper text, dense rows.</div></div>
+      <div class="type-row"><div class="label">Eyebrow · 10 mono</div><div class="eyebrow">READING · 04.27.26</div></div>
+      <div class="type-row"><div class="label">Caption · 9 mono</div><div class="mono" style="font-size:9px; letter-spacing:0.15em; color:var(--ink-tertiary);">CENTRALITY · KEEP RATE</div></div>
+    </div>
+
+    <!-- ─── SPACE ─── -->
+    <h2 class="section">Space</h2>
+    <p class="tagline">Soft scale. 8 is the workhorse.</p>
+    <div class="panel">
+      <div style="display:flex; flex-direction:column; gap:8px;">
+        <div style="display:flex; align-items:center; gap:12px;"><span class="mono" style="width:60px; color:var(--ink-tertiary); font-size:10px;">--space-2</span><div class="space-bar" style="width:4px;"></div><span class="mono" style="font-size:10px; color:var(--ink-tertiary);">4px</span></div>
+        <div style="display:flex; align-items:center; gap:12px;"><span class="mono" style="width:60px; color:var(--ink-tertiary); font-size:10px;">--space-4</span><div class="space-bar" style="width:8px;"></div><span class="mono" style="font-size:10px; color:var(--ink-tertiary);">8px</span></div>
+        <div style="display:flex; align-items:center; gap:12px;"><span class="mono" style="width:60px; color:var(--ink-tertiary); font-size:10px;">--space-6</span><div class="space-bar" style="width:12px;"></div><span class="mono" style="font-size:10px; color:var(--ink-tertiary);">12px</span></div>
+        <div style="display:flex; align-items:center; gap:12px;"><span class="mono" style="width:60px; color:var(--ink-tertiary); font-size:10px;">--space-8</span><div class="space-bar" style="width:16px;"></div><span class="mono" style="font-size:10px; color:var(--ink-tertiary);">16px</span></div>
+        <div style="display:flex; align-items:center; gap:12px;"><span class="mono" style="width:60px; color:var(--ink-tertiary); font-size:10px;">--space-12</span><div class="space-bar" style="width:24px;"></div><span class="mono" style="font-size:10px; color:var(--ink-tertiary);">24px</span></div>
+        <div style="display:flex; align-items:center; gap:12px;"><span class="mono" style="width:60px; color:var(--ink-tertiary); font-size:10px;">--space-16</span><div class="space-bar" style="width:32px;"></div><span class="mono" style="font-size:10px; color:var(--ink-tertiary);">32px</span></div>
+        <div style="display:flex; align-items:center; gap:12px;"><span class="mono" style="width:60px; color:var(--ink-tertiary); font-size:10px;">--space-24</span><div class="space-bar" style="width:48px;"></div><span class="mono" style="font-size:10px; color:var(--ink-tertiary);">48px</span></div>
+      </div>
+    </div>
+
+    <!-- ─── RADIUS ─── -->
+    <h2 class="section">Radius</h2>
+    <div class="row">
+      <div class="radius-demo" style="border-radius:var(--radius-sm)">sm · 4</div>
+      <div class="radius-demo" style="border-radius:var(--radius-md)">md · 6</div>
+      <div class="radius-demo" style="border-radius:var(--radius-lg)">lg · 8</div>
+      <div class="radius-demo" style="border-radius:var(--radius-xl)">xl · 12</div>
+      <div class="radius-demo" style="border-radius:var(--radius-2xl)">2xl · 14</div>
+      <div class="radius-demo" style="border-radius:var(--radius-3xl)">3xl · 18</div>
+      <div class="radius-demo" style="border-radius:var(--radius-pill)">pill</div>
+    </div>
+
+    <!-- ─── SHADOW ─── -->
+    <h2 class="section">Shadow &amp; glow</h2>
+    <div class="grid grid-4">
+      <div class="shadow-demo" style="box-shadow:var(--shadow-sm)">sm</div>
+      <div class="shadow-demo" style="box-shadow:var(--shadow-md)">md</div>
+      <div class="shadow-demo" style="box-shadow:var(--shadow-lg)">lg</div>
+      <div class="shadow-demo" style="box-shadow:var(--shadow-xl)">xl</div>
+      <div class="shadow-demo" style="box-shadow:var(--glow-sm)">glow-sm</div>
+      <div class="shadow-demo" style="box-shadow:var(--glow-md)">glow-md</div>
+      <div class="shadow-demo" style="box-shadow:var(--glow-lg)">glow-lg</div>
+      <div class="shadow-demo" style="box-shadow:var(--glow-aura)">glow-aura</div>
+    </div>
+
+    <!-- ─── BUTTONS ─── -->
+    <h2 class="section">Button</h2>
+    <p class="tagline">Variants × states.</p>
+    <div class="panel">
+      <h3 class="sub" style="margin-top:0;">Primary</h3>
+      <div class="row"><button class="btn btn-primary">Read this deck</button><button class="btn btn-primary" disabled>Disabled</button></div>
+      <h3 class="sub">Secondary</h3>
+      <div class="row"><button class="btn btn-secondary">Suggestions</button><button class="btn btn-secondary" disabled>Disabled</button></div>
+      <h3 class="sub">Ghost</h3>
+      <div class="row"><button class="btn btn-ghost">← Back</button></div>
+      <h3 class="sub">Icon</h3>
+      <div class="row"><button class="btn-icon">✕</button><button class="btn-icon">⤴</button><button class="btn-icon">⌕</button></div>
+    </div>
+
+    <!-- ─── INPUTS ─── -->
+    <h2 class="section">Input</h2>
+    <div class="panel">
+      <div style="display:flex; flex-direction:column; gap:12px; max-width: 480px;">
+        <input class="input" placeholder="Search by name, role…" />
+        <input class="input mono" placeholder="moxfield.com/decks/…" />
+        <input class="input error" value="Invalid URL" />
+        <input class="input" placeholder="Disabled" disabled />
+      </div>
+    </div>
+
+    <!-- ─── TAGS ─── -->
+    <h2 class="section">Tag</h2>
+    <p class="tagline">Mono · uppercase · pill. Status-coded.</p>
+    <div class="panel">
+      <div class="row">
+        <span class="tag accent">ENGINE</span>
+        <span class="tag accent">COMMANDER</span>
+        <span class="tag cyan">DRAW</span>
+        <span class="tag gold">RAMP</span>
+        <span class="tag ok">ON BUDGET</span>
+        <span class="tag warn">FLOOD RISK</span>
+        <span class="tag ghost">SNOOZED</span>
+      </div>
+    </div>
+
+    <!-- ─── CARD ─── -->
+    <h2 class="section">Card · panel</h2>
+    <div class="grid grid-3">
+      <div class="panel">
+        <div class="eyebrow">SURFACE-1</div>
+        <h3 class="serif" style="font-size:18px; font-weight:500; margin:6px 0 8px;">Default</h3>
+        <p style="color:var(--ink-secondary); font-size:13px; margin:0;">The baseline panel — everything sits in one of these unless it's hero or accent-soft.</p>
+      </div>
+      <div class="panel" style="background:var(--accent-soft); border-color:var(--border-accent);">
+        <div class="eyebrow">ACCENT-SOFT</div>
+        <h3 class="serif" style="font-size:18px; font-weight:500; margin:6px 0 8px;">Highlight</h3>
+        <p style="color:var(--ink-secondary); font-size:13px; margin:0;">For "the reading" callouts, primary recommendations, hero blocks.</p>
+      </div>
+      <div class="panel" style="background:transparent;">
+        <div class="eyebrow">OUTLINE</div>
+        <h3 class="serif" style="font-size:18px; font-weight:500; margin:6px 0 8px;">Quiet</h3>
+        <p style="color:var(--ink-secondary); font-size:13px; margin:0;">For grouping without weight. Used sparingly.</p>
+      </div>
+    </div>
+
+    <!-- ─── STAT TILE ─── -->
+    <h2 class="section">Stat tile</h2>
+    <div class="grid grid-4">
+      <div class="stat"><div class="lbl">POWER</div><div class="num accent">7.4</div></div>
+      <div class="stat"><div class="lbl">WIN RATE</div><div class="num">87%</div></div>
+      <div class="stat"><div class="lbl">AVG WIN</div><div class="num">T8.2</div></div>
+      <div class="stat"><div class="lbl">CURVE</div><div class="num">2.84</div></div>
+    </div>
+
+    <!-- ─── CARD ROW ─── -->
+    <h2 class="section">Card row</h2>
+    <p class="tagline">The list unit. Hover state shows accent fill.</p>
+    <div class="panel" style="padding: 6px;">
+      <div class="card-row"><span class="qty">1×</span><span class="name">Slogurk, the Overslime</span><span class="tag accent">COMMANDER</span><span class="price">$4.20</span></div>
+      <div class="card-row"><span class="qty">1×</span><span class="name">Crucible of Worlds</span><span class="tag accent">ENGINE</span><span class="price">$18.00</span></div>
+      <div class="card-row"><span class="qty">1×</span><span class="name">Cultivate</span><span class="tag gold">RAMP</span><span class="price">$0.50</span></div>
+      <div class="card-row"><span class="qty">1×</span><span class="name">Brainstorm</span><span class="tag cyan">DRAW</span><span class="price">$0.40</span></div>
+      <div class="card-row"><span class="qty">1×</span><span class="name">Cyclonic Rift</span><span class="tag warn">REMOVAL</span><span class="price">$32.00</span></div>
+    </div>
+
+    <!-- ─── SHEET ─── -->
+    <h2 class="section">Sheet · bottom drawer (mobile)</h2>
+    <p class="tagline">Anatomy preview. Real sheet animates from below.</p>
+    <div style="max-width: 400px; padding: 14px 18px 28px; background: var(--surface-overlay); border: 1px solid var(--sheet-border); border-radius: var(--sheet-radius) var(--sheet-radius) 0 0; box-shadow: var(--sheet-shadow);">
+      <div style="width:36px; height:4px; border-radius:2px; background:rgba(255,255,255,0.2); margin: 0 auto 14px;"></div>
+      <div class="eyebrow">PEEK</div>
+      <h3 class="serif" style="font-size:19px; font-weight:500; margin:4px 0 0;">Crucible of Worlds</h3>
+      <div class="mono" style="font-size:10px; color:var(--ink-tertiary); margin-top:4px;">ARTIFACT · 3</div>
+      <p class="serif" style="font-style:italic; font-size:13px; color:var(--ink-secondary); margin:14px 0 0; line-height:1.55; padding:10px 12px; background:rgba(0,0,0,0.3); border-left:2px solid var(--accent); border-radius:4px;">"You may play lands from your graveyard."</p>
+      <div class="grid grid-3" style="margin-top:14px;">
+        <div class="stat"><div class="lbl">CENTRALITY</div><div class="num accent" style="font-size:18px;">#2</div></div>
+        <div class="stat"><div class="lbl">KEEP RATE</div><div class="num accent" style="font-size:18px;">81%</div></div>
+        <div class="stat"><div class="lbl">PRICE</div><div class="num accent" style="font-size:18px;">$18</div></div>
+      </div>
+    </div>
+
+    <!-- ─── PATTERNS ─── -->
+    <h2 class="section">Pattern · the reading hero</h2>
+    <div class="panel" style="background: var(--accent-soft); border-color: var(--border-accent);">
+      <div class="eyebrow">READING · 04.27.26</div>
+      <h2 class="serif" style="font-size:32px; font-weight:500; margin:6px 0 0; letter-spacing:-0.015em;">Slogurk, the Overslime</h2>
+      <p class="serif" style="font-style:italic; font-size:15px; color:var(--ink-secondary); margin: 12px 0 18px; line-height:1.5;">"A landfall engine that wins decisively when it gets there — but watches the door for flood."</p>
+      <div style="display:flex; align-items:flex-end; gap:14px;">
+        <div class="serif" style="font-size:56px; font-weight:500; line-height:1; background:var(--accent-gradient); -webkit-background-clip:text; -webkit-text-fill-color:transparent; letter-spacing:-0.025em;">7.4</div>
+        <div class="mono" style="font-size:11px; color:var(--ink-tertiary); padding-bottom:8px;">/10 · UPGRADED BRACKET</div>
+      </div>
+    </div>
+
+    <!-- ─── FOOTER ─── -->
+    <h2 class="section">Adoption checklist</h2>
+    <div class="panel">
+      <ul style="margin:0; padding-left:20px; line-height:1.8;">
+        <li>Import <code class="mono">tokens.css</code> at app root.</li>
+        <li>Wire fonts via <code class="mono">next/font/google</code>.</li>
+        <li>Replace hard-coded colors with semantic tokens.</li>
+        <li>Build primitives in <code class="mono">components/ui/</code>.</li>
+        <li>Add focus rings to every interactive.</li>
+        <li>Honor <code class="mono">prefers-reduced-motion</code>.</li>
+        <li>Light theme — leave TODO until brand calls for it.</li>
+      </ul>
+    </div>
+  </main>
+</body>
+</html>

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -1,0 +1,248 @@
+/* ─────────────────────────────────────────────────────────────
+   Astral · Design Tokens (CSS variables)
+   ─────────────────────────────────────────────────────────────
+   Two layers:
+     1. RAW SCALE (--violet-500, --space-4)        — pure values.
+     2. SEMANTIC ALIASES (--accent, --surface-1)   — what UI uses.
+
+   Components should reference SEMANTIC tokens. Raw scales exist
+   so themes (light / brand variants) can be remixed without
+   touching component styles.
+
+   Dark theme is canonical. Light tokens are stubbed (TODO).
+───────────────────────────────────────────────────────────── */
+
+:root {
+  /* ─── RAW · COLOR ──────────────────────────────────────── */
+
+  /* Neutrals — voids & inks */
+  --void-950: #0a0a18;
+  --void-900: #10112a;
+  --void-800: #181a3a;
+  --void-700: #28264f;
+  --void-600: #3a3458;
+
+  --ink-50:  #ffffff;
+  --ink-100: #f0eaff;
+  --ink-200: #c5bce0;
+  --ink-300: #9990b8;
+  --ink-400: #6e6890;
+  --ink-500: #3a3458;
+
+  /* Brand · Cosmic */
+  --violet-300: #c4b5fd;
+  --violet-400: #a78bfa;   /* PRIMARY accent */
+  --violet-500: #8b5cf6;
+  --violet-600: #7c3aed;
+  --violet-700: #5b21b6;
+
+  --aura-300: #f9c4ff;
+  --aura-400: #f0aaff;     /* glow / gradient pair */
+  --aura-500: #d885e8;
+
+  --cyan-400: #88e7ff;
+  --gold-400: #f5d680;
+
+  /* Semantic palette · status */
+  --ok-400:    #86efac;
+  --watch-400: #fde68a;
+  --warn-400:  #ff86a0;
+
+  /* Mana colors (MTG · WUBRG + colorless) */
+  --mana-w: #f8f5d8;
+  --mana-u: #bfd9f0;
+  --mana-b: #bfb5b0;
+  --mana-r: #f4b8a3;
+  --mana-g: #b8d4b3;
+  --mana-c: #d8d2c4;
+
+  /* ─── RAW · TYPOGRAPHY ─────────────────────────────────── */
+  --font-serif: "Spectral", Georgia, "Times New Roman", serif;
+  --font-sans:  "Inter", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-mono:  "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Type scale (px) — display down to caption */
+  --text-display: 56px;   /* hero score numbers */
+  --text-h1:      40px;   /* page title */
+  --text-h2:      28px;   /* section title */
+  --text-h3:      22px;   /* sub-section */
+  --text-h4:      18px;
+  --text-body:    13px;   /* default body */
+  --text-body-lg: 15px;
+  --text-sm:      12px;
+  --text-xs:      11px;
+  --text-eyebrow: 10px;   /* mono · 0.22em tracked */
+  --text-caption: 9px;
+
+  --leading-tight: 1.15;
+  --leading-snug:  1.3;
+  --leading-body:  1.5;
+  --leading-loose: 1.65;
+
+  --tracking-tight:  -0.025em;
+  --tracking-normal: 0;
+  --tracking-wide:    0.05em;
+  --tracking-eyebrow: 0.22em;
+
+  --weight-regular:  400;
+  --weight-medium:   500;
+  --weight-semibold: 600;
+  --weight-bold:     700;
+
+  /* ─── RAW · SPACE ──────────────────────────────────────── */
+  --space-0:  0px;
+  --space-1:  2px;
+  --space-2:  4px;
+  --space-3:  6px;
+  --space-4:  8px;
+  --space-5:  10px;
+  --space-6:  12px;
+  --space-7:  14px;
+  --space-8:  16px;
+  --space-10: 20px;
+  --space-12: 24px;
+  --space-14: 28px;
+  --space-16: 32px;
+  --space-20: 40px;
+  --space-24: 48px;
+  --space-32: 64px;
+
+  /* ─── RAW · RADIUS ─────────────────────────────────────── */
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   8px;
+  --radius-xl:   12px;
+  --radius-2xl:  14px;   /* panels */
+  --radius-3xl:  18px;   /* sheets, hero cards */
+  --radius-pill: 999px;
+
+  /* ─── RAW · SHADOW (elevation + glow) ──────────────────── */
+  --shadow-sm:   0 1px 2px rgba(0,0,0,0.3);
+  --shadow-md:   0 8px 24px rgba(0,0,0,0.35);
+  --shadow-lg:   0 24px 60px rgba(0,0,0,0.4);
+  --shadow-xl:   0 30px 80px rgba(0,0,0,0.5);
+
+  --glow-sm:    0 0 8px  rgba(167,139,250,0.30);
+  --glow-md:    0 0 14px rgba(167,139,250,0.50);
+  --glow-lg:    0 0 24px rgba(167,139,250,0.50);
+  --glow-aura:  0 0 24px rgba(240,170,255,0.40);
+
+  /* ─── RAW · MOTION ─────────────────────────────────────── */
+  --ease-out:    cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+
+  --dur-instant: 80ms;
+  --dur-fast:    120ms;
+  --dur-base:    180ms;
+  --dur-slow:    240ms;
+  --dur-slower:  400ms;
+  --dur-reveal:  600ms;
+
+  /* ─── RAW · BLUR ───────────────────────────────────────── */
+  --blur-sm:  8px;
+  --blur-md:  12px;
+  --blur-lg:  20px;
+
+  /* ─── SEMANTIC · SURFACE ───────────────────────────────── */
+  --bg-base:        var(--void-950);   /* page background */
+  --bg-cosmos:      var(--void-950);   /* + radial gradient overlay */
+  --surface-1:      rgba(40, 38, 80, 0.40);    /* default panel */
+  --surface-1-hi:   rgba(60, 58, 110, 0.55);   /* hovered panel */
+  --surface-2:      rgba(255, 255, 255, 0.04); /* subtle fill (buttons, inputs) */
+  --surface-2-hi:   rgba(255, 255, 255, 0.08);
+  --surface-overlay: rgba(28, 22, 58, 0.98);   /* sheets, modals */
+  --surface-scrim:  rgba(0, 0, 0, 0.55);       /* sheet backdrop */
+
+  --border:    rgba(180, 170, 240, 0.16);
+  --border-hi: rgba(180, 170, 240, 0.32);
+  --border-accent: rgba(167, 139, 250, 0.30);
+
+  /* ─── SEMANTIC · TEXT ──────────────────────────────────── */
+  --ink-primary:   var(--ink-100);
+  --ink-secondary: var(--ink-200);
+  --ink-tertiary:  var(--ink-400);
+  --ink-disabled:  var(--ink-500);
+  --ink-on-accent: var(--void-950);    /* text on violet/aura buttons */
+
+  /* ─── SEMANTIC · ACCENT ────────────────────────────────── */
+  --accent:        var(--violet-400);
+  --accent-hi:     var(--aura-400);
+  --accent-soft:   rgba(167, 139, 250, 0.12);
+  --accent-soft-hi:rgba(167, 139, 250, 0.18);
+  --accent-gradient: linear-gradient(135deg, var(--violet-400) 0%, var(--aura-400) 100%);
+
+  /* ─── SEMANTIC · STATUS ────────────────────────────────── */
+  --status-ok:    var(--ok-400);
+  --status-watch: var(--watch-400);
+  --status-warn:  var(--warn-400);
+
+  --status-ok-soft:    rgba(134, 239, 172, 0.10);
+  --status-watch-soft: rgba(253, 230, 138, 0.10);
+  --status-warn-soft:  rgba(255, 134, 160, 0.10);
+
+  /* ─── SEMANTIC · COMPONENT TOKENS ──────────────────────── */
+  /* Buttons */
+  --btn-radius:        var(--radius-lg);
+  --btn-padding-y:     var(--space-5);
+  --btn-padding-x:     var(--space-10);
+  --btn-font-size:     var(--text-body);
+  --btn-font-weight:   var(--weight-semibold);
+
+  /* Inputs */
+  --input-radius:      var(--radius-xl);
+  --input-padding:     var(--space-7);
+  --input-bg:          rgba(0, 0, 0, 0.40);
+  --input-border:      var(--border-accent);
+  --input-font-size:   var(--text-sm);
+
+  /* Cards & panels */
+  --card-radius:       var(--radius-2xl);
+  --card-padding:      var(--space-12);
+  --card-bg:           var(--surface-1);
+  --card-border:       var(--border);
+
+  /* Sheet (mobile bottom drawer) */
+  --sheet-radius:      var(--radius-3xl);
+  --sheet-bg:          var(--surface-overlay);
+  --sheet-border:      var(--border-accent);
+  --sheet-shadow:      0 -20px 60px rgba(0,0,0,0.6);
+
+  /* Tags / chips */
+  --tag-radius:        var(--radius-pill);
+  --tag-padding-y:     var(--space-1);
+  --tag-padding-x:     var(--space-5);
+  --tag-font-size:     var(--text-caption);
+  --tag-tracking:      0.10em;
+}
+
+/* ─────────────────────────────────────────────────────────────
+   LIGHT THEME — TODO
+   These are placeholders. Re-derive once the brand calls for
+   a light surface. Keep semantic names identical so consumers
+   don't need to change.
+───────────────────────────────────────────────────────────── */
+@media (prefers-color-scheme: light) {
+  :root[data-theme="light"] {
+    /* TODO: --bg-base: #faf8ff; */
+    /* TODO: --surface-1: #ffffff; */
+    /* TODO: --ink-primary: #1a1530; */
+    /* TODO: invert all status soft fills */
+    /* TODO: pick non-glow shadows */
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────
+   REDUCED MOTION
+───────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    --dur-instant: 0ms;
+    --dur-fast: 0ms;
+    --dur-base: 0ms;
+    --dur-slow: 0ms;
+    --dur-slower: 0ms;
+    --dur-reveal: 0ms;
+  }
+}

--- a/design-system/tokens.json
+++ b/design-system/tokens.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://design-tokens.github.io/community-group/format/",
+  "_meta": {
+    "name": "Astral",
+    "version": "0.1.0",
+    "description": "Design tokens for Astral — cosmic deck-reading app. Dark canonical; light TODO.",
+    "consumers": ["Tailwind", "Style Dictionary", "Next.js (CSS vars)", "iOS", "Android"]
+  },
+
+  "color": {
+    "void": {
+      "950": { "value": "#0a0a18" },
+      "900": { "value": "#10112a" },
+      "800": { "value": "#181a3a" },
+      "700": { "value": "#28264f" },
+      "600": { "value": "#3a3458" }
+    },
+    "ink": {
+      "50":  { "value": "#ffffff" },
+      "100": { "value": "#f0eaff" },
+      "200": { "value": "#c5bce0" },
+      "300": { "value": "#9990b8" },
+      "400": { "value": "#6e6890" },
+      "500": { "value": "#3a3458" }
+    },
+    "violet": {
+      "300": { "value": "#c4b5fd" },
+      "400": { "value": "#a78bfa", "_role": "primary-accent" },
+      "500": { "value": "#8b5cf6" },
+      "600": { "value": "#7c3aed" },
+      "700": { "value": "#5b21b6" }
+    },
+    "aura": {
+      "300": { "value": "#f9c4ff" },
+      "400": { "value": "#f0aaff" },
+      "500": { "value": "#d885e8" }
+    },
+    "cyan":   { "400": { "value": "#88e7ff" } },
+    "gold":   { "400": { "value": "#f5d680" } },
+    "ok":     { "400": { "value": "#86efac" } },
+    "watch":  { "400": { "value": "#fde68a" } },
+    "warn":   { "400": { "value": "#ff86a0" } },
+
+    "mana": {
+      "w": { "value": "#f8f5d8" },
+      "u": { "value": "#bfd9f0" },
+      "b": { "value": "#bfb5b0" },
+      "r": { "value": "#f4b8a3" },
+      "g": { "value": "#b8d4b3" },
+      "c": { "value": "#d8d2c4" }
+    }
+  },
+
+  "semantic": {
+    "bg":      { "base":   { "value": "{color.void.950}" } },
+    "surface": {
+      "1":     { "value": "rgba(40, 38, 80, 0.40)" },
+      "1-hi":  { "value": "rgba(60, 58, 110, 0.55)" },
+      "2":     { "value": "rgba(255, 255, 255, 0.04)" },
+      "2-hi":  { "value": "rgba(255, 255, 255, 0.08)" },
+      "overlay": { "value": "rgba(28, 22, 58, 0.98)" },
+      "scrim":   { "value": "rgba(0, 0, 0, 0.55)" }
+    },
+    "border": {
+      "default": { "value": "rgba(180, 170, 240, 0.16)" },
+      "hi":      { "value": "rgba(180, 170, 240, 0.32)" },
+      "accent":  { "value": "rgba(167, 139, 250, 0.30)" }
+    },
+    "ink": {
+      "primary":    { "value": "{color.ink.100}" },
+      "secondary":  { "value": "{color.ink.200}" },
+      "tertiary":   { "value": "{color.ink.400}" },
+      "disabled":   { "value": "{color.ink.500}" },
+      "on-accent":  { "value": "{color.void.950}" }
+    },
+    "accent": {
+      "default":  { "value": "{color.violet.400}" },
+      "hi":       { "value": "{color.aura.400}" },
+      "soft":     { "value": "rgba(167, 139, 250, 0.12)" },
+      "soft-hi":  { "value": "rgba(167, 139, 250, 0.18)" },
+      "gradient": { "value": "linear-gradient(135deg, #a78bfa 0%, #f0aaff 100%)" }
+    },
+    "status": {
+      "ok":         { "value": "{color.ok.400}" },
+      "watch":      { "value": "{color.watch.400}" },
+      "warn":       { "value": "{color.warn.400}" },
+      "ok-soft":    { "value": "rgba(134, 239, 172, 0.10)" },
+      "watch-soft": { "value": "rgba(253, 230, 138, 0.10)" },
+      "warn-soft":  { "value": "rgba(255, 134, 160, 0.10)" }
+    }
+  },
+
+  "typography": {
+    "font": {
+      "serif": { "value": "Spectral, Georgia, 'Times New Roman', serif" },
+      "sans":  { "value": "Inter, system-ui, -apple-system, BlinkMacSystemFont, sans-serif" },
+      "mono":  { "value": "'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace" }
+    },
+    "size": {
+      "display":  { "value": "56px" },
+      "h1":       { "value": "40px" },
+      "h2":       { "value": "28px" },
+      "h3":       { "value": "22px" },
+      "h4":       { "value": "18px" },
+      "body-lg":  { "value": "15px" },
+      "body":     { "value": "13px" },
+      "sm":       { "value": "12px" },
+      "xs":       { "value": "11px" },
+      "eyebrow":  { "value": "10px" },
+      "caption":  { "value": "9px" }
+    },
+    "leading": {
+      "tight": { "value": 1.15 },
+      "snug":  { "value": 1.30 },
+      "body":  { "value": 1.50 },
+      "loose": { "value": 1.65 }
+    },
+    "tracking": {
+      "tight":   { "value": "-0.025em" },
+      "normal":  { "value": "0" },
+      "wide":    { "value": "0.05em" },
+      "eyebrow": { "value": "0.22em" }
+    },
+    "weight": {
+      "regular":  { "value": 400 },
+      "medium":   { "value": 500 },
+      "semibold": { "value": 600 },
+      "bold":     { "value": 700 }
+    }
+  },
+
+  "space": {
+    "0":  { "value": "0px" },
+    "1":  { "value": "2px" },
+    "2":  { "value": "4px" },
+    "3":  { "value": "6px" },
+    "4":  { "value": "8px" },
+    "5":  { "value": "10px" },
+    "6":  { "value": "12px" },
+    "7":  { "value": "14px" },
+    "8":  { "value": "16px" },
+    "10": { "value": "20px" },
+    "12": { "value": "24px" },
+    "14": { "value": "28px" },
+    "16": { "value": "32px" },
+    "20": { "value": "40px" },
+    "24": { "value": "48px" },
+    "32": { "value": "64px" }
+  },
+
+  "radius": {
+    "xs":   { "value": "2px" },
+    "sm":   { "value": "4px" },
+    "md":   { "value": "6px" },
+    "lg":   { "value": "8px" },
+    "xl":   { "value": "12px" },
+    "2xl":  { "value": "14px" },
+    "3xl":  { "value": "18px" },
+    "pill": { "value": "999px" }
+  },
+
+  "shadow": {
+    "sm":  { "value": "0 1px 2px rgba(0,0,0,0.3)" },
+    "md":  { "value": "0 8px 24px rgba(0,0,0,0.35)" },
+    "lg":  { "value": "0 24px 60px rgba(0,0,0,0.4)" },
+    "xl":  { "value": "0 30px 80px rgba(0,0,0,0.5)" },
+    "glow-sm":   { "value": "0 0 8px rgba(167,139,250,0.30)" },
+    "glow-md":   { "value": "0 0 14px rgba(167,139,250,0.50)" },
+    "glow-lg":   { "value": "0 0 24px rgba(167,139,250,0.50)" },
+    "glow-aura": { "value": "0 0 24px rgba(240,170,255,0.40)" }
+  },
+
+  "motion": {
+    "ease": {
+      "out":    { "value": "cubic-bezier(0.2, 0.8, 0.2, 1)" },
+      "in-out": { "value": "cubic-bezier(0.4, 0, 0.2, 1)" },
+      "spring": { "value": "cubic-bezier(0.34, 1.56, 0.64, 1)" }
+    },
+    "duration": {
+      "instant": { "value": "80ms" },
+      "fast":    { "value": "120ms" },
+      "base":    { "value": "180ms" },
+      "slow":    { "value": "240ms" },
+      "slower":  { "value": "400ms" },
+      "reveal":  { "value": "600ms" }
+    }
+  },
+
+  "blur": {
+    "sm": { "value": "8px" },
+    "md": { "value": "12px" },
+    "lg": { "value": "20px" }
+  },
+
+  "component": {
+    "button":  { "radius": { "value": "{radius.lg}" }, "padding-y": { "value": "{space.5}" }, "padding-x": { "value": "{space.10}" } },
+    "input":   { "radius": { "value": "{radius.xl}" }, "padding":   { "value": "{space.7}" } },
+    "card":    { "radius": { "value": "{radius.2xl}" }, "padding":  { "value": "{space.12}" } },
+    "sheet":   { "radius": { "value": "{radius.3xl}" } },
+    "tag":     { "radius": { "value": "{radius.pill}" }, "padding-y": { "value": "{space.1}" }, "padding-x": { "value": "{space.5}" } }
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,8 +8,9 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-sans);
+  --font-serif: var(--font-serif);
+  --font-mono: var(--font-mono);
 }
 
 body {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,25 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Spectral, JetBrains_Mono } from "next/font/google";
 import Link from "next/link";
 import Footer from "@/components/Footer";
 import NavLinks from "@/components/NavLinks";
 import "./globals.css";
+import "../../design-system/tokens.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-sans",
   subsets: ["latin"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const spectral = Spectral({
+  variable: "--font-serif",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  style: ["normal", "italic"],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-mono",
   subsets: ["latin"],
 });
 
@@ -35,10 +43,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} flex min-h-screen flex-col antialiased`}
-      >
+    <html
+      lang="en"
+      data-theme="dark"
+      className={`${inter.variable} ${spectral.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="flex min-h-screen flex-col antialiased">
         <nav
           aria-label="Main navigation"
           className="border-b border-slate-700 bg-slate-900/50 backdrop-blur-sm"


### PR DESCRIPTION
## Summary

This PR introduces the **Astral design system** foundations — tokens and font wiring only. No existing components are migrated here.

### What's included

- **`design-system/tokens.css`** — Source of truth for all CSS variables: two-layer architecture (raw scale + semantic aliases) covering color, typography, spacing, radius, shadow/glow, and motion.
- **`design-system/tokens.json`** — DTCG-style token export for Tailwind / Style Dictionary / native use.
- **`design-system/README.md`** — Component specs, composition patterns, and usage guidelines.
- **`design-system/CLAUDE.md`** — Full integration brief and build order for subsequent PRs.
- **`design-system/preview.html`** — Visual reference rendering every token and component in every state. Serve locally with `python3 -m http.server --directory design-system` and open `http://localhost:8000/preview.html` to review.
- **`design-system/components/primitives.jsx`** — JSX reference implementations (Button, Card, Tag, Input, Sheet, StatTile).

### Wiring changes (`src/app/layout.tsx` + `src/app/globals.css`)

| Before | After |
|--------|-------|
| Geist Sans + Geist Mono (next/font) | Inter (sans) + Spectral (serif) + JetBrains Mono (mono) |
| `--font-geist-sans` / `--font-geist-mono` | `--font-sans` / `--font-serif` / `--font-mono` |
| no `data-theme` attribute | `data-theme="dark"` on `<html>` |
| no token import | `tokens.css` imported in layout root |

Font variables are injected at the `<html>` element via `next/font/google`, overriding the fallback stacks already defined in `tokens.css`.

### Design system color spine

Brand spine: `--violet-400` → `--aura-400` at 135° (used for primary CTAs and hero score numbers only). All components should reference **semantic tokens** (`var(--accent)`, `var(--ink-primary)`) — never raw values.

### Light theme

> **TODO:** Light theme is intentionally stubbed. The `[data-theme="light"]` block in `tokens.css` exists as a placeholder but all values are commented out. `data-theme="light"` does nothing yet — this is expected and will be addressed in a future PR once brand decisions are final.

## What's next

Subsequent PRs will follow the build order in `design-system/CLAUDE.md`:

1. **Cosmos shell** — fixed background (radial gradients + twinkling stars) + top nav
2. **Primitives** — `<Button>`, `<Input>`, `<Card>`, `<Tag>`, `<Sheet>`, `<StatTile>`
3. **Domain components** — `<ManaCost>`, `<ColorPie>`, `<CurveConstellation>`, `<CardRow>`, `<DeckHero>`
4. **Screen routes** — import, loading, reading, cards, goldfish, suggestions, add, compare, share

## Verification

- `npm run build` passes clean
- `preview.html` serves correctly at `http://localhost:8000/preview.html` (see above)
- No existing components or tests are affected — this is additive only

🤖 Generated with [Claude Code](https://claude.com/claude-code)