### PR TITLE
feat(deck): migrate AdditionsPanel to Astral tokens

### DIFF
--- a/src/components/AdditionsPanel.module.css
+++ b/src/components/AdditionsPanel.module.css
@@ -1,0 +1,174 @@
+/* AdditionsPanel — Astral design tokens */
+
+.section {
+  /* no extra wrapper needed; section is the root */
+}
+
+/* ── Heading ──────────────────────────────────────────── */
+.heading {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: var(--weight-medium);
+}
+
+/* ── Subheading / description ─────────────────────────── */
+.description {
+  margin: 0 0 var(--space-8);
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+  line-height: var(--leading-body);
+}
+
+/* ── Empty state ──────────────────────────────────────── */
+.emptyState {
+  padding: var(--space-20) 0;
+  text-align: center;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+}
+
+/* ── Candidate list ───────────────────────────────────── */
+.candidateList {
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Error card ───────────────────────────────────────── */
+.errorCard {
+  margin-bottom: var(--space-6);
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 134, 160, 0.35);
+  background: var(--status-warn-soft);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.errorCardInner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-5);
+}
+
+.errorCardText {
+  min-width: 0;
+}
+
+.errorCardName {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--ink-primary);
+}
+
+.errorCardMessage {
+  margin: var(--space-1) 0 0;
+  font-size: var(--text-xs);
+  color: var(--status-warn);
+  line-height: var(--leading-snug);
+}
+
+.errorCardActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  flex-shrink: 0;
+}
+
+.retryBtn {
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  padding: var(--space-2) var(--space-5);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  color: var(--ink-secondary);
+  cursor: pointer;
+  transition: background var(--dur-base) var(--ease-out),
+              color var(--dur-base) var(--ease-out);
+}
+
+.retryBtn:hover {
+  background: var(--surface-2-hi);
+  color: var(--ink-primary);
+}
+
+.retryBtn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.removeBtn {
+  border-radius: var(--radius-sm);
+  padding: var(--space-2);
+  background: transparent;
+  border: none;
+  color: var(--ink-tertiary);
+  cursor: pointer;
+  transition: color var(--dur-base) var(--ease-out);
+}
+
+.removeBtn:hover {
+  color: var(--status-warn);
+}
+
+.removeBtn:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.removeBtnIcon {
+  width: 16px;
+  height: 16px;
+  display: block;
+}
+
+/* ── Loading card ─────────────────────────────────────── */
+.loadingCard {
+  margin-bottom: var(--space-6);
+  padding: var(--space-6);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.loadingCardInner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+}
+
+.loadingSpinner {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  animation: spin var(--dur-slow) linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loadingSpinner {
+    animation: none;
+    border-top-color: var(--accent);
+    opacity: 0.6;
+  }
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loadingCardName {
+  font-size: var(--text-sm);
+  color: var(--ink-secondary);
+}

--- a/src/components/AdditionsPanel.tsx
+++ b/src/components/AdditionsPanel.tsx
@@ -4,6 +4,7 @@ import type { EnrichedCard } from "@/lib/types";
 import type { CandidateAnalysis } from "@/lib/candidate-analysis";
 import CardSearchInput from "@/components/CardSearchInput";
 import CandidateCardRow from "@/components/CandidateCardRow";
+import styles from "./AdditionsPanel.module.css";
 
 interface AdditionsPanelProps {
   candidates: string[];
@@ -30,11 +31,11 @@ export default function AdditionsPanel({
     <section aria-labelledby="additions-heading">
       <h3
         id="additions-heading"
-        className="mb-1 text-sm font-semibold uppercase tracking-wide text-slate-300"
+        className={styles.heading}
       >
         Possible Additions
       </h3>
-      <p className="mb-4 text-xs text-slate-400">
+      <p className={styles.description}>
         Search for candidate cards and evaluate their impact on your deck
       </p>
 
@@ -45,11 +46,11 @@ export default function AdditionsPanel({
       />
 
       {candidates.length === 0 ? (
-        <p className="text-center text-sm text-slate-500 py-8">
+        <p className={styles.emptyState}>
           Search for cards to evaluate as possible additions
         </p>
       ) : (
-        <div>
+        <div className={styles.candidateList}>
           {candidates.map((name) => {
             const card = candidateCardMap[name];
             const error = errors[name];
@@ -60,31 +61,31 @@ export default function AdditionsPanel({
                   key={name}
                   role="alert"
                   data-testid="candidate-error"
-                  className="rounded-lg border border-red-700/50 bg-slate-800/50 mb-3 p-3"
+                  className={styles.errorCard}
                 >
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="min-w-0">
-                      <span className="text-sm font-medium text-slate-200">
+                  <div className={styles.errorCardInner}>
+                    <div className={styles.errorCardText}>
+                      <span className={styles.errorCardName}>
                         {name}
                       </span>
-                      <p className="text-xs text-red-400 mt-0.5">{error}</p>
+                      <p className={styles.errorCardMessage}>{error}</p>
                     </div>
-                    <div className="flex items-center gap-2 shrink-0">
+                    <div className={styles.errorCardActions}>
                       <button
                         type="button"
                         onClick={() => onRetryCard(name)}
-                        className="rounded-md bg-slate-700 px-2.5 py-1 text-xs font-medium text-slate-200 hover:bg-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+                        className={styles.retryBtn}
                       >
                         Retry
                       </button>
                       <button
                         type="button"
                         onClick={() => onRemoveCard(name)}
-                        className="rounded-sm p-1 text-slate-400 hover:text-red-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+                        className={styles.removeBtn}
                         aria-label={`Remove ${name}`}
                       >
                         <svg
-                          className="h-4 w-4"
+                          className={styles.removeBtnIcon}
                           viewBox="0 0 20 20"
                           fill="currentColor"
                           aria-hidden="true"
@@ -103,14 +104,14 @@ export default function AdditionsPanel({
                 <div
                   key={name}
                   data-testid="candidate-loading"
-                  className="rounded-lg border border-slate-700 bg-slate-800/50 mb-3 p-3"
+                  className={styles.loadingCard}
                 >
-                  <div className="flex items-center gap-2">
+                  <div className={styles.loadingCardInner}>
                     <div
-                      className="h-4 w-4 animate-spin rounded-full border-2 border-slate-500 border-t-purple-400"
+                      className={styles.loadingSpinner}
                       aria-hidden="true"
                     />
-                    <span className="text-sm text-slate-300">
+                    <span className={styles.loadingCardName}>
                       Loading {name}...
                     </span>
                   </div>


### PR DESCRIPTION
## Summary

- Created `src/components/AdditionsPanel.module.css` with semantic Astral token classes
- Replaced all Tailwind utility classes in `src/components/AdditionsPanel.tsx` with CSS Module references
- No behavior or test contract changes

## Visual changes

| Element | Before (Tailwind) | After (Astral token) |
|---|---|---|
| Section heading | `text-sm font-semibold uppercase tracking-wide text-slate-300` | `--accent` mono eyebrow pattern |
| Description | `text-xs text-slate-400` | `--ink-tertiary` at `--text-sm` |
| Empty state | `text-sm text-slate-500` | `--ink-tertiary` at `--text-sm` |
| Error card | `border-red-700/50 bg-slate-800/50` | `--status-warn-soft` bg + rose border |
| Error message | `text-red-400` | `--status-warn` |
| Retry button | `bg-slate-700 hover:bg-slate-600` | `--surface-2` + `--surface-2-hi` |
| Remove button | `text-slate-400 hover:text-red-400` | `--ink-tertiary` → `--status-warn` |
| Loading card | `border-slate-700 bg-slate-800/50` | `--card-bg` + `--card-border` + backdrop blur |
| Loading spinner | `border-slate-500 border-t-purple-400 animate-spin` | `--accent` top-border, CSS keyframes, respects `prefers-reduced-motion` |
| Focus rings | Tailwind `focus-visible:ring-2 focus-visible:ring-purple-400` | `box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent)` |

## Preserved contracts

- `data-testid="candidate-error"` and `data-testid="candidate-loading"` — unchanged
- `aria-labelledby="additions-heading"`, `id="additions-heading"`, `role="alert"` — unchanged
- All `aria-label` attributes on remove buttons — unchanged
- Button text "Retry" — unchanged
- Component `AdditionsPanelProps` interface — unchanged
- All conditional render guards — unchanged

## TDD verification

All 17 specs in `e2e/possible-additions.spec.ts` pass on chromium (17 passed, 0 failed). No tests asserted Tailwind class names, so no test modifications were required.

## What's next

`CandidateCardRow` and `CardSearchInput` (both used by this panel) still use Tailwind utilities and are candidates for the same migration pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)