### PR TITLE
feat(design-system): Astral domain components

### DIFF
--- a/e2e/design-system-preview.spec.ts
+++ b/e2e/design-system-preview.spec.ts
@@ -19,6 +19,11 @@ test.describe("/preview — Astral primitives gallery", () => {
       "CardTag",
       "StatTile",
       "Sheet",
+      "ManaCost",
+      "ColorPie",
+      "CurveConstellation",
+      "CardRow",
+      "DeckHero",
     ]) {
       await expect(
         page.getByRole("heading", { level: 2, name: section, exact: true }),
@@ -71,6 +76,53 @@ test.describe("/preview — Astral primitives gallery", () => {
     ]) {
       await expect(cardTagSection.getByText(role, { exact: true })).toBeVisible();
     }
+  });
+
+  test("ManaCost renders one pip per symbol with mana-color tokens", async ({
+    page,
+  }) => {
+    const mc = page.getByTestId("preview-manacost");
+    // {2}{U}{G} demo cost should produce 3 pips. The preview renders the
+    // same cost at md and lg sizes; .first() picks the md instance.
+    const cost = mc
+      .getByLabel("Mana cost: 2 generic, 1 blue, 1 green")
+      .first();
+    await expect(cost).toBeVisible();
+    await expect(cost.locator("[data-pip]")).toHaveCount(3);
+  });
+
+  test("ColorPie renders one segment per non-zero color", async ({ page }) => {
+    const pie = page.getByTestId("preview-colorpie");
+    // 4 non-zero colors in our demo (W, U, R, G — B is 0, C is 0)
+    await expect(pie.locator('[data-segment]')).toHaveCount(4);
+  });
+
+  test("CurveConstellation renders a planet per CMC bucket", async ({
+    page,
+  }) => {
+    const cc = page.getByTestId("preview-curveconstellation");
+    // 8 buckets: 0,1,2,3,4,5,6,7+
+    await expect(cc.locator('[data-planet]')).toHaveCount(8);
+  });
+
+  test("CardRow exposes qty, name, role tag, and price", async ({ page }) => {
+    const cr = page.getByTestId("preview-cardrow");
+    await expect(cr.getByText("Slogurk, the Overslime")).toBeVisible();
+    await expect(cr.getByText("COMMANDER")).toBeVisible();
+    await expect(cr.getByText("$4.20")).toBeVisible();
+  });
+
+  test("DeckHero shows eyebrow, title, tagline, and power score", async ({
+    page,
+  }) => {
+    const hero = page.getByTestId("preview-deckhero");
+    await expect(hero.getByText(/READING/i)).toBeVisible();
+    await expect(
+      hero.getByRole("heading", { name: /Slogurk, the Overslime/i }),
+    ).toBeVisible();
+    await expect(hero.getByText(/landfall engine/i)).toBeVisible();
+    await expect(hero.getByText("7.4")).toBeVisible();
+    await expect(hero.getByText(/UPGRADED BRACKET/i)).toBeVisible();
   });
 
   test("Sheet opens and closes via trigger and escape key", async ({ page }) => {

--- a/src/app/preview/page.tsx
+++ b/src/app/preview/page.tsx
@@ -13,6 +13,13 @@ import {
   Textarea,
   type DeckRole,
 } from "@/components/ui";
+import {
+  CardRow,
+  ColorPie,
+  CurveConstellation,
+  DeckHero,
+  ManaCost,
+} from "@/components/deck";
 import styles from "./preview.module.css";
 
 const DECK_ROLES: DeckRole[] = [
@@ -219,6 +226,138 @@ export default function PreviewPage() {
             <StatTile label="AVG WIN" value="T8.2" sub="TURNS" />
             <StatTile label="CURVE" value="2.84" />
           </div>
+        </section>
+
+        {/* ─── ManaCost ─── */}
+        <section className={styles.section} data-testid="preview-manacost">
+          <div className={styles.sectionHead}>
+            <Eyebrow>DOMAIN · 01</Eyebrow>
+            <h2 className={styles.sectionTitle}>ManaCost</h2>
+            <p className={styles.sectionTagline}>
+              Colored pips per WUBRG · numeric · X. Uses --mana-* tokens.
+            </p>
+          </div>
+          <div className={styles.panel}>
+            <div className={styles.column}>
+              <div className={styles.row}>
+                <ManaCost symbols={["2", "U", "G"]} />
+                <ManaCost symbols={["W", "W"]} />
+                <ManaCost symbols={["X", "B", "R"]} />
+                <ManaCost symbols={["3"]} />
+              </div>
+              <div className={styles.row}>
+                <ManaCost symbols={["2", "U", "G"]} size="lg" />
+                <ManaCost symbols={["1", "W", "U", "B", "R", "G"]} size="lg" />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* ─── ColorPie ─── */}
+        <section className={styles.section} data-testid="preview-colorpie">
+          <div className={styles.sectionHead}>
+            <Eyebrow>DOMAIN · 02</Eyebrow>
+            <h2 className={styles.sectionTitle}>ColorPie</h2>
+            <p className={styles.sectionTagline}>
+              SVG donut for color distribution. Empty colors are skipped.
+            </p>
+          </div>
+          <div className={styles.panel}>
+            <ColorPie
+              distribution={{ W: 5, U: 12, B: 0, R: 3, G: 7, C: 0 }}
+              size={120}
+            />
+          </div>
+        </section>
+
+        {/* ─── CurveConstellation ─── */}
+        <section
+          className={styles.section}
+          data-testid="preview-curveconstellation"
+        >
+          <div className={styles.sectionHead}>
+            <Eyebrow>DOMAIN · 03</Eyebrow>
+            <h2 className={styles.sectionTitle}>CurveConstellation</h2>
+            <p className={styles.sectionTagline}>
+              Planet-sized circles per CMC bucket. Radius ∝ √count.
+            </p>
+          </div>
+          <div className={styles.panel}>
+            <CurveConstellation
+              curve={{ buckets: [4, 8, 12, 9, 6, 4, 2, 1] }}
+            />
+          </div>
+        </section>
+
+        {/* ─── CardRow ─── */}
+        <section className={styles.section} data-testid="preview-cardrow">
+          <div className={styles.sectionHead}>
+            <Eyebrow>DOMAIN · 04</Eyebrow>
+            <h2 className={styles.sectionTitle}>CardRow</h2>
+            <p className={styles.sectionTagline}>
+              The list unit. Hover surfaces an accent fill.
+            </p>
+          </div>
+          <div className={styles.panel} style={{ padding: "var(--space-2)" }}>
+            <CardRow
+              qty={1}
+              name="Slogurk, the Overslime"
+              cost={["1", "G", "G", "U"]}
+              role="COMMANDER"
+              price="$4.20"
+              onClick={() => {}}
+            />
+            <CardRow
+              qty={1}
+              name="Crucible of Worlds"
+              cost={["3"]}
+              role="ENGINE"
+              price="$18.00"
+              onClick={() => {}}
+            />
+            <CardRow
+              qty={1}
+              name="Cultivate"
+              cost={["2", "G"]}
+              role="RAMP"
+              price="$0.50"
+              onClick={() => {}}
+            />
+            <CardRow
+              qty={1}
+              name="Brainstorm"
+              cost={["U"]}
+              role="DRAW"
+              price="$0.40"
+              onClick={() => {}}
+            />
+            <CardRow
+              qty={1}
+              name="Cyclonic Rift"
+              cost={["1", "U"]}
+              role="REMOVAL"
+              price="$32.00"
+              onClick={() => {}}
+            />
+          </div>
+        </section>
+
+        {/* ─── DeckHero ─── */}
+        <section className={styles.section} data-testid="preview-deckhero">
+          <div className={styles.sectionHead}>
+            <Eyebrow>DOMAIN · 05</Eyebrow>
+            <h2 className={styles.sectionTitle}>DeckHero</h2>
+            <p className={styles.sectionTagline}>
+              Eyebrow → serif title → italic tagline → gradient power score.
+            </p>
+          </div>
+          <DeckHero
+            eyebrow="READING · 04.27.26"
+            title="Slogurk, the Overslime"
+            tagline='"A landfall engine that wins decisively when it gets there — but watches the door for flood."'
+            score="7.4"
+            scoreMeta="/10 · UPGRADED BRACKET"
+          />
         </section>
 
         {/* ─── Sheet ─── */}

--- a/src/components/deck/CardRow.module.css
+++ b/src/components/deck/CardRow.module.css
@@ -1,0 +1,62 @@
+.row {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto auto auto;
+  align-items: center;
+  gap: var(--space-7);
+  padding: var(--space-4) var(--space-7);
+  border-radius: var(--radius-lg);
+  text-decoration: none;
+  color: var(--ink-primary);
+  background: transparent;
+  border: 1px solid transparent;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.interactive {
+  cursor: pointer;
+}
+
+.interactive:hover,
+.interactive:focus-visible {
+  background: var(--accent-soft);
+  border-color: var(--border-accent);
+  outline: none;
+}
+
+.qty {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  color: var(--ink-tertiary);
+  text-transform: uppercase;
+}
+
+.name {
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--ink-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.price {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  color: var(--ink-secondary);
+  text-transform: uppercase;
+}
+
+@media (max-width: 540px) {
+  .row {
+    grid-template-columns: 28px minmax(0, 1fr) auto;
+  }
+  .cost,
+  .price {
+    display: none;
+  }
+}

--- a/src/components/deck/CardRow.tsx
+++ b/src/components/deck/CardRow.tsx
@@ -1,0 +1,58 @@
+import type { ComponentPropsWithoutRef, MouseEventHandler } from "react";
+import { CardTag, type DeckRole } from "@/components/ui";
+import { ManaCost, type ManaSymbol } from "./ManaCost";
+import styles from "./CardRow.module.css";
+
+export type CardRowProps = Omit<ComponentPropsWithoutRef<"div">, "onClick"> & {
+  qty: number;
+  name: string;
+  cost?: ManaSymbol[];
+  role?: DeckRole;
+  /** Pre-formatted price string, e.g. "$4.20". */
+  price?: string;
+  onClick?: MouseEventHandler<HTMLDivElement | HTMLButtonElement>;
+};
+
+export function CardRow({
+  qty,
+  name,
+  cost,
+  role,
+  price,
+  onClick,
+  className,
+  ...rest
+}: CardRowProps) {
+  const interactive = Boolean(onClick);
+  const classes = [styles.row, interactive && styles.interactive, className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={classes}
+      role={interactive ? "button" : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={
+        interactive
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick?.(e as never);
+              }
+            }
+          : undefined
+      }
+      {...rest}
+    >
+      <span className={styles.qty}>{qty}×</span>
+      <span className={styles.name}>{name}</span>
+      <span className={styles.cost}>
+        {cost && cost.length > 0 ? <ManaCost symbols={cost} /> : null}
+      </span>
+      <span>{role ? <CardTag role={role} /> : null}</span>
+      <span className={styles.price}>{price}</span>
+    </div>
+  );
+}

--- a/src/components/deck/ColorPie.module.css
+++ b/src/components/deck/ColorPie.module.css
@@ -1,0 +1,53 @@
+.wrap {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-10);
+}
+
+.svg {
+  display: block;
+  flex-shrink: 0;
+}
+
+.legend {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: var(--space-2) var(--space-7);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.06em;
+  color: var(--ink-secondary);
+  text-transform: uppercase;
+}
+
+.legendItem {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  flex-shrink: 0;
+}
+
+.dotW {
+  background: var(--mana-w);
+}
+.dotU {
+  background: var(--mana-u);
+}
+.dotB {
+  background: var(--mana-b);
+}
+.dotR {
+  background: var(--mana-r);
+}
+.dotG {
+  background: var(--mana-g);
+}
+.dotC {
+  background: var(--mana-c);
+}

--- a/src/components/deck/ColorPie.tsx
+++ b/src/components/deck/ColorPie.tsx
@@ -1,0 +1,119 @@
+import styles from "./ColorPie.module.css";
+
+export type ColorDistribution = {
+  W?: number;
+  U?: number;
+  B?: number;
+  R?: number;
+  G?: number;
+  C?: number;
+};
+
+export type ColorPieProps = {
+  distribution: ColorDistribution;
+  size?: number;
+  showLegend?: boolean;
+  className?: string;
+};
+
+const ORDER = ["W", "U", "B", "R", "G", "C"] as const;
+const COLOR_VAR: Record<(typeof ORDER)[number], string> = {
+  W: "var(--mana-w)",
+  U: "var(--mana-u)",
+  B: "var(--mana-b)",
+  R: "var(--mana-r)",
+  G: "var(--mana-g)",
+  C: "var(--mana-c)",
+};
+const LABEL: Record<(typeof ORDER)[number], string> = {
+  W: "White",
+  U: "Blue",
+  B: "Black",
+  R: "Red",
+  G: "Green",
+  C: "Colorless",
+};
+const DOT_CLASS: Record<(typeof ORDER)[number], string> = {
+  W: styles.dotW,
+  U: styles.dotU,
+  B: styles.dotB,
+  R: styles.dotR,
+  G: styles.dotG,
+  C: styles.dotC,
+};
+
+export function ColorPie({
+  distribution,
+  size = 96,
+  showLegend = true,
+  className,
+}: ColorPieProps) {
+  const entries = ORDER.map((k) => ({ key: k, value: distribution[k] ?? 0 })).filter(
+    (e) => e.value > 0,
+  );
+  const total = entries.reduce((sum, e) => sum + e.value, 0);
+
+  const radius = 40;
+  const stroke = 14;
+  const cx = 50;
+  const cy = 50;
+  const circumference = 2 * Math.PI * radius;
+
+  let offset = 0;
+
+  return (
+    <div className={[styles.wrap, className].filter(Boolean).join(" ")}>
+      <svg
+        className={styles.svg}
+        width={size}
+        height={size}
+        viewBox="0 0 100 100"
+        role="img"
+        aria-label={`Color distribution: ${entries
+          .map((e) => `${e.value} ${LABEL[e.key]}`)
+          .join(", ")}`}
+      >
+        {/* Faint base ring so an empty pie is still visible */}
+        <circle
+          cx={cx}
+          cy={cy}
+          r={radius}
+          fill="none"
+          stroke="var(--border)"
+          strokeWidth={stroke}
+        />
+        {entries.map((e) => {
+          const fraction = total === 0 ? 0 : e.value / total;
+          const length = fraction * circumference;
+          const seg = (
+            <circle
+              key={e.key}
+              data-segment={e.key}
+              cx={cx}
+              cy={cy}
+              r={radius}
+              fill="none"
+              stroke={COLOR_VAR[e.key]}
+              strokeWidth={stroke}
+              strokeDasharray={`${length} ${circumference - length}`}
+              strokeDashoffset={-offset}
+              transform={`rotate(-90 ${cx} ${cy})`}
+            />
+          );
+          offset += length;
+          return seg;
+        })}
+      </svg>
+      {showLegend && entries.length > 0 ? (
+        <ul className={styles.legend}>
+          {entries.map((e) => (
+            <li key={e.key} className={styles.legendItem}>
+              <span className={[styles.dot, DOT_CLASS[e.key]].join(" ")} aria-hidden="true" />
+              {LABEL[e.key]} · {e.value}
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/deck/CurveConstellation.module.css
+++ b/src/components/deck/CurveConstellation.module.css
@@ -1,0 +1,48 @@
+.wrap {
+  position: relative;
+  width: 100%;
+}
+
+.svg {
+  display: block;
+  width: 100%;
+  height: 140px;
+}
+
+.line {
+  stroke: var(--border-accent);
+  stroke-width: 0.4;
+  stroke-dasharray: 1.2 1.2;
+  fill: none;
+}
+
+.planetGlow {
+  fill: rgba(167, 139, 250, 0.18);
+}
+
+.planet {
+  fill: var(--accent);
+  filter: drop-shadow(0 0 4px rgba(167, 139, 250, 0.6));
+  transition: fill var(--dur-base) var(--ease-out);
+}
+
+.planetEmpty {
+  fill: var(--ink-disabled);
+  filter: none;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 4.4px;
+  fill: var(--ink-tertiary);
+  text-anchor: middle;
+  letter-spacing: 0.05em;
+}
+
+.count {
+  font-family: var(--font-serif);
+  font-size: 6.2px;
+  fill: var(--ink-primary);
+  text-anchor: middle;
+  font-weight: 500;
+}

--- a/src/components/deck/CurveConstellation.tsx
+++ b/src/components/deck/CurveConstellation.tsx
@@ -1,0 +1,83 @@
+import styles from "./CurveConstellation.module.css";
+
+export type ManaCurve = {
+  /** Counts indexed by CMC bucket — index 7 is "7+". Length must be 8. */
+  buckets: [number, number, number, number, number, number, number, number];
+};
+
+export type CurveConstellationProps = {
+  curve: ManaCurve;
+  className?: string;
+};
+
+const LABELS = ["0", "1", "2", "3", "4", "5", "6", "7+"];
+
+const VIEW_W = 200;
+const VIEW_H = 70;
+const PAD_X = 12;
+const TOP = 22;
+const BASE = 50;
+const MIN_R = 1.4;
+const MAX_R = 6.5;
+
+export function CurveConstellation({ curve, className }: CurveConstellationProps) {
+  const max = Math.max(1, ...curve.buckets);
+  const step = (VIEW_W - PAD_X * 2) / (LABELS.length - 1);
+
+  const points = curve.buckets.map((count, i) => {
+    const ratio = count / max;
+    const r = count === 0 ? MIN_R : MIN_R + Math.sqrt(ratio) * (MAX_R - MIN_R);
+    const cx = PAD_X + i * step;
+    // Vertical position: more cards drift toward top (drama)
+    const cy = BASE - ratio * (BASE - TOP);
+    return { count, r, cx, cy };
+  });
+
+  const linePath = points
+    .map((p, i) => `${i === 0 ? "M" : "L"} ${p.cx.toFixed(2)} ${p.cy.toFixed(2)}`)
+    .join(" ");
+
+  const total = curve.buckets.reduce((s, n) => s + n, 0);
+
+  return (
+    <div className={[styles.wrap, className].filter(Boolean).join(" ")}>
+      <svg
+        className={styles.svg}
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={`Mana curve: ${total} cards across ${LABELS.length} CMC buckets`}
+      >
+        <path className={styles.line} d={linePath} />
+        {points.map((p, i) => (
+          <g key={i} data-planet>
+            {p.count > 0 ? (
+              <circle
+                cx={p.cx}
+                cy={p.cy}
+                r={p.r + 2.4}
+                className={styles.planetGlow}
+              />
+            ) : null}
+            <circle
+              cx={p.cx}
+              cy={p.cy}
+              r={p.r}
+              className={[styles.planet, p.count === 0 && styles.planetEmpty]
+                .filter(Boolean)
+                .join(" ")}
+            />
+            {p.count > 0 ? (
+              <text x={p.cx} y={p.cy - p.r - 2.5} className={styles.count}>
+                {p.count}
+              </text>
+            ) : null}
+            <text x={p.cx} y={VIEW_H - 4} className={styles.label}>
+              {LABELS[i]}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/src/components/deck/DeckHero.module.css
+++ b/src/components/deck/DeckHero.module.css
@@ -1,0 +1,67 @@
+.hero {
+  padding: var(--space-14) var(--space-12) var(--space-12);
+  border-radius: var(--radius-3xl);
+  background: var(--accent-soft);
+  border: 1px solid var(--border-accent);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: var(--text-h1);
+  font-weight: var(--weight-medium);
+  letter-spacing: -0.015em;
+  color: var(--ink-primary);
+  margin: var(--space-3) 0 0;
+  line-height: 1.05;
+}
+
+.tagline {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-body-lg);
+  color: var(--ink-secondary);
+  margin: var(--space-7) 0 var(--space-12);
+  line-height: var(--leading-body);
+}
+
+.scoreRow {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-7);
+}
+
+.score {
+  font-family: var(--font-serif);
+  font-size: var(--text-display);
+  font-weight: var(--weight-medium);
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.scoreMeta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+  padding-bottom: var(--space-3);
+}
+
+@media (max-width: 540px) {
+  .hero {
+    padding: var(--space-10) var(--space-8);
+  }
+  .title {
+    font-size: var(--text-h2);
+  }
+  .score {
+    font-size: var(--text-h1);
+  }
+}

--- a/src/components/deck/DeckHero.tsx
+++ b/src/components/deck/DeckHero.tsx
@@ -1,0 +1,38 @@
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { Eyebrow } from "@/components/ui";
+import styles from "./DeckHero.module.css";
+
+export type DeckHeroProps = ComponentPropsWithoutRef<"section"> & {
+  eyebrow: ReactNode;
+  title: ReactNode;
+  tagline?: ReactNode;
+  /** Numeric score, typically 0–10. */
+  score: number | string;
+  /** Right-side meta after the score, e.g. "/10 · UPGRADED BRACKET". */
+  scoreMeta?: ReactNode;
+};
+
+export function DeckHero({
+  eyebrow,
+  title,
+  tagline,
+  score,
+  scoreMeta,
+  className,
+  ...rest
+}: DeckHeroProps) {
+  const classes = [styles.hero, className].filter(Boolean).join(" ");
+  return (
+    <section className={classes} {...rest}>
+      <Eyebrow>{eyebrow}</Eyebrow>
+      <h1 className={styles.title}>{title}</h1>
+      {tagline ? <p className={styles.tagline}>{tagline}</p> : null}
+      <div className={styles.scoreRow}>
+        <div className={styles.score} aria-label={`Score ${score}`}>
+          {score}
+        </div>
+        {scoreMeta ? <div className={styles.scoreMeta}>{scoreMeta}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/deck/ManaCost.module.css
+++ b/src/components/deck/ManaCost.module.css
@@ -1,0 +1,50 @@
+.cost {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  vertical-align: middle;
+}
+
+.pip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-sans);
+  font-size: 9.5px;
+  font-weight: var(--weight-bold);
+  color: rgba(0, 0, 0, 0.78);
+  letter-spacing: 0;
+  line-height: 1;
+  flex-shrink: 0;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.18),
+    0 1px 1px rgba(0, 0, 0, 0.35);
+}
+
+.lg .pip {
+  width: 22px;
+  height: 22px;
+  font-size: 12px;
+}
+
+.w {
+  background: var(--mana-w);
+}
+.u {
+  background: var(--mana-u);
+}
+.b {
+  background: var(--mana-b);
+}
+.r {
+  background: var(--mana-r);
+}
+.g {
+  background: var(--mana-g);
+}
+.c {
+  background: var(--mana-c);
+}

--- a/src/components/deck/ManaCost.tsx
+++ b/src/components/deck/ManaCost.tsx
@@ -1,0 +1,98 @@
+import styles from "./ManaCost.module.css";
+
+export type ManaSymbol = "W" | "U" | "B" | "R" | "G" | "C" | "X" | string;
+
+export type ManaCostProps = {
+  /** Symbols in order, e.g. ["2", "U", "G"]. */
+  symbols: ManaSymbol[];
+  size?: "md" | "lg";
+  className?: string;
+};
+
+const COLOR_KEY: Record<string, string> = {
+  W: "w",
+  U: "u",
+  B: "b",
+  R: "r",
+  G: "g",
+  C: "c",
+};
+
+const COLOR_LABEL: Record<string, string> = {
+  W: "white",
+  U: "blue",
+  B: "black",
+  R: "red",
+  G: "green",
+  C: "colorless",
+};
+
+function classify(symbol: string): { className: string; label: string; display: string } {
+  const up = symbol.toUpperCase();
+  if (up in COLOR_KEY) {
+    return {
+      className: styles[COLOR_KEY[up]],
+      label: COLOR_LABEL[up],
+      display: up,
+    };
+  }
+  if (up === "X") {
+    return { className: styles.c, label: "X", display: "X" };
+  }
+  // Generic numeric (treat as colorless visually)
+  return { className: styles.c, label: "generic", display: up };
+}
+
+function buildAriaLabel(symbols: ManaSymbol[]): string {
+  const colored: Record<string, number> = {};
+  let generic = 0;
+  let xCount = 0;
+  for (const s of symbols) {
+    const up = String(s).toUpperCase();
+    if (up in COLOR_LABEL) {
+      colored[up] = (colored[up] ?? 0) + 1;
+    } else if (up === "X") {
+      xCount += 1;
+    } else {
+      const n = Number(up);
+      if (!Number.isNaN(n)) generic += n;
+    }
+  }
+  const parts: string[] = [];
+  if (generic > 0) parts.push(`${generic} generic`);
+  if (xCount > 0) parts.push(`${xCount} X`);
+  for (const k of ["W", "U", "B", "R", "G", "C"]) {
+    if (colored[k]) {
+      parts.push(`${colored[k]} ${COLOR_LABEL[k]}`);
+    }
+  }
+  return parts.length === 0 ? "no mana cost" : `Mana cost: ${parts.join(", ")}`;
+}
+
+export function ManaCost({ symbols, size = "md", className }: ManaCostProps) {
+  const classes = [styles.cost, size === "lg" && styles.lg, className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <span
+      className={classes}
+      role="img"
+      aria-label={buildAriaLabel(symbols)}
+    >
+      {symbols.map((s, i) => {
+        const { className: pipClass, display } = classify(String(s));
+        return (
+          <span
+            key={i}
+            data-pip
+            className={[styles.pip, pipClass].filter(Boolean).join(" ")}
+            aria-hidden="true"
+          >
+            {display}
+          </span>
+        );
+      })}
+    </span>
+  );
+}

--- a/src/components/deck/index.ts
+++ b/src/components/deck/index.ts
@@ -1,0 +1,10 @@
+export { ManaCost } from "./ManaCost";
+export type { ManaCostProps, ManaSymbol } from "./ManaCost";
+export { ColorPie } from "./ColorPie";
+export type { ColorPieProps, ColorDistribution } from "./ColorPie";
+export { CurveConstellation } from "./CurveConstellation";
+export type { CurveConstellationProps, ManaCurve } from "./CurveConstellation";
+export { CardRow } from "./CardRow";
+export type { CardRowProps } from "./CardRow";
+export { DeckHero } from "./DeckHero";
+export type { DeckHeroProps } from "./DeckHero";


### PR DESCRIPTION
## Summary

Adds the five **Astral domain components** in `src/components/deck/` and demonstrates each in `/preview`. Pure addition — no existing app components are touched.

Follows up [#86](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/86) (tokens), [#87](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/87) (primitives), [#88](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/88) (cosmos shell).

## What's included

| Component | What it renders | Tokens / styling |
|---|---|---|
| `ManaCost` | `["2","U","G"]` → 3 colored pips, sizes `md`/`lg` | `--mana-w/u/b/r/g/c`; aria-label like *"Mana cost: 2 generic, 1 blue, 1 green"* |
| `ColorPie` | SVG donut for `{ W: 5, U: 12, B: 0, R: 3, G: 7, C: 0 }`; empty colors skipped; optional mono legend | Stroke segments using `--mana-*`; faint base ring keeps zero-pie visible |
| `CurveConstellation` | "Planet" SVG per CMC bucket (0–7+); radius ∝ √count; faint dashed line connects them | `--accent` planets with violet glow; empty buckets show a small `--ink-disabled` dot |
| `CardRow` | qty · name · `ManaCost` · `CardTag` · price; interactive when given `onClick` | Hover/focus surfaces `--accent-soft` fill; mobile collapses cost + price |
| `DeckHero` | Eyebrow → Spectral title → italic tagline → gradient-text score + mono meta | Score uses `--accent-gradient` via `background-clip: text` |

All exported via `src/components/deck/index.ts`. Each component co-locates a `.module.css` referencing **semantic tokens only**.

## TDD

`e2e/design-system-preview.spec.ts` adds five specs (written before implementation):

- `ManaCost` renders 3 pips for `[\"2\",\"U\",\"G\"]` and emits the expected aria-label
- `ColorPie` renders one `[data-segment]` per non-zero color (4 in the demo)
- `CurveConstellation` renders 8 `[data-planet]` groups (one per bucket)
- `CardRow` exposes name, role tag, and price text
- `DeckHero` renders eyebrow / title heading / tagline / score / meta

```
✓ 14 passed (5.0s)   # full design-system-preview suite
✓ 4 passed           # cosmos-shell suite
✓ 2462 unit tests passed
```

Production build is clean.

## Visual

Visit `http://localhost:3000/preview` — the new sections appear after StatTile under headings *DOMAIN · 01 … 05*.

## What's next

Per `design-system/CLAUDE.md`, the final phase is **screen migration** — the home import flow, `/reading/*`, etc. — replacing the existing slate Tailwind components with the new shell + primitives + domain components in cohesive routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)