### PR TITLE
feat(deck): migrate SuggestionsPanel to Astral tokens

### DIFF
--- a/src/components/SuggestionsPanel.module.css
+++ b/src/components/SuggestionsPanel.module.css
@@ -1,0 +1,206 @@
+/* ─────────────────────────────────────────────────────────────
+   SuggestionsPanel — Astral tokens
+───────────────────────────────────────────────────────────── */
+
+/* Section wrapper */
+.section {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Section heading (eyebrow) */
+.heading {
+  margin: 0 0 var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  font-weight: var(--weight-semibold);
+  color: var(--accent);
+}
+
+/* Sub-heading / tagline */
+.subHeading {
+  margin: 0 0 var(--space-8);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+  line-height: var(--leading-snug);
+}
+
+/* ─── Verdict banner ─────────────────────────────────────── */
+.verdict {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-4);
+  margin-bottom: var(--space-8);
+  padding: var(--space-7) var(--space-8);
+  border-radius: var(--radius-xl);
+  border: 1px solid;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.verdictIssues {
+  background: var(--status-watch-soft);
+  border-color: rgba(253, 230, 138, 0.3);
+  color: var(--status-watch);
+}
+
+.verdictOk {
+  background: var(--status-ok-soft);
+  border-color: rgba(134, 239, 172, 0.3);
+  color: var(--status-ok);
+}
+
+.verdictIcon {
+  margin-top: 1px;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+/* ─── Panel list ─────────────────────────────────────────── */
+.panelList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+/* ─── Summary pill (inline in CollapsiblePanel summary slot) */
+.summaryPill {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}
+
+/* ─── Loading state ──────────────────────────────────────── */
+.loadingRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+}
+
+.spinner {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spinner {
+    animation: none;
+  }
+}
+
+.loadingTextOnly {
+  padding: var(--space-4) 0;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+}
+
+/* ─── API error banner ───────────────────────────────────── */
+.apiError {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 134, 160, 0.3);
+  background: var(--status-warn-soft);
+  font-size: var(--text-sm);
+  color: var(--status-warn);
+  line-height: var(--leading-snug);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+/* Retry button (error state — warn-tinted) */
+.retryButtonError {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  padding: 0 var(--space-6);
+  background: rgba(255, 134, 160, 0.18);
+  color: var(--status-warn);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  border: 1px solid rgba(255, 134, 160, 0.35);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.retryButtonError:hover {
+  background: rgba(255, 134, 160, 0.28);
+}
+
+.retryButtonError:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--status-warn);
+}
+
+/* ─── Refresh button (success state) ────────────────────── */
+.refreshRow {
+  margin-top: var(--space-8);
+  display: flex;
+  justify-content: flex-end;
+}
+
+.refreshButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  padding: 0 var(--space-6);
+  background: var(--surface-2);
+  color: var(--ink-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.refreshButton:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--border-accent);
+}
+
+.refreshButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .refreshButton,
+  .retryButtonError {
+    transition: none;
+  }
+}

--- a/src/components/SuggestionsPanel.tsx
+++ b/src/components/SuggestionsPanel.tsx
@@ -6,6 +6,7 @@ import WeakCardList from "@/components/WeakCardList";
 import UpgradeList from "@/components/UpgradeList";
 import LandSwapList from "@/components/LandSwapList";
 import CollapsiblePanel from "@/components/CollapsiblePanel";
+import styles from "./SuggestionsPanel.module.css";
 import {
   identifyWeakCards,
   selectUpgradeCandidates,
@@ -223,31 +224,28 @@ export default function SuggestionsPanel({
     <section
       data-testid="suggestions-panel"
       aria-labelledby="suggestions-heading"
+      className={styles.section}
     >
       <h3
         id="suggestions-heading"
-        className="mb-1 text-sm font-semibold uppercase tracking-wide text-slate-300"
+        className={styles.heading}
       >
         Swap Suggestions
       </h3>
-      <p className="mb-4 text-xs text-slate-400">
+      <p className={styles.subHeading}>
         Cards to consider cutting and what to add instead
       </p>
 
       {/* Verdict banner */}
       <div
         data-testid="suggestions-verdict"
-        className={`mb-4 flex items-start gap-2 rounded-lg border px-4 py-3 text-sm ${
-          hasIssues
-            ? "border-amber-500/30 bg-amber-500/10 text-amber-200"
-            : "border-green-500/30 bg-green-500/10 text-green-300"
-        }`}
+        className={`${styles.verdict} ${hasIssues ? styles.verdictIssues : styles.verdictOk}`}
       >
         {hasIssues ? (
           <svg
             viewBox="0 0 20 20"
             fill="currentColor"
-            className="mt-0.5 h-4 w-4 shrink-0 text-amber-400"
+            className={styles.verdictIcon}
             aria-hidden="true"
           >
             <path
@@ -260,7 +258,7 @@ export default function SuggestionsPanel({
           <svg
             viewBox="0 0 20 20"
             fill="currentColor"
-            className="mt-0.5 h-4 w-4 shrink-0 text-green-400"
+            className={styles.verdictIcon}
             aria-hidden="true"
           >
             <path
@@ -273,7 +271,7 @@ export default function SuggestionsPanel({
         <span>{verdictText}</span>
       </div>
 
-      <div className="flex flex-col gap-4">
+      <div className={styles.panelList}>
         {/* ----------------------------------------------------------------- */}
         {/* Section 1: Cards Your Deck Needs (Category Fills)                 */}
         {/* ----------------------------------------------------------------- */}
@@ -285,7 +283,7 @@ export default function SuggestionsPanel({
           testId="suggestions-fills-panel"
           summary={
             gaps.length > 0 ? (
-              <span className="text-xs text-slate-400">
+              <span className={styles.summaryPill}>
                 {gaps.length} categor{gaps.length !== 1 ? "ies" : "y"} underserved
               </span>
             ) : undefined
@@ -294,26 +292,26 @@ export default function SuggestionsPanel({
           {fetchStatus === "loading" && (
             <div
               data-testid="suggestions-loading"
-              className="flex items-center gap-2 text-sm text-slate-400 py-2"
+              className={styles.loadingRow}
             >
               <svg
-                className="h-4 w-4 animate-spin motion-reduce:hidden"
+                className={styles.spinner}
                 viewBox="0 0 24 24"
                 fill="none"
                 aria-hidden="true"
               >
                 <circle
-                  className="opacity-25"
                   cx="12"
                   cy="12"
                   r="10"
                   stroke="currentColor"
                   strokeWidth="4"
+                  style={{ opacity: 0.25 }}
                 />
                 <path
-                  className="opacity-75"
                   fill="currentColor"
                   d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  style={{ opacity: 0.75 }}
                 />
               </svg>
               Loading recommendations...
@@ -323,14 +321,14 @@ export default function SuggestionsPanel({
           {fetchStatus === "error" && (
             <div
               data-testid="suggestions-api-error"
-              className="flex flex-col gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-300"
+              className={styles.apiError}
             >
               <p>Could not load fill recommendations: {fetchError}</p>
               <button
                 type="button"
                 data-testid="refresh-suggestions"
                 onClick={() => fetchSuggestions(true)}
-                className="self-start rounded bg-red-500/20 px-2.5 py-1 text-xs font-medium text-red-300 hover:bg-red-500/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                className={styles.retryButtonError}
               >
                 Retry
               </button>
@@ -353,7 +351,7 @@ export default function SuggestionsPanel({
           testId="suggestions-weak-panel"
           summary={
             weakCards.length > 0 ? (
-              <span className="text-xs text-slate-400">
+              <span className={styles.summaryPill}>
                 {weakCards.length} card{weakCards.length !== 1 ? "s" : ""} underperforming
               </span>
             ) : undefined
@@ -373,7 +371,7 @@ export default function SuggestionsPanel({
           testId="suggestions-land-swap-panel"
           summary={
             landSwap ? (
-              <span className="text-xs text-slate-400">
+              <span className={styles.summaryPill}>
                 {landSwap.gap} land{landSwap.gap !== 1 ? "s" : ""} short
               </span>
             ) : undefined
@@ -393,20 +391,20 @@ export default function SuggestionsPanel({
           testId="suggestions-upgrades-panel"
           summary={
             upgrades.length > 0 ? (
-              <span className="text-xs text-slate-400">
+              <span className={styles.summaryPill}>
                 {upgrades.length} card{upgrades.length !== 1 ? "s" : ""} with alternatives
               </span>
             ) : undefined
           }
         >
           {fetchStatus === "loading" && (
-            <div className="text-sm text-slate-400 py-2">
+            <div className={styles.loadingTextOnly}>
               Loading upgrade alternatives...
             </div>
           )}
 
           {fetchStatus === "error" && (
-            <div className="text-sm text-slate-400 py-2">
+            <div className={styles.loadingTextOnly}>
               Could not load upgrades due to an error.
             </div>
           )}
@@ -417,12 +415,12 @@ export default function SuggestionsPanel({
 
       {/* Refresh button */}
       {fetchStatus === "success" && (gaps.length > 0 || upgradeCandidates.length > 0) && (
-        <div className="mt-4 flex justify-end">
+        <div className={styles.refreshRow}>
           <button
             type="button"
             data-testid="refresh-suggestions"
             onClick={() => fetchSuggestions(true)}
-            className="rounded-md border border-slate-700 bg-slate-800 px-3 py-1.5 text-xs font-medium text-slate-300 hover:bg-slate-700 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-400 transition-colors"
+            className={styles.refreshButton}
           >
             Refresh Suggestions
           </button>


### PR DESCRIPTION
## Summary

- Migrates `src/components/SuggestionsPanel.tsx` (433 lines) from Tailwind slate utilities to a co-located CSS Module (`SuggestionsPanel.module.css`) driven by Astral semantic tokens
- Preserves all behavior, test contracts, and sub-component interfaces exactly

## Visual changes

| Element | Before | After |
|---|---|---|
| Section heading | `text-sm font-semibold uppercase tracking-wide text-slate-300` | Mono eyebrow `var(--accent)` `var(--tracking-eyebrow)` |
| Tagline | `text-xs text-slate-400` | Spectral italic `var(--text-sm)` `var(--ink-tertiary)` |
| Verdict banner (issues) | `border-amber-500/30 bg-amber-500/10 text-amber-200` | `var(--status-watch-soft)` + amber border token |
| Verdict banner (ok) | `border-green-500/30 bg-green-500/10 text-green-300` | `var(--status-ok-soft)` + green border token |
| API error banner | `border-red-500/30 bg-red-500/10 text-red-300` | `var(--status-warn-soft)` + `var(--status-warn)` |
| Retry button | `rounded bg-red-500/20 text-xs` | Mono uppercase pill matching `DeckImportSection.module.css` |
| Refresh button | `border-slate-700 bg-slate-800 text-slate-300` | Mono uppercase pill with `var(--accent-soft)` hover |
| Summary pills | `text-xs text-slate-400` | Mono uppercase `var(--ink-tertiary)` |
| Loading spinner | Tailwind `animate-spin motion-reduce:hidden` | CSS `@keyframes spin`, honors reduced-motion via token |
| Focus rings | `focus-visible:ring-2 focus-visible:ring-purple-400` | `0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent)` |

## Preserved contracts

- All `data-testid`: `suggestions-panel`, `suggestions-verdict`, `suggestions-loading`, `suggestions-api-error`, `refresh-suggestions` (×2), `suggestions-fills-panel`, `suggestions-weak-panel`, `suggestions-land-swap-panel`, `suggestions-upgrades-panel`
- All `aria-labelledby`, `id`, button text, label text
- All conditional render guards and fetch/cache logic
- Exported `SuggestionsPanelProps` interface unchanged
- Sub-components `CategoryFillList`, `WeakCardList`, `UpgradeList`, `LandSwapList`, `CollapsiblePanel` untouched
- Per-axis/role colors from data left as-is (deliberate brand colors in sub-components)

## TDD verification

```
CI=1 npx playwright test --config playwright.config.ts e2e/suggestions-tab.spec.ts --project=chromium --reporter=line
14 passed (8.5s)
```

Build: `npm run build` exits 0 with no type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)