### PR TITLE
feat(deck): migrate SynergySection to Astral tokens

### DIFF
--- a/src/components/SynergySection.module.css
+++ b/src/components/SynergySection.module.css
@@ -1,0 +1,30 @@
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.spacer {
+  margin-top: var(--space-7);
+}
+
+.emptyState {
+  margin-bottom: var(--space-8);
+}
+
+.emptyHeading {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  font-weight: var(--weight-semibold);
+  color: var(--ink-tertiary);
+}
+
+.emptyBody {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+  line-height: var(--leading-body);
+}

--- a/src/components/SynergySection.tsx
+++ b/src/components/SynergySection.tsx
@@ -12,6 +12,7 @@ import CardSynergyTable from "@/components/CardSynergyTable";
 import CollapsiblePanel from "@/components/CollapsiblePanel";
 import SectionNav from "@/components/SectionNav";
 import VerifiedCombos, { NearCombos } from "@/components/VerifiedCombos";
+import styles from "./SynergySection.module.css";
 
 interface SynergySectionProps {
   deck: DeckData;
@@ -76,7 +77,7 @@ export default function SynergySection({
   const localCombosTitle = hasSpellbookExact ? "Local Combos" : "Known Combos";
 
   return (
-    <div className="space-y-3">
+    <div className={styles.list}>
       <SectionNav
         sections={synergySections}
         expandedSections={expandedSections}
@@ -91,12 +92,12 @@ export default function SynergySection({
       >
         <DeckThemes themes={analysis.deckThemes} />
         {analysis.deckThemes.some((t) => t.axisId === "tribal") && (
-          <div className="mt-4">
+          <div className={styles.spacer}>
             <CreatureTypeBreakdown deck={deck} cardMap={cardMap} />
           </div>
         )}
         {analysis.deckThemes.some((t) => t.axisId === "supertypeMatter") && (
-          <div className="mt-4">
+          <div className={styles.spacer}>
             <SupertypeBreakdown deck={deck} cardMap={cardMap} />
           </div>
         )}
@@ -179,11 +180,11 @@ export default function SynergySection({
         )}
 
         {combos.length === 0 && heuristicSynergies.length === 0 && (
-          <div data-testid="synergy-pairs" className="mb-4">
-            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <div data-testid="synergy-pairs" className={styles.emptyState}>
+            <h4 className={styles.emptyHeading}>
               Top Synergies
             </h4>
-            <p className="text-xs text-slate-500">
+            <p className={styles.emptyBody}>
               No significant synergy pairs detected.
             </p>
           </div>
@@ -205,11 +206,11 @@ export default function SynergySection({
         />
 
         {analysis.antiSynergies.length === 0 && (
-          <div data-testid="anti-synergy-pairs" className="mb-4">
-            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+          <div data-testid="anti-synergy-pairs" className={styles.emptyState}>
+            <h4 className={styles.emptyHeading}>
               Anti-Synergy Warnings
             </h4>
-            <p className="text-xs text-slate-500">
+            <p className={styles.emptyBody}>
               No anti-synergies detected.
             </p>
           </div>


### PR DESCRIPTION
## Summary

- Replaced the `space-y-3` Tailwind wrapper with a CSS Module `.list` class using semantic token `var(--space-5)` gap, matching the DeckAnalysis pattern
- Replaced `mt-4` spacer divs (tribal/supertype conditional breakdowns) with `.spacer` using `var(--space-7)` margin-top
- Replaced slate Tailwind utilities on empty-state headings with `.emptyHeading`: mono uppercase eyebrow style via `var(--font-mono)`, `var(--text-eyebrow)`, `var(--tracking-eyebrow)`, `var(--ink-tertiary)`
- Replaced slate utilities on empty-state body text with `.emptyBody`: `var(--text-sm)`, `var(--ink-tertiary)`, `var(--leading-body)`

## Preserved contracts

- All `data-testid` attributes: `synergy-pairs`, `anti-synergy-pairs`, `heuristic-synergies`
- All CollapsiblePanel `id` and `title` props (resolves to `panel-themes`, `panel-synergy-stats`, `panel-verified-combos`, `panel-near-combos`, `panel-synergy-pairs`, `panel-anti-synergies`, `panel-card-scores`)
- All conditional render guards and the exported `SynergySectionProps` interface unchanged
- All aria attributes delegated through the already-migrated CollapsiblePanel

## Visual changes

Empty-state headings now render in the Astral eyebrow style (mono, uppercase, 0.22em tracked, `var(--ink-tertiary)`) instead of slate-400 Tailwind text. Body text uses `var(--ink-tertiary)` / `var(--text-sm)`. Panel gap uses `var(--space-5)` consistent with DeckAnalysis.

## TDD verification

- `npm run build` — succeeded (Next.js standalone output, no TS/CSS errors)
- `CI=1 npx playwright test e2e/synergy-ui.spec.ts e2e/spellbook-combos.spec.ts --project=chromium` — **26/26 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)