### PR TITLE
feat(deck): migrate DeckSidebar + DeckDrawer to Astral tokens

### DIFF
--- a/src/components/DeckSidebar.module.css
+++ b/src/components/DeckSidebar.module.css
@@ -1,0 +1,582 @@
+/* ─── Desktop sidebar wrapper ─── */
+.sidebar {
+  display: none;
+  flex-direction: column;
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  flex-shrink: 0;
+  background: rgba(10, 10, 24, 0.65);
+  border-right: 1px solid var(--border);
+  backdrop-filter: blur(var(--blur-md));
+  -webkit-backdrop-filter: blur(var(--blur-md));
+  overflow: hidden;
+  transition: width var(--dur-base) var(--ease-out);
+}
+
+@media (min-width: 768px) {
+  .sidebar {
+    display: flex;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar {
+    transition: none;
+  }
+}
+
+.collapseToggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 40px;
+  border: none;
+  border-top: 1px solid var(--border);
+  background: transparent;
+  color: var(--ink-tertiary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    color var(--dur-base) var(--ease-out),
+    background var(--dur-base) var(--ease-out);
+}
+
+.collapseToggle:hover {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.collapseToggle:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
+/* ─── Mobile drawer ─── */
+.drawer {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: block;
+}
+
+@media (min-width: 768px) {
+  .drawer {
+    display: none;
+  }
+}
+
+.drawerClosed {
+  pointer-events: none;
+}
+
+.drawerOverlay {
+  position: absolute;
+  inset: 0;
+  background: var(--surface-scrim);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+  transition: opacity var(--dur-base) var(--ease-out);
+}
+
+.drawerOpen .drawerOverlay {
+  opacity: 1;
+}
+
+.drawerClosed .drawerOverlay {
+  opacity: 0;
+}
+
+.drawerPanel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: min(280px, 85vw);
+  background: var(--sheet-bg);
+  border-right: 1px solid var(--sheet-border);
+  box-shadow: 20px 0 60px rgba(0, 0, 0, 0.6);
+  transition: transform var(--dur-slow) var(--ease-out);
+}
+
+.drawerOpen .drawerPanel {
+  transform: translateX(0);
+}
+
+.drawerClosed .drawerPanel {
+  transform: translateX(-100%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .drawerOverlay,
+  .drawerPanel {
+    transition: none;
+  }
+}
+
+/* ─── Inner content column ─── */
+.content {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* ─── Identity block ─── */
+.identity {
+  padding: var(--space-7) var(--space-7) var(--space-6);
+  border-bottom: 1px solid var(--border);
+}
+
+.identityHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.identityMain {
+  min-width: 0;
+}
+
+.deckTitle {
+  font-family: var(--font-serif);
+  font-size: var(--text-body-lg);
+  font-weight: var(--weight-medium);
+  color: var(--ink-primary);
+  letter-spacing: var(--tracking-tight);
+  margin: 0;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.commanderText {
+  margin: var(--space-1) 0 0;
+  font-size: var(--text-sm);
+  color: var(--ink-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.metaRow {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1) var(--space-5);
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}
+
+.metaLink {
+  color: var(--accent);
+  text-decoration: none;
+  border-radius: var(--radius-xs);
+  text-transform: uppercase;
+}
+
+.metaLink:hover {
+  text-decoration: underline;
+}
+
+.metaLink:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.identityActions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+}
+
+.bracketBadge {
+  display: inline-block;
+  margin-top: var(--space-5);
+  padding: var(--space-1) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.06em;
+  font-weight: var(--weight-semibold);
+  color: var(--ink-secondary);
+  text-transform: uppercase;
+}
+
+.collapsedStatusRow {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-5) var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+
+.closeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  color: var(--ink-tertiary);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.closeButton:hover {
+  color: var(--ink-primary);
+  background: var(--surface-2-hi);
+}
+
+.closeButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+@media (min-width: 768px) {
+  .closeButton {
+    display: none;
+  }
+}
+
+/* ─── Themes pills row ─── */
+.themesRow {
+  padding: var(--space-5) var(--space-7);
+  border-bottom: 1px solid var(--border);
+}
+
+.themesList {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+/* ─── Hand stats ─── */
+.handStatsRow {
+  padding: var(--space-5) var(--space-7);
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+/* ─── Nav (tablist) ─── */
+.nav {
+  flex: 1;
+  padding: var(--space-5) var(--space-3);
+}
+
+.category {
+  margin-bottom: var(--space-3);
+}
+
+.categoryToggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  font-weight: var(--weight-medium);
+  color: var(--ink-tertiary);
+  cursor: pointer;
+  transition: color var(--dur-fast) var(--ease-out);
+}
+
+.categoryToggle:hover {
+  color: var(--ink-secondary);
+}
+
+.categoryToggle:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.categoryGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.categoryGroupCollapsed {
+  align-items: center;
+  padding: var(--space-2) 0;
+  gap: var(--space-2);
+}
+
+/* ─── Nav button ─── */
+.navButton {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  width: 100%;
+  padding: var(--space-4);
+  padding-left: calc(var(--space-4) - 2px);
+  border: none;
+  border-left: 2px solid transparent;
+  border-radius: var(--radius-md);
+  background: transparent;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--ink-secondary);
+  cursor: pointer;
+  text-align: left;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.navButton:hover:not(:disabled) {
+  color: var(--ink-primary);
+  background: var(--surface-2);
+}
+
+.navButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.navButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.navButtonActive {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-left-color: var(--accent);
+}
+
+.navButtonActive:hover:not(:disabled) {
+  background: var(--accent-soft-hi);
+  color: var(--accent);
+}
+
+.navButtonCollapsed {
+  width: 36px;
+  padding: var(--space-3);
+  justify-content: center;
+  border-left: none;
+  border-radius: var(--radius-md);
+}
+
+.navIcon {
+  flex-shrink: 0;
+  display: inline-flex;
+}
+
+.navLabel {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.navBadge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--accent);
+  color: var(--ink-on-accent);
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.04em;
+  line-height: 1;
+}
+
+/* ─── Share section ─── */
+.shareSection {
+  padding: var(--space-5) var(--space-3);
+  border-top: 1px solid var(--border);
+}
+
+.copyFeedback {
+  display: block;
+  margin-bottom: var(--space-2);
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--status-ok);
+}
+
+.shareWrap {
+  position: relative;
+}
+
+.shareButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  width: 100%;
+  height: 32px;
+  padding: 0 var(--space-7);
+  border: none;
+  border-radius: var(--radius-md);
+  background: var(--accent-gradient);
+  color: var(--ink-on-accent);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition:
+    box-shadow var(--dur-base) var(--ease-out),
+    transform var(--dur-fast) var(--ease-out);
+}
+
+.shareButton:hover:not(:disabled) {
+  box-shadow: var(--glow-md);
+}
+
+.shareButton:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+.shareButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.shareButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.shareButtonCollapsed {
+  width: 36px;
+  padding: 0;
+}
+
+.shareMenu {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  margin-bottom: var(--space-2);
+  width: 220px;
+  background: var(--surface-overlay);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-xl);
+  padding: var(--space-2);
+  box-shadow: var(--shadow-lg);
+  z-index: 40;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.shareMenuItem {
+  display: block;
+  width: 100%;
+  padding: var(--space-4) var(--space-6);
+  border: none;
+  background: transparent;
+  border-radius: var(--radius-md);
+  text-align: left;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--ink-secondary);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.shareMenuItem:hover:not(:disabled) {
+  background: var(--accent-soft);
+  color: var(--ink-primary);
+}
+
+.shareMenuItem:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
+.shareMenuItem:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.shareMenuDivider {
+  margin: var(--space-2) 0;
+  border: 0;
+  border-top: 1px solid var(--border);
+}
+
+/* ─── Enrichment status ─── */
+.enrichmentStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.enrichmentLoading {
+  color: var(--accent);
+}
+
+.enrichmentOk {
+  color: var(--status-ok);
+}
+
+.enrichmentError {
+  color: var(--status-watch);
+}
+
+.enrichmentSpinner {
+  width: 14px;
+  height: 14px;
+  animation: spin 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .enrichmentSpinner {
+    animation: none;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/DeckSidebar.tsx
+++ b/src/components/DeckSidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/export-report";
 import { useSidebarCollapsed } from "@/hooks/useSidebarCollapsed";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import styles from "./DeckSidebar.module.css";
 
 // ---------------------------------------------------------------------------
 // Inline SVG icons (Heroicons outline 20x20)
@@ -104,10 +105,13 @@ function IconChevronDown({ rotated }: { rotated?: boolean }) {
       fill="none"
       stroke="currentColor"
       strokeWidth="1.5"
-      width="16"
-      height="16"
+      width="14"
+      height="14"
       aria-hidden="true"
-      className={`transition-transform duration-200 motion-reduce:transition-none ${rotated ? "rotate-180" : ""}`}
+      style={{
+        transform: rotated ? "rotate(180deg)" : undefined,
+        transition: "transform var(--dur-base) var(--ease-out)",
+      }}
     >
       <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
     </svg>
@@ -124,7 +128,7 @@ function IconShare() {
 
 function IconX() {
   return (
-    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" width="20" height="20" aria-hidden="true">
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" width="18" height="18" aria-hidden="true">
       <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
     </svg>
   );
@@ -160,10 +164,13 @@ function EnrichmentStatus({
 }) {
   if (enrichLoading) {
     return (
-      <span className="flex items-center gap-1 text-xs text-purple-300" title="Loading card details...">
-        <svg className="h-3.5 w-3.5 animate-spin motion-reduce:hidden" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+      <span
+        className={`${styles.enrichmentStatus} ${styles.enrichmentLoading}`}
+        title="Loading card details..."
+      >
+        <svg className={styles.enrichmentSpinner} viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" opacity="0.25" />
+          <path fill="currentColor" opacity="0.85" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
         </svg>
         <span className="sr-only">Loading card details</span>
       </span>
@@ -171,8 +178,11 @@ function EnrichmentStatus({
   }
   if (!enrichLoading && cardMap && !enrichError) {
     return (
-      <span className="text-xs text-green-400" title="Card details loaded">
-        <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <span
+        className={`${styles.enrichmentStatus} ${styles.enrichmentOk}`}
+        title="Card details loaded"
+      >
+        <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fillRule="evenodd" d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z" clipRule="evenodd" />
         </svg>
         <span className="sr-only">Card details loaded</span>
@@ -181,8 +191,11 @@ function EnrichmentStatus({
   }
   if (!enrichLoading && enrichError) {
     return (
-      <span className="text-xs text-amber-400" title="Card enrichment error">
-        <svg className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <span
+        className={`${styles.enrichmentStatus} ${styles.enrichmentError}`}
+        title="Card enrichment error"
+      >
+        <svg width="14" height="14" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
           <path fillRule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd" />
         </svg>
         <span className="sr-only">Card enrichment error</span>
@@ -217,6 +230,14 @@ function NavButton({
 }) {
   const icon = TAB_ICONS[tabKey];
 
+  const classes = [
+    styles.navButton,
+    isActive && styles.navButtonActive,
+    collapsed && styles.navButtonCollapsed,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
     <button
       id={`tab-deck-${tabKey}`}
@@ -229,21 +250,13 @@ function NavButton({
       onKeyDown={onKeyDown}
       disabled={isDisabled}
       title={collapsed ? label : undefined}
-      className={`group flex w-full items-center gap-3 rounded-md px-2 py-2 text-sm font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 disabled:opacity-40 disabled:cursor-not-allowed ${
-        isActive
-          ? "bg-purple-600/20 text-purple-300 border-l-2 border-purple-500 pl-[calc(0.5rem-2px)]"
-          : "text-slate-300 hover:text-white hover:bg-slate-800 border-l-2 border-transparent pl-[calc(0.5rem-2px)]"
-      }`}
+      className={classes}
     >
-      <span className="shrink-0">{icon}</span>
+      <span className={styles.navIcon}>{icon}</span>
       {!collapsed && (
-        <span className="min-w-0 truncate flex items-center gap-1.5">
+        <span className={styles.navLabel}>
           {label}
-          {badge && (
-            <span className="bg-purple-600/80 px-1.5 py-0.5 text-[10px] font-bold text-purple-100 rounded-full leading-none">
-              {badge}
-            </span>
-          )}
+          {badge && <span className={styles.navBadge}>{badge}</span>}
         </span>
       )}
     </button>
@@ -311,10 +324,8 @@ function ShareMenu({
   const disabled = !analysisResults || enrichLoading;
 
   return (
-    <div className="relative">
-      {copyFeedback && (
-        <span className="block mb-1 text-xs text-green-400 text-center">{copyFeedback}</span>
-      )}
+    <div className={styles.shareWrap}>
+      {copyFeedback && <span className={styles.copyFeedback}>{copyFeedback}</span>}
       <button
         ref={buttonRef}
         type="button"
@@ -324,7 +335,9 @@ function ShareMenu({
         aria-expanded={open}
         aria-haspopup="true"
         title={disabled ? "Waiting for card enrichment..." : "Share deck analysis"}
-        className={`flex items-center gap-1.5 rounded-md bg-purple-600 px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-purple-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 disabled:opacity-40 disabled:cursor-not-allowed ${collapsed ? "w-9 px-2 justify-center" : "w-full justify-center"}`}
+        className={[styles.shareButton, collapsed && styles.shareButtonCollapsed]
+          .filter(Boolean)
+          .join(" ")}
       >
         <IconShare />
         {!collapsed && "Share"}
@@ -335,13 +348,13 @@ function ShareMenu({
           ref={menuRef}
           data-testid="share-menu"
           aria-label="Share options"
-          className="absolute bottom-full left-0 mb-1 w-52 rounded-lg border border-slate-700 bg-slate-800 py-1 shadow-lg z-40"
+          className={styles.shareMenu}
         >
           <button
             type="button"
             onClick={() => { onCopyMarkdown(); setOpen(false); }}
             disabled={!analysisResults}
-            className="w-full px-3 py-2 text-left text-sm text-slate-300 hover:bg-slate-700 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed"
+            className={styles.shareMenuItem}
           >
             Copy as Markdown
           </button>
@@ -349,7 +362,7 @@ function ShareMenu({
             type="button"
             onClick={() => { onCopyJson(); setOpen(false); }}
             disabled={!analysisResults}
-            className="w-full px-3 py-2 text-left text-sm text-slate-300 hover:bg-slate-700 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed"
+            className={styles.shareMenuItem}
           >
             Copy as JSON
           </button>
@@ -357,7 +370,7 @@ function ShareMenu({
             type="button"
             onClick={() => { onDiscord(); setOpen(false); }}
             disabled={!analysisResults}
-            className="w-full px-3 py-2 text-left text-sm text-slate-300 hover:bg-slate-700 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed"
+            className={styles.shareMenuItem}
           >
             Export to Discord...
           </button>
@@ -366,16 +379,16 @@ function ShareMenu({
             onClick={() => { onSaveImage(); setOpen(false); }}
             disabled={!analysisResults}
             data-testid="save-as-image-button"
-            className="w-full px-3 py-2 text-left text-sm text-slate-300 hover:bg-slate-700 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed"
+            className={styles.shareMenuItem}
           >
             Save as Image
           </button>
-          <div className="border-t border-slate-700 my-1" />
+          <hr className={styles.shareMenuDivider} />
           <button
             type="button"
             onClick={() => { onShareLink(); setOpen(false); }}
             disabled={disabled}
-            className="w-full px-3 py-2 text-left text-sm text-slate-300 hover:bg-slate-700 hover:text-white disabled:opacity-40 disabled:cursor-not-allowed"
+            className={styles.shareMenuItem}
           >
             Copy Share Link
           </button>
@@ -544,21 +557,21 @@ function SidebarContent({
   };
 
   return (
-    <div className="flex flex-col h-full overflow-y-auto overflow-x-hidden">
+    <div className={styles.content}>
       {/* Deck identity */}
       {!collapsed && (
-        <div className="px-3 pt-4 pb-3 border-b border-slate-700/60">
-          <div className="flex items-start justify-between gap-2">
-            <div className="min-w-0">
-              <h2 className="text-sm font-bold text-white truncate" title={deck.name}>
+        <div className={styles.identity}>
+          <div className={styles.identityHeader}>
+            <div className={styles.identityMain}>
+              <h2 className={styles.deckTitle} title={deck.name}>
                 {deck.name}
               </h2>
               {commanderNames.length > 0 && (
-                <p className="mt-0.5 text-xs text-slate-300 truncate" title={commanderNames.join(" & ")}>
+                <p className={styles.commanderText} title={commanderNames.join(" & ")}>
                   {commanderNames.join(" & ")}
                 </p>
               )}
-              <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 mt-1 text-xs text-slate-400">
+              <div className={styles.metaRow}>
                 <span>
                   via{" "}
                   {deck.url ? (
@@ -566,19 +579,19 @@ function SidebarContent({
                       href={deck.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="capitalize text-purple-400 hover:underline focus:outline-none focus-visible:ring-1 focus-visible:ring-purple-400 rounded-sm"
+                      className={styles.metaLink}
                     >
                       {deck.source}
                       <span className="sr-only"> (opens in a new tab)</span>
                     </a>
                   ) : (
-                    <span className="capitalize text-purple-400">{deck.source}</span>
+                    <span className={styles.metaLink}>{deck.source}</span>
                   )}
                 </span>
                 <span>{totalCards} cards</span>
               </div>
             </div>
-            <div className="flex items-center gap-1.5 shrink-0">
+            <div className={styles.identityActions}>
               <EnrichmentStatus
                 enrichLoading={enrichLoading}
                 cardMap={cardMap}
@@ -588,7 +601,7 @@ function SidebarContent({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="rounded-md p-1 text-slate-400 hover:text-white hover:bg-slate-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 md:hidden"
+                  className={styles.closeButton}
                   aria-label="Close navigation"
                 >
                   <IconX />
@@ -599,10 +612,7 @@ function SidebarContent({
 
           {/* Bracket/power badge */}
           {analysisResults && (
-            <span
-              data-testid="bracket-power-badge"
-              className="mt-2 inline-block rounded border px-1.5 py-0.5 text-xs font-semibold bg-slate-700/50 border-slate-600 text-slate-300"
-            >
+            <span data-testid="bracket-power-badge" className={styles.bracketBadge}>
               B{analysisResults.bracketResult.bracket} | PL
               {analysisResults.powerLevel.powerLevel}
             </span>
@@ -612,7 +622,7 @@ function SidebarContent({
 
       {/* Collapsed: show enrichment icon only */}
       {collapsed && (
-        <div className="px-2 pt-3 pb-2 border-b border-slate-700/60 flex justify-center">
+        <div className={styles.collapsedStatusRow}>
           <EnrichmentStatus
             enrichLoading={enrichLoading}
             cardMap={cardMap}
@@ -623,8 +633,8 @@ function SidebarContent({
 
       {/* Theme pills */}
       {!collapsed && analysisResults && analysisResults.synergyAnalysis.deckThemes.length > 0 && (
-        <div className="px-3 py-2 border-b border-slate-700/60">
-          <div data-testid="header-themes" className="flex flex-wrap items-center gap-1.5">
+        <div className={styles.themesRow}>
+          <div data-testid="header-themes" className={styles.themesList}>
             {analysisResults.synergyAnalysis.deckThemes.slice(0, 3).map((theme) => {
               const axisDef = SYNERGY_AXES.find((a) => a.id === theme.axisId);
               const bg = axisDef?.color.bg ?? "bg-slate-500/20";
@@ -647,8 +657,8 @@ function SidebarContent({
 
       {/* Hand stats */}
       {!collapsed && analysisResults?.simulationStats && (
-        <div className="px-3 py-2 border-b border-slate-700/60">
-          <div data-testid="hand-stats" className="flex items-center gap-2 text-xs text-slate-400">
+        <div className={styles.handStatsRow}>
+          <div data-testid="hand-stats" style={{ display: "inline-flex", alignItems: "center", gap: "var(--space-3)" }}>
             <span>{Math.round(analysisResults.simulationStats.keepableRate * 100)}% keep</span>
             <span aria-hidden="true">·</span>
             <span>{analysisResults.simulationStats.avgLandsInOpener.toFixed(1)} lands</span>
@@ -657,16 +667,16 @@ function SidebarContent({
       )}
 
       {/* Nav groups */}
-      <nav role="tablist" aria-label="Deck view" className="flex-1 px-2 py-2">
+      <nav role="tablist" aria-label="Deck view" className={styles.nav}>
         {NAV_CATEGORIES.map((category) => {
           const isExpanded = expandedCategories.has(category.id);
           return (
-            <div key={category.id} className="mb-1">
+            <div key={category.id} className={styles.category}>
               {!collapsed && (
                 <button
                   type="button"
                   onClick={() => toggleCategory(category.id)}
-                  className="flex w-full items-center justify-between px-2 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-slate-500 hover:text-slate-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 rounded"
+                  className={styles.categoryToggle}
                   aria-expanded={isExpanded}
                 >
                   {category.label}
@@ -675,7 +685,14 @@ function SidebarContent({
               )}
 
               {(collapsed || isExpanded) && (
-                <div className={collapsed ? "flex flex-col items-center gap-1 py-1" : "space-y-0.5"}>
+                <div
+                  className={[
+                    styles.categoryGroup,
+                    collapsed && styles.categoryGroupCollapsed,
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                >
                   {category.items.map((tabKey) => {
                     const tabDef = ALL_TABS.find((t) => t.key === tabKey)!;
                     const isDisabled = ENRICHMENT_REQUIRED_TABS.has(tabKey) && analysisDisabled;
@@ -701,7 +718,7 @@ function SidebarContent({
       </nav>
 
       {/* Share button */}
-      <div className="px-2 py-3 border-t border-slate-700/60">
+      <div className={styles.shareSection}>
         <ShareMenu
           analysisResults={analysisResults}
           enrichLoading={enrichLoading}
@@ -722,11 +739,7 @@ function SidebarContent({
           collapsed={collapsed}
         />
         {/* aria-live region for image export status announcements */}
-        <div
-          aria-live="assertive"
-          aria-atomic="true"
-          className="sr-only"
-        >
+        <div aria-live="assertive" aria-atomic="true" className="sr-only">
           {imageStatus === "generating" && "Generating image, please wait..."}
           {imageStatus === "success" && "Image saved successfully."}
           {imageStatus === "error" && "Image generation failed."}
@@ -771,7 +784,7 @@ export function DeckSidebar({
     <div
       data-testid="deck-header"
       style={{ width: collapsed ? 52 : 240 }}
-      className="hidden md:flex flex-col sticky top-0 h-screen shrink-0 bg-slate-900 border-r border-slate-700/60 transition-[width] duration-200 motion-reduce:transition-none overflow-hidden"
+      className={styles.sidebar}
     >
       <SidebarContent
         deck={deck}
@@ -791,7 +804,7 @@ export function DeckSidebar({
       <button
         type="button"
         onClick={() => setCollapsed(!collapsed)}
-        className="flex items-center justify-center h-10 border-t border-slate-700/60 text-slate-400 hover:text-white hover:bg-slate-800 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-purple-400 shrink-0"
+        className={styles.collapseToggle}
         aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
         title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
       >
@@ -849,24 +862,22 @@ export function DeckDrawer({
 
   return (
     <div
-      className={`md:hidden fixed inset-0 z-50 ${open ? "" : "pointer-events-none"}`}
+      className={[styles.drawer, open ? styles.drawerOpen : styles.drawerClosed]
+        .filter(Boolean)
+        .join(" ")}
       aria-modal="true"
       role="dialog"
       aria-label="Navigation"
     >
       {/* Overlay */}
       <div
-        className={`absolute inset-0 bg-black/60 transition-opacity duration-200 motion-reduce:transition-none ${open ? "opacity-100" : "opacity-0"}`}
+        className={styles.drawerOverlay}
         onClick={onClose}
         aria-hidden="true"
       />
 
       {/* Drawer panel */}
-      <div
-        ref={drawerRef}
-        className={`absolute top-0 left-0 h-full bg-slate-900 border-r border-slate-700/60 transition-transform duration-200 motion-reduce:transition-none ${open ? "translate-x-0" : "-translate-x-full"}`}
-        style={{ width: "min(280px, 85vw)" }}
-      >
+      <div ref={drawerRef} className={styles.drawerPanel}>
         {open && (
           <SidebarContent
             deck={deck}


### PR DESCRIPTION
## Summary

Migrates the entire 889-line `DeckSidebar.tsx` (desktop sidebar + mobile drawer + ShareMenu + NavButton + EnrichmentStatus + SidebarContent + collapse toggle) from slate Tailwind to a token-driven CSS Module. **Every ARIA / role / data-testid / button-text contract is preserved verbatim.**

Follows up [#94](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/94) (DeckMobileTopBar).

## Preserved (load-bearing for e2e)

- `data-testid=\"deck-header\"` (used by `deck-header.spec.ts` + `fixtures.ts`)
- `data-testid=\"bracket-power-badge\"`, `\"header-themes\"`, `\"hand-stats\"`
- `data-testid=\"share-button\"` (used by `export-toolbar.spec.ts`)
- `data-testid=\"share-menu\"`, `\"save-as-image-button\"`
- Tab IDs `tab-deck-{key}` + tabpanel IDs (asserted by `opening-hand-ui.spec.ts`)
- `aria-label` on dialog (`Navigation`), tablist (`Deck view`), close (`Close navigation`), and toggle (`Collapse sidebar` / `Expand sidebar`)
- All share-menu item text: `\"Copy as Markdown\"` / `\"Copy as JSON\"` / `\"Export to Discord...\"` / `\"Save as Image\"` / `\"Copy Share Link\"`
- `title` attrs on enrichment-status icons, share button, sidebar toggle
- `sr-only` text for enrichment + image-export announcements
- Focus trap, body-scroll lock, Escape-to-close, click-outside on share menu
- Per-axis `SYNERGY_AXES` theme pill colors are kept as Tailwind utilities — those are deliberate per-axis brand colors, not slate chrome

## Visual changes

| Surface | Before | After |
|---|---|---|
| Sidebar panel | `bg-slate-900` solid | `rgba(10,10,24,0.65)` + `blur-md` (matches the global TopNav glass) |
| Deck title | bold sans-white | Spectral medium with `--tracking-tight` |
| Source link | `text-purple-400` | mono-uppercase `--accent` |
| Bracket/power badge | slate-700/50 | mono-uppercase `--surface-2` + `--border` outline |
| Nav buttons | slate hover | `--surface-2` baseline · `--accent-soft` + `--accent` text + `--accent` left-border on active |
| Nav badges | `bg-purple-600/80` | solid `--accent` pill in mono caption with `--ink-on-accent` |
| Category headers | slate-500 uppercase | mono-uppercase `--ink-tertiary` |
| Share button | `bg-purple-600` | `--accent-gradient` with `--shadow-sm` + `--glow-md` hover |
| Share menu | slate-800 dropdown | `--surface-overlay` with `--border-accent` and `--accent-soft` hover |
| Drawer | slate panel + `black/60` overlay | `--sheet-bg` + `--surface-scrim` + `blur-sm`; transitions use `--dur-slow` + `--ease-out`, honors `prefers-reduced-motion` |

## TDD verification

```
✓ 66 passed (35.3s)
   deck-header (8) · export-toolbar (5) · suggestions-tab (16)
   · interactions-tab (12) · opening-hand-ui (15)
   · deck-import (8) · deck-display (5) · cosmos-shell (4)
✓ 2462 unit tests passed
```

Production build clean.

## What's next

`DeckViewTabs.tsx` (419 lines) is the inner tab-content router that lives next to the sidebar. That's the next focused PR. After that the deck-results body proper — `DeckList`, `EnrichedCardRow`, etc. — gets to consume `<CardRow>` and `<ManaCost>` from the design system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)