### PR TITLE
feat(home): migrate DeckInput to Astral primitives + tokens

### DIFF
--- a/src/components/DeckInput.module.css
+++ b/src/components/DeckInput.module.css
@@ -1,0 +1,189 @@
+.panel {
+  width: 100%;
+  border-radius: var(--card-radius);
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  padding: var(--card-padding);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.tabBar {
+  display: flex;
+  gap: var(--space-2);
+  margin-bottom: var(--space-12);
+  padding: var(--space-2);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+
+.tab {
+  flex: 1;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3) var(--space-7);
+  border: none;
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--ink-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    color var(--dur-base) var(--ease-out),
+    background var(--dur-base) var(--ease-out);
+}
+
+.tab:hover:not(:disabled) {
+  color: var(--ink-primary);
+  background: var(--surface-2-hi);
+}
+
+.tab:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.tab[aria-selected="true"] {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.tab:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-10);
+}
+
+.guide {
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: var(--radius-lg);
+  padding: var(--space-7) var(--space-8);
+  font-size: var(--text-sm);
+  color: var(--ink-secondary);
+  line-height: var(--leading-snug);
+}
+
+.guideTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--space-4);
+}
+
+.guideList {
+  list-style: decimal inside;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.guideAccent {
+  color: var(--accent);
+  font-family: var(--font-mono);
+}
+
+.zoneGuide {
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-8);
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+}
+
+.zoneSummary {
+  cursor: pointer;
+  user-select: none;
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-secondary);
+  list-style: none;
+  outline: none;
+}
+
+.zoneSummary::-webkit-details-marker {
+  display: none;
+}
+
+.zoneSummary::before {
+  content: "▸";
+  display: inline-block;
+  margin-right: var(--space-3);
+  color: var(--accent);
+  transition: transform var(--dur-base) var(--ease-out);
+}
+
+.zoneGuide[open] .zoneSummary::before {
+  transform: rotate(90deg);
+}
+
+.zoneSummary:hover,
+.zoneSummary:focus-visible {
+  color: var(--ink-primary);
+}
+
+.zoneBody {
+  margin-top: var(--space-7);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  font-size: var(--text-sm);
+  color: var(--ink-secondary);
+  line-height: var(--leading-snug);
+}
+
+.zoneBody ul {
+  list-style: disc inside;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.zoneBody code {
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+
+.label {
+  display: block;
+  margin-bottom: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-secondary);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-5);
+}
+
+.actionsLeft {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-5);
+}

--- a/src/components/DeckInput.tsx
+++ b/src/components/DeckInput.tsx
@@ -3,6 +3,8 @@
 import { useState, useRef, useCallback, type FormEvent } from "react";
 import CommanderInput from "@/components/CommanderInput";
 import CardLookupInput from "@/components/CardLookupInput";
+import { Button, Textarea } from "@/components/ui";
+import styles from "./DeckInput.module.css";
 
 type ImportTab = "manual" | "moxfield" | "archidekt";
 
@@ -154,16 +156,9 @@ export default function DeckInput({
   };
 
   return (
-    <section
-      aria-label="Deck import"
-      className="w-full rounded-xl border border-slate-700 bg-slate-800/50 p-6"
-    >
+    <section aria-label="Deck import" className={styles.panel}>
       {/* Tab bar */}
-      <div
-        role="tablist"
-        aria-label="Deck import method"
-        className="mb-6 flex rounded-lg bg-slate-900 p-1"
-      >
+      <div role="tablist" aria-label="Deck import method" className={styles.tabBar}>
         {tabs.map((tab) => (
           <button
             key={tab.key}
@@ -178,11 +173,7 @@ export default function DeckInput({
               setCommanders([]);
             }}
             onKeyDown={handleTabKeyDown}
-            className={`flex-1 min-h-[44px] rounded-md px-3 py-2.5 sm:px-4 sm:py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 ${
-              activeTab === tab.key
-                ? "bg-slate-600 text-white"
-                : "text-slate-300 hover:text-white"
-            }`}
+            className={styles.tab}
             disabled={loading}
           >
             {tab.label}
@@ -198,25 +189,20 @@ export default function DeckInput({
         <form
           onSubmit={handleSubmit}
           aria-busy={loading}
-          className="flex flex-col gap-4"
+          className={styles.form}
         >
           {/* Moxfield export instructions */}
           {activeTab === "moxfield" && (
-            <div
-              data-testid="moxfield-export-guide"
-              className="rounded-lg border border-slate-600 bg-slate-900/50 px-4 py-3 text-sm text-slate-300"
-            >
-              <p className="mb-2 font-medium text-white">
-                How to import from Moxfield:
-              </p>
-              <ol className="list-inside list-decimal space-y-1 text-slate-400">
+            <div data-testid="moxfield-export-guide" className={styles.guide}>
+              <p className={styles.guideTitle}>How to import from Moxfield</p>
+              <ol className={styles.guideList}>
                 <li>
                   Open your deck on{" "}
-                  <span className="text-purple-400">moxfield.com</span>
+                  <span className={styles.guideAccent}>moxfield.com</span>
                 </li>
                 <li>
-                  Click <strong className="text-slate-300">Export</strong> →{" "}
-                  <strong className="text-slate-300">Copy for MTGO</strong>
+                  Click <strong>Export</strong> →{" "}
+                  <strong>Copy for MTGO</strong>
                 </li>
                 <li>Paste the copied text below</li>
               </ol>
@@ -242,43 +228,36 @@ export default function DeckInput({
 
           {/* Zone format guide (manual tab only) */}
           {activeTab === "manual" && (
-            <details
-              data-testid="zone-format-guide"
-              className="rounded-lg border border-slate-700 bg-slate-900/50 px-4 py-2 text-sm text-slate-400"
-            >
-              <summary className="cursor-pointer select-none font-medium text-slate-300 hover:text-white">
+            <details data-testid="zone-format-guide" className={styles.zoneGuide}>
+              <summary className={styles.zoneSummary}>
                 Zone headers &amp; decklist format
               </summary>
-              <div className="mt-2 space-y-2">
+              <div className={styles.zoneBody}>
                 <p>
                   You can optionally organize your decklist into zones using
                   headers. Each header marks the start of a section — all cards
                   below it belong to that zone until the next header.
                 </p>
-                <ul className="list-inside list-disc space-y-1 text-slate-400">
+                <ul>
                   <li>
-                    <code className="text-purple-400">COMMANDER:</code> — your
-                    commander(s), max 2
+                    <code>COMMANDER:</code> — your commander(s), max 2
                   </li>
                   <li>
-                    <code className="text-purple-400">MAINBOARD:</code> — the
-                    main deck (default if no header)
+                    <code>MAINBOARD:</code> — the main deck (default if no
+                    header)
                   </li>
                   <li>
-                    <code className="text-purple-400">SIDEBOARD:</code> — sideboard
-                    cards
+                    <code>SIDEBOARD:</code> — sideboard cards
                   </li>
                   <li>
-                    <code className="text-purple-400">COMPANION:</code> — treated
-                    as sideboard
+                    <code>COMPANION:</code> — treated as sideboard
                   </li>
                 </ul>
                 <p>
-                  Cards added via search are always placed in the mainboard.
-                  If no headers are used, all cards default to mainboard.
-                  You can also select your commander using the input above
-                  instead of a <code className="text-purple-400">COMMANDER:</code>{" "}
-                  header.
+                  Cards added via search are always placed in the mainboard. If
+                  no headers are used, all cards default to mainboard. You can
+                  also select your commander using the input above instead of a{" "}
+                  <code>COMMANDER:</code> header.
                 </p>
               </div>
             </details>
@@ -286,46 +265,43 @@ export default function DeckInput({
 
           {/* Decklist textarea */}
           <div>
-            <label
-              htmlFor="decklist"
-              className="mb-1 block text-sm font-medium text-slate-300"
-            >
+            <label htmlFor="decklist" className={styles.label}>
               Decklist
             </label>
-            <textarea
+            <Textarea
               ref={textareaRef}
               id="decklist"
               value={textValue}
               onChange={(e) => setTextValue(e.target.value)}
               placeholder={placeholders[activeTab]}
               rows={10}
-              className="w-full rounded-lg border border-slate-600 bg-slate-900 px-4 py-2 font-mono text-sm text-white placeholder-slate-400 focus:border-purple-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500/50 disabled:cursor-not-allowed disabled:opacity-50"
+              mono
               disabled={loading}
               required
             />
           </div>
 
           {/* Actions */}
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div>
+          <div className={styles.actions}>
+            <div className={styles.actionsLeft}>
               {activeTab === "manual" && (
-                <button
+                <Button
                   type="button"
+                  variant="secondary"
                   onClick={loadExample}
                   disabled={loading}
-                  className="rounded-lg border border-slate-600 px-4 py-2 text-sm font-medium text-slate-300 hover:bg-slate-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   Load Example
-                </button>
+                </Button>
               )}
             </div>
-            <button
+            <Button
               type="submit"
+              variant="primary"
               disabled={loading || !textValue.trim()}
-              className="rounded-lg bg-purple-600 px-6 py-2 text-sm font-medium text-white hover:bg-purple-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {loading ? "Loading..." : "Import Deck"}
-            </button>
+            </Button>
           </div>
         </form>
       </div>


### PR DESCRIPTION
## Summary

Migrates `src/components/DeckInput.tsx` — the 3-tab Manual / Moxfield / Archidekt import form — from slate Tailwind to Astral primitives and tokens. Behavior, ARIA, and every test-contract attribute are preserved exactly.

Follows up [#90](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/90) (home chrome).

## Preserved (load-bearing for e2e)

- `<label htmlFor=\"decklist\">Decklist</label>` — for `getByLabel(\"Decklist\")`
- `<textarea id=\"decklist\">` — preserves label association
- Button text: `\"Import Deck\"` / `\"Loading...\"` / `\"Load Example\"`
- `data-testid=\"moxfield-export-guide\"`, `data-testid=\"zone-format-guide\"`
- `role=\"tablist\"` / `role=\"tab\"` / `aria-selected` / `aria-controls`
- `role=\"tabpanel\"` / `aria-labelledby`
- IDs `tab-manual` / `tab-moxfield` / `tab-archidekt` (focus management)
- Tab labels `\"Manual Import\"` / `\"Moxfield\"` / `\"Archidekt\"`
- Arrow / Home / End keyboard navigation between tabs
- All form logic — card lookup consolidation, mainboard zone insertion, etc.

## Visual changes

| Element | Before | After |
|---|---|---|
| Outer panel | `<section>` slate-700 / slate-800-50 | `<section>` with token-driven CSS (`--card-bg`, `--card-border`, `blur-sm`) — same DOM, different paint |
| Tab bar | slate-900 holder, slate-600 active | `--surface-2` holder, mono uppercase tabs, `--accent-soft` + `--accent` active |
| Moxfield guide | slate-600 panel, slate-300 list | dark-rgba panel with mono-accent eyebrow title |
| Zone format guide | slate-700 `<details>`, slate-300 summary | mono uppercase summary, accent caret that rotates on open, mono-accent `<code>` tags |
| Decklist | bespoke slate-900 textarea | `<Textarea mono>` primitive (canonical focus ring + invalid + disabled) |
| Submit | bg-purple-600 | `<Button variant=\"primary\">` (gradient + glow on hover) |
| Load Example | slate-600 outline | `<Button variant=\"secondary\">` (`--surface-2`) |
| Decklist label | slate-300 body type | mono uppercase eyebrow |

## TDD verification

- **deck-import + tab-navigation + deck-display + home-chrome + cosmos-shell + design-system-preview: 37 passed**
- **2462 unit tests passed**
- Production build clean

```
✓ 37 passed (12.1s)
✓ 2462 passed (7.1s)
```

## Out of scope

`DeckImportSection.tsx` (628 lines — the surrounding error/warning banners, results panels, and overall import orchestration) is intentionally untouched here. That's a focused follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)