### PR TITLE
feat(deck): migrate DeckViewTabs section headers to Astral

### DIFF
--- a/src/components/DeckViewTabs.module.css
+++ b/src/components/DeckViewTabs.module.css
@@ -1,0 +1,30 @@
+/* Section header pattern used across the analysis tabs.
+   Eyebrow-style heading (mono uppercase accent) + italic Spectral tagline,
+   as specified in design-system/README.md.
+
+   The <h3> retains heading semantics for `aria-labelledby` consumers. */
+
+.sectionHeader {
+  margin-bottom: var(--space-12);
+}
+
+.sectionHeading {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: var(--weight-medium);
+  margin: 0 0 var(--space-4);
+  line-height: 1;
+}
+
+.sectionTagline {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+  line-height: var(--leading-snug);
+  margin: 0;
+  max-width: 60ch;
+}

--- a/src/components/DeckViewTabs.tsx
+++ b/src/components/DeckViewTabs.tsx
@@ -20,6 +20,7 @@ import {
   computeCompositionScorecard,
   AVAILABLE_TEMPLATES,
 } from "@/lib/deck-composition";
+import styles from "./DeckViewTabs.module.css";
 
 interface DeckViewTabsProps {
   deck: DeckData;
@@ -267,15 +268,14 @@ export default function DeckViewTabs({
       >
         {activeTab === "synergy" && cardMap && synergyAnalysis && (
           <section aria-labelledby="synergy-heading">
-            <h3
-              id="synergy-heading"
-              className="mb-1 text-sm font-semibold uppercase tracking-wide text-slate-300"
-            >
-              Card Synergy
-            </h3>
-            <p className="mb-4 text-xs text-slate-400">
-              Synergy analysis, known combos, and anti-synergy warnings
-            </p>
+            <header className={styles.sectionHeader}>
+              <h3 id="synergy-heading" className={styles.sectionHeading}>
+                Card Synergy
+              </h3>
+              <p className={styles.sectionTagline}>
+                Synergy analysis, known combos, and anti-synergy warnings
+              </p>
+            </header>
             <SynergySection
               deck={deck}
               analysis={synergyAnalysis}
@@ -297,16 +297,15 @@ export default function DeckViewTabs({
       >
         {activeTab === "hands" && cardMap && !enrichLoading && (
           <section aria-labelledby="hands-heading">
-            <h3
-              id="hands-heading"
-              className="mb-1 text-sm font-semibold uppercase tracking-wide text-slate-300"
-            >
-              Opening Hand Simulator
-            </h3>
-            <p className="mb-4 text-xs text-slate-400">
-              Draw sample opening hands, evaluate quality, and view aggregate
-              statistics
-            </p>
+            <header className={styles.sectionHeader}>
+              <h3 id="hands-heading" className={styles.sectionHeading}>
+                Opening Hand Simulator
+              </h3>
+              <p className={styles.sectionTagline}>
+                Draw sample opening hands, evaluate quality, and view aggregate
+                statistics
+              </p>
+            </header>
             <HandSimulator
               deck={deck}
               cardMap={cardMap}
@@ -346,15 +345,15 @@ export default function DeckViewTabs({
       >
         {activeTab === "interactions" && cardMap && !enrichLoading && (
           <section aria-labelledby="interactions-heading">
-            <h3
-              id="interactions-heading"
-              className="mb-1 text-sm font-semibold uppercase tracking-wide text-slate-300"
-            >
-              Card Interactions
-            </h3>
-            <p className="mb-4 text-xs text-slate-400">
-              Mechanical interaction analysis powered by oracle text compilation
-            </p>
+            <header className={styles.sectionHeader}>
+              <h3 id="interactions-heading" className={styles.sectionHeading}>
+                Card Interactions
+              </h3>
+              <p className={styles.sectionTagline}>
+                Mechanical interaction analysis powered by oracle text
+                compilation
+              </p>
+            </header>
             <InteractionSection
               analysis={interactionAnalysis}
               loading={interactionLoading}
@@ -380,16 +379,15 @@ export default function DeckViewTabs({
       >
         {activeTab === "goldfish" && cardMap && !enrichLoading && (
           <section aria-labelledby="goldfish-heading">
-            <h3
-              id="goldfish-heading"
-              className="mb-1 text-sm font-semibold uppercase tracking-wide text-slate-300"
-            >
-              Goldfish Simulator
-            </h3>
-            <p className="mb-4 text-xs text-slate-400">
-              Monte Carlo solitaire simulation: mana development and spell casting over {/* turns shown dynamically */}
-              10 turns across 1,000+ games
-            </p>
+            <header className={styles.sectionHeader}>
+              <h3 id="goldfish-heading" className={styles.sectionHeading}>
+                Goldfish Simulator
+              </h3>
+              <p className={styles.sectionTagline}>
+                Monte Carlo solitaire simulation: mana development and spell
+                casting over 10 turns across 1,000+ games
+              </p>
+            </header>
             <GoldfishSimulator deck={deck} cardMap={cardMap} />
           </section>
         )}


### PR DESCRIPTION
## Summary

Migrates the four tab-panel section headers (Synergy, Opening Hands, Interactions, Goldfish) inside `DeckViewTabs.tsx` from slate Tailwind utilities to a token-driven CSS Module. The 419-line file is mostly orchestration logic — the actual visual surface migrated here is just the four repeated `<h3>` + `<p>` pairs.

Follows up [#95](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/95). The deck-results body (`DeckList`, `EnrichedCardRow`, `DeckAnalysis`, `SynergySection`, etc.) is the remaining slate surface; that's where the design-system primitives (`<CardRow>`, `<ManaCost>`) finally land in the live app.

## Preserved (load-bearing for e2e)

- `data-testid=\"deck-view-tabs\"` wrapper
- Section heading IDs: `synergy-heading` / `hands-heading` / `interactions-heading` / `goldfish-heading` (consumed by `aria-labelledby`)
- Section heading names asserted by `getByRole(\"heading\", { name })`: `\"Card Synergy\"` / `\"Opening Hand Simulator\"` / `\"Card Interactions\"` / `\"Goldfish Simulator\"`
- All `role=\"tabpanel\"` + `id=\"tabpanel-deck-{key}\"` + `aria-labelledby=\"tab-deck-{key}\"` contracts on every panel
- The `hidden={activeTab !== \"...\"}` render gating

## Visual changes

| Element | Before | After |
|---|---|---|
| Section heading | slate-300 uppercase `tracking-wide` `font-semibold` | mono uppercase `--accent` at `--tracking-eyebrow` — the eyebrow pattern called \"sacred\" in `design-system/CLAUDE.md`, with `<h3>` semantics preserved |
| Section tagline | slate-400 body | italic Spectral at body-sm in `--ink-tertiary`, max-width 60ch |
| Layout | per-element `mb-1` / `mb-4` margins | grouped under a `<header>` with a single bottom margin |

## TDD verification

```
✓ 63 passed (52.5s)
   synergy-ui (~30) · opening-hand-ui (~15) · goldfish-tab (~5)
   · interactions-tab (~5) · deck-header (~5) · cosmos-shell (4)
```

Production build clean.

## What's next

The deck-results body — `DeckList`, `EnrichedCardRow`, `DeckAnalysis`, `SynergySection`, `InteractionSection`, `HandSimulator`, `GoldfishSimulator`, `AdditionsPanel`, `SuggestionsPanel` — is the remaining slate surface. This is where `<CardRow>` and `<ManaCost>` from the design system primitives finally come home. Likely needs to be split across several focused PRs given the surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)