### PR TITLE
feat(deck): migrate HandSimulator to Astral tokens

### DIFF
--- a/src/components/HandSimulator.module.css
+++ b/src/components/HandSimulator.module.css
@@ -1,0 +1,121 @@
+/* ─────────────────────────────────────────────────────────────
+   HandSimulator — Astral design tokens
+───────────────────────────────────────────────────────────── */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+/* ─── Action buttons ─────────────────────────────────────── */
+
+.buttonRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+/* Primary: Draw Hand */
+.btnPrimary {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--btn-padding-y) var(--btn-padding-x);
+  border: none;
+  border-radius: var(--btn-radius);
+  background: var(--accent-gradient);
+  color: var(--ink-on-accent);
+  font-family: var(--font-sans);
+  font-size: var(--btn-font-size);
+  font-weight: var(--btn-font-weight);
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition:
+    box-shadow var(--dur-base) var(--ease-out),
+    filter var(--dur-base) var(--ease-out);
+}
+
+.btnPrimary:hover {
+  box-shadow: var(--shadow-sm), var(--glow-md);
+  filter: brightness(1.08);
+}
+
+.btnPrimary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+/* Secondary: Mulligan (outlined) */
+.btnOutline {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--btn-padding-y) var(--btn-padding-x);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--btn-radius);
+  background: transparent;
+  color: var(--accent);
+  font-family: var(--font-sans);
+  font-size: var(--btn-font-size);
+  font-weight: var(--btn-font-weight);
+  cursor: pointer;
+  transition:
+    background var(--dur-base) var(--ease-out),
+    border-color var(--dur-base) var(--ease-out);
+}
+
+.btnOutline:hover {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+}
+
+.btnOutline:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.btnOutline:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+/* Tertiary: New Hand (surface fill) */
+.btnSecondary {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--btn-padding-y) var(--btn-padding-x);
+  border: 1px solid var(--border);
+  border-radius: var(--btn-radius);
+  background: var(--surface-2);
+  color: var(--ink-primary);
+  font-family: var(--font-sans);
+  font-size: var(--btn-font-size);
+  font-weight: var(--btn-font-weight);
+  cursor: pointer;
+  transition:
+    background var(--dur-base) var(--ease-out),
+    border-color var(--dur-base) var(--ease-out);
+}
+
+.btnSecondary:hover {
+  background: var(--surface-2-hi);
+  border-color: var(--border-hi);
+}
+
+.btnSecondary:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+/* ─── Hand display wrapper ───────────────────────────────── */
+
+.handDisplayWrapper {
+  margin-top: var(--space-10);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btnPrimary,
+  .btnOutline,
+  .btnSecondary {
+    transition: none;
+  }
+}

--- a/src/components/HandSimulator.tsx
+++ b/src/components/HandSimulator.tsx
@@ -20,6 +20,7 @@ import TopHands from "@/components/TopHands";
 import HandBuilder from "@/components/HandBuilder";
 import CollapsiblePanel from "@/components/CollapsiblePanel";
 import SectionNav from "@/components/SectionNav";
+import styles from "./HandSimulator.module.css";
 
 const MAX_MULLIGANS = 3;
 
@@ -125,7 +126,7 @@ export default function HandSimulator({
   );
 
   return (
-    <div data-testid="hand-simulator" className="space-y-3">
+    <div data-testid="hand-simulator" className={styles.root}>
       <SectionNav
         sections={HANDS_SECTIONS}
         expandedSections={expandedSections}
@@ -157,13 +158,13 @@ export default function HandSimulator({
         onToggle={() => onToggleSection("draw-hand")}
       >
         {/* Action buttons */}
-        <div className="flex flex-wrap gap-3">
+        <div className={styles.buttonRow}>
           {!currentHand ? (
             <button
               type="button"
               onClick={handleDrawHand}
               data-testid="draw-hand-btn"
-              className="rounded-lg bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+              className={styles.btnPrimary}
             >
               Draw Hand
             </button>
@@ -174,7 +175,7 @@ export default function HandSimulator({
                 onClick={handleMulligan}
                 disabled={mulliganCount >= MAX_MULLIGANS}
                 data-testid="mulligan-btn"
-                className="rounded-lg border border-purple-500 px-4 py-2 text-sm font-medium text-purple-300 transition-colors hover:bg-purple-500/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 disabled:cursor-not-allowed disabled:opacity-40"
+                className={styles.btnOutline}
               >
                 Mulligan{mulliganCount > 0 ? ` (${mulliganCount}/${MAX_MULLIGANS})` : ""}
               </button>
@@ -182,7 +183,7 @@ export default function HandSimulator({
                 type="button"
                 onClick={handleNewHand}
                 data-testid="new-hand-btn"
-                className="rounded-lg bg-slate-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-slate-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400"
+                className={styles.btnSecondary}
               >
                 New Hand
               </button>
@@ -192,7 +193,7 @@ export default function HandSimulator({
 
         {/* Hand display */}
         {currentHand && (
-          <div className="mt-4">
+          <div className={styles.handDisplayWrapper}>
             <HandDisplay hand={currentHand} commandZone={commandZone} />
           </div>
         )}


### PR DESCRIPTION
## Summary

- Migrated `src/components/HandSimulator.tsx` (211 lines) from inline Tailwind utilities to a co-located CSS Module (`HandSimulator.module.css`) driven entirely by Astral semantic tokens
- Zero behavioral changes — all `data-testid`, `aria-*`, button text, and prop interface preserved exactly

## Visual changes

| Element | Before (Tailwind) | After (Astral tokens) |
|---|---|---|
| Root wrapper | `space-y-3` | `var(--space-3)` flex-column gap |
| Draw Hand button | `bg-purple-600 hover:bg-purple-500` | `var(--accent-gradient)` + `var(--glow-md)` hover |
| Mulligan button | `border-purple-500 text-purple-300` | `var(--border-accent)` / `var(--accent)` outline |
| New Hand button | `bg-slate-600 hover:bg-slate-500` | `var(--surface-2)` / `var(--surface-2-hi)` |
| Focus rings | `focus-visible:ring-2 focus-visible:ring-purple-400` | `box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent)` |
| Hand display gap | `mt-4` | `var(--space-10)` |

## Preserved contracts

- `data-testid`: `hand-simulator`, `draw-hand-btn`, `mulligan-btn`, `new-hand-btn`
- Button text strings: "Draw Hand", "Mulligan", "Mulligan (N/3)", "New Hand" — exact
- `disabled` attribute on Mulligan at `MAX_MULLIGANS`
- Props interface `HandSimulatorProps` unchanged
- `#tabpanel-deck-hands` / `#tab-deck-hands` ARIA ids in `DeckViewTabs` (untouched)
- No Tailwind class assertions existed in the e2e spec; no brittle contracts broken

## TDD verification

- `npm run build` — passes (zero errors)
- `e2e/opening-hand-ui.spec.ts` — **13/13 passed** (chromium)

🤖 Generated with [Claude Code](https://claude.com/claude-code)