### PR TITLE
feat(deck): migrate CollapsiblePanel + SectionNav + DeckAnalysis chrome

### DIFF
--- a/src/components/CollapsiblePanel.module.css
+++ b/src/components/CollapsiblePanel.module.css
@@ -1,0 +1,78 @@
+.panel {
+  border-radius: var(--card-radius);
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  overflow: hidden;
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.toggle {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: var(--space-5);
+  padding: var(--space-5) var(--space-8);
+  border: none;
+  background: transparent;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--dur-base) var(--ease-out);
+}
+
+.toggle:hover {
+  background: var(--accent-soft);
+}
+
+.toggle:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent);
+}
+
+.chevron {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+  color: var(--ink-tertiary);
+  transition: transform var(--dur-base) var(--ease-out);
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+  color: var(--accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron {
+    transition: none;
+  }
+}
+
+.title {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-secondary);
+  font-weight: var(--weight-medium);
+}
+
+.toggle:hover .title,
+.toggle[aria-expanded="true"] .title {
+  color: var(--accent);
+}
+
+.summary {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}
+
+.content {
+  padding: 0 var(--space-8) var(--space-10);
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-7);
+}

--- a/src/components/CollapsiblePanel.tsx
+++ b/src/components/CollapsiblePanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useRef } from "react";
+import styles from "./CollapsiblePanel.module.css";
 
 interface CollapsiblePanelProps {
   id: string;
@@ -39,7 +40,7 @@ export default function CollapsiblePanel({
       ref={panelRef}
       id={`panel-${id}`}
       data-testid={testId ?? `panel-${id}`}
-      className="rounded-lg border border-slate-700 bg-slate-800/50 overflow-hidden"
+      className={styles.panel}
     >
       <button
         type="button"
@@ -47,15 +48,15 @@ export default function CollapsiblePanel({
         aria-controls={contentId}
         onClick={onToggle}
         onKeyDown={handleKeyDown}
-        className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-slate-700/30 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 focus-visible:ring-inset"
+        className={styles.toggle}
       >
         <svg
           aria-hidden="true"
           viewBox="0 0 20 20"
           fill="currentColor"
-          className={`h-4 w-4 shrink-0 text-slate-400 transition-transform duration-150 motion-reduce:transition-none ${
-            expanded ? "rotate-90" : ""
-          }`}
+          className={[styles.chevron, expanded && styles.chevronOpen]
+            .filter(Boolean)
+            .join(" ")}
         >
           <path
             fillRule="evenodd"
@@ -63,16 +64,12 @@ export default function CollapsiblePanel({
             clipRule="evenodd"
           />
         </svg>
-        <span className="text-sm font-semibold uppercase tracking-wide text-slate-300">
-          {title}
-        </span>
-        {summary && (
-          <span className="ml-auto text-xs text-slate-400">{summary}</span>
-        )}
+        <span className={styles.title}>{title}</span>
+        {summary && <span className={styles.summary}>{summary}</span>}
       </button>
 
       {expanded && (
-        <div id={contentId} className="px-4 pt-2 pb-5">
+        <div id={contentId} className={styles.content}>
           {children}
         </div>
       )}

--- a/src/components/DeckAnalysis.module.css
+++ b/src/components/DeckAnalysis.module.css
@@ -1,0 +1,38 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.budgetStack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.tagline {
+  margin: 0 0 var(--space-7);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+  line-height: var(--leading-snug);
+}
+
+.filterWrap {
+  margin-bottom: var(--space-7);
+}
+
+.classificationBadge {
+  display: inline-block;
+  padding: var(--space-1) var(--space-4);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.06em;
+  font-weight: var(--weight-semibold);
+  color: var(--ink-secondary);
+  text-transform: uppercase;
+}

--- a/src/components/DeckAnalysis.tsx
+++ b/src/components/DeckAnalysis.tsx
@@ -39,6 +39,7 @@ import TopExpensiveCardsTable from "@/components/TopExpensiveCardsTable";
 import PriceByCategoryChart from "@/components/PriceByCategoryChart";
 import CreatureTypeBreakdown from "@/components/CreatureTypeBreakdown";
 import SupertypeBreakdown from "@/components/SupertypeBreakdown";
+import styles from "./DeckAnalysis.module.css";
 
 const ANALYSIS_SECTIONS = [
   { id: "commander", label: "Commander" },
@@ -182,7 +183,7 @@ export default function DeckAnalysis({
   );
 
   return (
-    <div className="space-y-3">
+    <div className={styles.list}>
       <SectionNav
         sections={ANALYSIS_SECTIONS}
         expandedSections={expandedSections}
@@ -233,7 +234,7 @@ export default function DeckAnalysis({
         summary={
           <span
             data-testid="classification-summary-badge"
-            className="rounded border px-1.5 py-0.5 text-xs font-semibold bg-slate-700/50 border-slate-600 text-slate-300"
+            className={styles.classificationBadge}
           >
             B{bracketResult.bracket} | PL{powerLevel.powerLevel}
           </span>
@@ -255,12 +256,12 @@ export default function DeckAnalysis({
           >
             Mana Curve
           </h3>
-          <p className="mb-4 text-xs text-slate-400" data-testid="curve-subtitle">
+          <p className={styles.tagline} data-testid="curve-subtitle">
             {allEnabled
               ? `${totalAllSpells} non-land spells by converted mana cost`
               : `${filteredSpells} of ${totalAllSpells} non-land spells by converted mana cost`}
           </p>
-          <div className="mb-4">
+          <div className={styles.filterWrap}>
             <TypeFilterBar
               enabledTypes={enabledTypes}
               onToggle={handleToggle}
@@ -284,7 +285,7 @@ export default function DeckAnalysis({
           >
             Color Distribution
           </h3>
-          <p className="mb-4 text-xs text-slate-400">
+          <p className={styles.tagline}>
             Mana sources versus pip demand by color
           </p>
           <ManaBaseStats metrics={metrics} />
@@ -322,7 +323,7 @@ export default function DeckAnalysis({
         expanded={expandedSections.has("budget")}
         onToggle={() => onToggleSection("budget")}
       >
-        <div className="space-y-6">
+        <div className={styles.budgetStack}>
           <BudgetStats result={budgetAnalysis} />
           <PriceDistributionChart data={budgetAnalysis.distribution} />
           <TopExpensiveCardsTable cards={budgetAnalysis.mostExpensive} />

--- a/src/components/SectionNav.module.css
+++ b/src/components/SectionNav.module.css
@@ -1,0 +1,44 @@
+.nav {
+  margin-bottom: var(--space-7);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.pill {
+  padding: var(--space-2) var(--space-7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--surface-2);
+  color: var(--ink-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.pill:hover {
+  border-color: var(--border-accent);
+  color: var(--ink-secondary);
+}
+
+.pill:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.pillActive {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--border-accent);
+}
+
+.pillActive:hover {
+  background: var(--accent-soft-hi);
+  color: var(--accent);
+}

--- a/src/components/SectionNav.tsx
+++ b/src/components/SectionNav.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import styles from "./SectionNav.module.css";
+
 interface SectionNavProps {
   sections: readonly { id: string; label: string }[];
   expandedSections: Set<string>;
@@ -28,7 +30,7 @@ export default function SectionNav({
     <nav
       aria-label="Section navigation"
       data-testid="section-nav"
-      className="mb-4 flex flex-wrap gap-2"
+      className={styles.nav}
     >
       {sections.map((section) => {
         const isExpanded = expandedSections.has(section.id);
@@ -38,11 +40,9 @@ export default function SectionNav({
             type="button"
             onClick={() => handleClick(section.id)}
             data-testid={`section-nav-${section.id}`}
-            className={`rounded-full border px-3 py-1 text-xs transition-colors cursor-pointer ${
-              isExpanded
-                ? "border-purple-500 bg-purple-900/30 text-purple-300"
-                : "border-slate-600 bg-slate-800 text-slate-400 hover:border-purple-500 hover:text-slate-200"
-            }`}
+            className={[styles.pill, isExpanded && styles.pillActive]
+              .filter(Boolean)
+              .join(" ")}
           >
             {section.label}
           </button>


### PR DESCRIPTION
## Summary

`CollapsiblePanel` is the workhorse used by **7 components** (`DeckAnalysis`, `SynergySection`, `HandSimulator`, `SuggestionsPanel`, `InteractionSection`, `GoldfishTurnTimeline`, `CategoryFillList`). Migrating it visually transforms every analysis tab in one focused PR. `SectionNav` and the inline chrome in `DeckAnalysis` ride along since they're the same surface.

Follows up [#97](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/97).

## Preserved (load-bearing for e2e)

- `data-testid=\"panel-{id}\"` on every collapsible panel (`panel-mana-curve`, `panel-budget`, `panel-commander`, etc.)
- `panel-content-{id}` inner content id, `aria-expanded`, `aria-controls`, Escape-to-collapse
- Panel title text (used by `getByText` / `getByRole(\"button\", { name })`)
- `data-testid=\"section-nav\"` + `data-testid=\"section-nav-{id}\"`
- `data-testid=\"classification-summary-badge\"`, `data-testid=\"curve-subtitle\"`

## Visual changes

### CollapsiblePanel
| Element | Before | After |
|---|---|---|
| Outer panel | `bg-slate-800/50` + `slate-700` border | `--card-bg` + `--card-border` + `blur-sm` (matches the rest of the deck-results chrome) |
| Toggle hover | `slate-700/30` | `--accent-soft` |
| Title | slate-300 uppercase `tracking-wide` | mono uppercase eyebrow at `--tracking-eyebrow`; turns `--accent` on hover or when expanded |
| Chevron | slate-400 | `--ink-tertiary`, becomes `--accent` + `rotate(90deg)` when expanded; honors `prefers-reduced-motion` |
| Summary text | slate-400 | mono uppercase `--ink-tertiary` |
| Content area | flush | now has `--border` top divider for hierarchy |

### SectionNav
| Element | Before | After |
|---|---|---|
| Pill (inactive) | `border-slate-600` + `bg-slate-800` + `text-slate-400` | `--surface-2` baseline + mono uppercase `--ink-tertiary` |
| Pill (active) | `border-purple-500` + `bg-purple-900/30` + `text-purple-300` | `--accent-soft` + `--accent` + `--border-accent` |
| Hover | switch to slate-200 | `--border-accent` ring + `--ink-secondary` text |

### DeckAnalysis
- Panel-list container: `space-y-3` → token gap `var(--space-5)`
- Budget stack: `space-y-6` → token gap `var(--space-12)`
- Section taglines (mana-curve, color-distribution): slate-400 body → italic Spectral `--ink-tertiary` at `--text-sm`
- Classification badge: slate-700/50 + slate-600 + slate-300 → mono uppercase `--surface-2` + `--border` outline at `--tracking-eyebrow`

## TDD verification

```
✓ 102 passed (49.2s)
   deck-analysis (~50) · collapsible-panels (~10) · synergy-ui (~30)
   · suggestions-tab (~16) · cosmos-shell (4)
```

Production build clean.

## What's next

`SynergySection`, `HandSimulator`, `SuggestionsPanel`, `InteractionSection`, `GoldfishSimulator`, `AdditionsPanel` — and their nested table/chart subcomponents — are the remaining slate surfaces. Each is its own focused PR given the surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)