### PR TITLE
feat(deck): migrate GoldfishSimulator to Astral tokens

### DIFF
--- a/src/components/GoldfishSimulator.module.css
+++ b/src/components/GoldfishSimulator.module.css
@@ -1,0 +1,454 @@
+/* ─────────────────────────────────────────────────────────────
+   GoldfishSimulator — Astral token-driven styles
+   Replaces inline Tailwind utilities with semantic CSS tokens.
+───────────────────────────────────────────────────────────── */
+
+/* Root wrapper */
+.simulator {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-16);
+}
+
+/* ─── Section panel (generic card chrome) ─────────────────── */
+.panel {
+  border-radius: var(--card-radius);
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+  padding: var(--space-12) var(--card-padding);
+}
+
+.panelCompact {
+  padding: var(--space-8) var(--space-12);
+}
+
+/* ─── Section eyebrow headings ─────────────────────────────── */
+.sectionHeading {
+  margin: 0 0 var(--space-8);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  font-weight: var(--weight-medium);
+}
+
+.sectionHeadingSmall {
+  margin: 0 0 var(--space-8);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-secondary);
+  font-weight: var(--weight-medium);
+}
+
+/* ─── Config controls grid ─────────────────────────────────── */
+.controlsGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-12);
+}
+
+@media (min-width: 640px) {
+  .controlsGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.controlGroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.sliderLabel {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  color: var(--ink-tertiary);
+  margin-bottom: var(--space-2);
+}
+
+.sliderLabelValue {
+  font-weight: var(--weight-semibold);
+  color: var(--ink-secondary);
+}
+
+.slider {
+  width: 100%;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.sliderRange {
+  display: flex;
+  justify-content: space-between;
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  color: var(--ink-disabled);
+  margin-top: var(--space-1);
+}
+
+.positionLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: 0.04em;
+  color: var(--ink-tertiary);
+  margin-bottom: var(--space-5);
+}
+
+.radioGroup {
+  display: flex;
+  gap: var(--space-10);
+}
+
+.radioLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  font-size: var(--text-sm);
+  color: var(--ink-secondary);
+  cursor: pointer;
+}
+
+.radioInput {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* ─── Loading state ────────────────────────────────────────── */
+.loadingHeading {
+  margin: 0 0 var(--space-8);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: var(--ink-secondary);
+}
+
+.progressTrack {
+  height: 6px;
+  width: 100%;
+  overflow: hidden;
+  border-radius: var(--radius-pill);
+  background: var(--surface-2-hi);
+  margin-bottom: var(--space-8);
+}
+
+.progressFill {
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-gradient);
+  transition: width var(--dur-base) var(--ease-out);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .progressFill {
+    transition: none;
+  }
+}
+
+.stepsList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.stepItem {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  font-size: var(--text-sm);
+}
+
+.stepIconDone {
+  color: var(--status-ok);
+  flex-shrink: 0;
+}
+
+.stepIconActive {
+  color: var(--accent);
+  flex-shrink: 0;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stepIconActive {
+    animation: none;
+  }
+}
+
+.stepIconPending {
+  color: var(--ink-disabled);
+  flex-shrink: 0;
+}
+
+.stepLabelDone {
+  color: var(--ink-secondary);
+}
+
+.stepLabelActive {
+  color: var(--accent);
+}
+
+.stepLabelPending {
+  color: var(--ink-tertiary);
+}
+
+/* ─── Error state ──────────────────────────────────────────── */
+.errorPanel {
+  border-radius: var(--card-radius);
+  border: 1px solid rgba(255, 134, 160, 0.30);
+  background: var(--status-warn-soft);
+  padding: var(--space-12) var(--card-padding);
+  font-size: var(--text-sm);
+  color: var(--status-warn);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+/* ─── Empty / starting state ───────────────────────────────── */
+.emptyPanel {
+  border-radius: var(--card-radius);
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  padding: var(--space-32) var(--card-padding);
+  text-align: center;
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.emptyText {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}
+
+/* ─── Stats tagline ────────────────────────────────────────── */
+.statsTagline {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+  margin: 0 0 var(--space-8);
+  line-height: var(--leading-snug);
+}
+
+/* ─── Stat cards grid ──────────────────────────────────────── */
+.statGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-8);
+}
+
+@media (min-width: 640px) {
+  .statGrid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.statGridSecondary {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-8);
+  margin-top: var(--space-8);
+}
+
+@media (min-width: 640px) {
+  .statGridSecondary {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+/* ─── Stat tile (StatCard sub-component) ───────────────────── */
+.statTile {
+  padding: var(--space-7) var(--space-8);
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--border);
+  background: var(--surface-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.statTileLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--ink-tertiary);
+  text-transform: uppercase;
+  line-height: 1;
+}
+
+.statTileValue {
+  font-family: var(--font-serif);
+  font-size: var(--text-h3);
+  font-weight: var(--weight-medium);
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
+}
+
+.statTileValuePurple {
+  background: var(--accent-gradient);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+.statTileValueBlue {
+  color: var(--cyan-400);
+}
+
+.statTileValueGreen {
+  color: var(--status-ok);
+}
+
+.statTileValueAmber {
+  color: var(--status-watch);
+}
+
+.statTileSub {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  color: var(--ink-tertiary);
+  letter-spacing: 0.04em;
+}
+
+/* ─── Ramp sources table ───────────────────────────────────── */
+.tablePanel {
+  border-radius: var(--card-radius);
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  overflow: hidden;
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.table {
+  width: 100%;
+  font-size: var(--text-sm);
+  border-collapse: collapse;
+}
+
+.tableHead th {
+  padding: var(--space-5) var(--space-8);
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+  font-weight: var(--weight-medium);
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+}
+
+.tableHead th:not(:first-child) {
+  text-align: right;
+}
+
+.tableRow {
+  border-bottom: 1px solid var(--border);
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.tableRow:last-child {
+  border-bottom: none;
+}
+
+.tableRow:hover {
+  background: var(--accent-soft);
+}
+
+.tdName {
+  padding: var(--space-5) var(--space-8);
+  color: var(--ink-secondary);
+}
+
+.tdType {
+  padding: var(--space-5) var(--space-8);
+  white-space: nowrap;
+}
+
+.tdNum {
+  padding: var(--space-5) var(--space-8);
+  text-align: right;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--ink-tertiary);
+  white-space: nowrap;
+}
+
+.tdNumPrimary {
+  color: var(--ink-secondary);
+}
+
+/* ─── Ramp type badge ──────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-5);
+  font-size: var(--text-caption);
+  font-family: var(--font-mono);
+  letter-spacing: var(--tag-tracking);
+  font-weight: var(--weight-medium);
+}
+
+.badgeRock {
+  background: var(--status-watch-soft);
+  color: var(--status-watch);
+}
+
+.badgeDork {
+  background: rgba(134, 239, 172, 0.12);
+  color: var(--status-ok);
+}
+
+.badgeLandSearch {
+  background: rgba(134, 239, 172, 0.08);
+  color: var(--ok-400);
+}
+
+.badgeRitual {
+  background: var(--status-warn-soft);
+  color: var(--status-warn);
+}
+
+/* ─── Chart wrapper ────────────────────────────────────────── */
+.chartWrapper {
+  border-radius: var(--card-radius);
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  padding: var(--space-8) var(--space-12);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+/* ─── Timeline wrapper ─────────────────────────────────────── */
+.timelineWrapper {
+  margin-top: var(--space-12);
+}
+
+/* ─── Focus ring (interactive elements) ────────────────────── */
+.slider:focus-visible,
+.radioInput:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+  border-radius: var(--radius-sm);
+}

--- a/src/components/GoldfishSimulator.tsx
+++ b/src/components/GoldfishSimulator.tsx
@@ -15,6 +15,7 @@ import GoldfishGameSelector from "@/components/GoldfishGameSelector";
 import type { GameSelection } from "@/components/GoldfishGameSelector";
 import ComboAssemblyChart from "@/components/ComboAssemblyChart";
 import BoardMilestones from "@/components/BoardMilestones";
+import styles from "./GoldfishSimulator.module.css";
 
 interface GoldfishSimulatorProps {
   deck: DeckData;
@@ -39,20 +40,20 @@ interface StatCardProps {
 }
 
 function StatCard({ label, value, sub, accent = "purple" }: StatCardProps) {
-  const accentClass =
+  const valueClass =
     accent === "blue"
-      ? "text-blue-300"
+      ? styles.statTileValueBlue
       : accent === "green"
-        ? "text-green-300"
+        ? styles.statTileValueGreen
         : accent === "amber"
-          ? "text-amber-300"
-          : "text-purple-300";
+          ? styles.statTileValueAmber
+          : styles.statTileValuePurple;
 
   return (
-    <div className="rounded-xl border border-slate-700 bg-slate-800/50 px-4 py-3">
-      <p className="text-xs text-slate-500">{label}</p>
-      <p className={`text-xl font-bold ${accentClass}`}>{value}</p>
-      {sub && <p className="text-xs text-slate-400 mt-0.5">{sub}</p>}
+    <div className={styles.statTile}>
+      <p className={styles.statTileLabel}>{label}</p>
+      <p className={`${styles.statTileValue} ${valueClass}`}>{value}</p>
+      {sub && <p className={styles.statTileSub}>{sub}</p>}
     </div>
   );
 }
@@ -65,10 +66,10 @@ function ProgressSteps({
   progress: number;
 }) {
   return (
-    <div className="space-y-3">
-      <div className="h-2 w-full overflow-hidden rounded-full bg-slate-700">
+    <div>
+      <div className={styles.progressTrack}>
         <div
-          className="h-2 rounded-full bg-purple-500 transition-all duration-300"
+          className={styles.progressFill}
           style={{ width: `${progress}%` }}
           role="progressbar"
           aria-valuenow={progress}
@@ -77,29 +78,29 @@ function ProgressSteps({
           aria-label={`Simulation progress: ${progress}%`}
         />
       </div>
-      <ul className="space-y-1.5">
+      <ul className={styles.stepsList}>
         {steps.map((step) => (
-          <li key={step.id} className="flex items-center gap-2 text-sm">
+          <li key={step.id} className={styles.stepItem}>
             {step.status === "done" ? (
-              <span className="text-green-400" aria-hidden="true">
+              <span className={styles.stepIconDone} aria-hidden="true">
                 ✓
               </span>
             ) : step.status === "active" ? (
-              <span className="animate-spin text-purple-400" aria-hidden="true">
+              <span className={styles.stepIconActive} aria-hidden="true">
                 ◌
               </span>
             ) : (
-              <span className="text-slate-600" aria-hidden="true">
+              <span className={styles.stepIconPending} aria-hidden="true">
                 ○
               </span>
             )}
             <span
               className={
                 step.status === "done"
-                  ? "text-slate-300"
+                  ? styles.stepLabelDone
                   : step.status === "active"
-                    ? "text-purple-300"
-                    : "text-slate-500"
+                    ? styles.stepLabelActive
+                    : styles.stepLabelPending
               }
             >
               {step.label}
@@ -285,27 +286,27 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
   }
 
   return (
-    <div data-testid="goldfish-simulator" className="space-y-6">
+    <div data-testid="goldfish-simulator" className={styles.simulator}>
       {/* Config controls */}
       <section
         aria-labelledby="goldfish-config-heading"
-        className="rounded-xl border border-slate-700 bg-slate-800/50 p-4"
+        className={styles.panel}
       >
         <h4
           id="goldfish-config-heading"
-          className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-300"
+          className={styles.sectionHeadingSmall}
         >
           Simulation Settings
         </h4>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className={styles.controlsGrid}>
           {/* Turns slider */}
-          <div>
+          <div className={styles.controlGroup}>
             <label
               htmlFor="goldfish-turns"
-              className="mb-1 flex justify-between text-xs text-slate-400"
+              className={styles.sliderLabel}
             >
               <span>Turns</span>
-              <span className="font-semibold text-slate-300">{config.turns}</span>
+              <span className={styles.sliderLabelValue}>{config.turns}</span>
             </label>
             <input
               id="goldfish-turns"
@@ -315,23 +316,23 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
               step={1}
               value={config.turns}
               onChange={handleTurnsChange}
-              className="w-full accent-purple-500"
+              className={styles.slider}
               data-testid="goldfish-turns-slider"
             />
-            <div className="flex justify-between text-xs text-slate-600">
+            <div className={styles.sliderRange}>
               <span>5</span>
               <span>15</span>
             </div>
           </div>
 
           {/* Iterations slider */}
-          <div>
+          <div className={styles.controlGroup}>
             <label
               htmlFor="goldfish-iterations"
-              className="mb-1 flex justify-between text-xs text-slate-400"
+              className={styles.sliderLabel}
             >
               <span>Iterations</span>
-              <span className="font-semibold text-slate-300">
+              <span className={styles.sliderLabelValue}>
                 {config.iterations.toLocaleString()}
               </span>
             </label>
@@ -343,42 +344,42 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
               step={100}
               value={config.iterations}
               onChange={handleIterationsChange}
-              className="w-full accent-purple-500"
+              className={styles.slider}
               data-testid="goldfish-iterations-slider"
             />
-            <div className="flex justify-between text-xs text-slate-600">
+            <div className={styles.sliderRange}>
               <span>100</span>
               <span>5,000</span>
             </div>
           </div>
 
           {/* Play/Draw toggle */}
-          <div>
-            <p className="mb-1 text-xs text-slate-400">Position</p>
-            <div className="flex gap-3">
-              <label className="flex cursor-pointer items-center gap-2 text-sm">
+          <div className={styles.controlGroup}>
+            <p className={styles.positionLabel}>Position</p>
+            <div className={styles.radioGroup}>
+              <label className={styles.radioLabel}>
                 <input
                   type="radio"
                   name="goldfish-position"
                   value="play"
                   checked={config.onThePlay}
                   onChange={handleOnThePlayChange}
-                  className="accent-purple-500"
+                  className={styles.radioInput}
                   data-testid="goldfish-on-the-play"
                 />
-                <span className="text-slate-300">On the play</span>
+                <span>On the play</span>
               </label>
-              <label className="flex cursor-pointer items-center gap-2 text-sm">
+              <label className={styles.radioLabel}>
                 <input
                   type="radio"
                   name="goldfish-position"
                   value="draw"
                   checked={!config.onThePlay}
                   onChange={handleOnThePlayChange}
-                  className="accent-purple-500"
+                  className={styles.radioInput}
                   data-testid="goldfish-on-the-draw"
                 />
-                <span className="text-slate-300">On the draw</span>
+                <span>On the draw</span>
               </label>
             </div>
           </div>
@@ -387,8 +388,8 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
 
       {/* Loading state */}
       {loading && (
-        <div className="rounded-xl border border-slate-700 bg-slate-800/50 p-5">
-          <h4 className="mb-3 text-sm font-semibold text-slate-300">
+        <div className={styles.panel}>
+          <h4 className={styles.loadingHeading}>
             Running {config.iterations.toLocaleString()} games...
           </h4>
           <ProgressSteps steps={steps} progress={progress} />
@@ -397,7 +398,7 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
 
       {/* Error state */}
       {error && (
-        <div className="rounded-xl border border-red-800/50 bg-red-900/20 p-4 text-sm text-red-300">
+        <div className={styles.errorPanel}>
           Simulation error: {error}
         </div>
       )}
@@ -409,15 +410,15 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
           <section aria-labelledby="goldfish-stats-heading">
             <h4
               id="goldfish-stats-heading"
-              className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-300"
+              className={styles.sectionHeading}
             >
               Aggregate Statistics
             </h4>
-            <p className="mb-3 text-xs text-slate-500 italic">
+            <p className={styles.statsTagline}>
               Assumes optimal solitaire play with no interaction.
             </p>
             <div
-              className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+              className={styles.statGrid}
               data-testid="goldfish-stat-cards"
             >
               <StatCard
@@ -452,7 +453,7 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
 
             {/* Advanced stat cards */}
             <div
-              className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4"
+              className={styles.statGridSecondary}
               data-testid="goldfish-advanced-stat-cards"
             >
               <StatCard
@@ -491,44 +492,44 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
             <section aria-labelledby="goldfish-ramp-heading">
               <h4
                 id="goldfish-ramp-heading"
-                className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-300"
+                className={styles.sectionHeading}
               >
                 Ramp Sources ({stats.rampSources.length})
               </h4>
-              <div className="rounded-xl border border-slate-700 bg-slate-800/50 overflow-hidden">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-slate-700 text-xs text-slate-500">
-                      <th className="px-3 py-2 text-left font-semibold">Card</th>
-                      <th className="px-3 py-2 text-left font-semibold whitespace-nowrap">Type</th>
-                      <th className="px-3 py-2 text-right font-semibold whitespace-nowrap">CMC</th>
-                      <th className="px-3 py-2 text-right font-semibold whitespace-nowrap">Cast Rate</th>
-                      <th className="px-3 py-2 text-right font-semibold whitespace-nowrap">Avg Turn</th>
+              <div className={styles.tablePanel}>
+                <table className={styles.table}>
+                  <thead className={styles.tableHead}>
+                    <tr>
+                      <th>Card</th>
+                      <th>Type</th>
+                      <th>CMC</th>
+                      <th>Cast Rate</th>
+                      <th>Avg Turn</th>
                     </tr>
                   </thead>
                   <tbody>
                     {stats.rampSources.map((src: RampSource) => (
                       <tr
                         key={src.name}
-                        className="border-b border-slate-700/50 last:border-0"
+                        className={styles.tableRow}
                       >
-                        <td className="px-3 py-1.5 text-slate-300">{src.name}</td>
-                        <td className="px-3 py-1.5">
-                          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                        <td className={styles.tdName}>{src.name}</td>
+                        <td className={styles.tdType}>
+                          <span className={`${styles.badge} ${
                             src.type === "rock"
-                              ? "bg-amber-500/20 text-amber-300"
+                              ? styles.badgeRock
                               : src.type === "dork"
-                                ? "bg-green-500/20 text-green-300"
+                                ? styles.badgeDork
                                 : src.type === "land-search"
-                                  ? "bg-emerald-500/20 text-emerald-300"
-                                  : "bg-red-500/20 text-red-300"
+                                  ? styles.badgeLandSearch
+                                  : styles.badgeRitual
                           }`}>
                             {src.type === "rock" ? "Rock" : src.type === "dork" ? "Dork" : src.type === "land-search" ? "Land Search" : "Ritual"}
                           </span>
                         </td>
-                        <td className="px-3 py-1.5 text-right text-slate-400">{src.cmc}</td>
-                        <td className="px-3 py-1.5 text-right text-slate-300">{src.castRate}%</td>
-                        <td className="px-3 py-1.5 text-right text-slate-400">
+                        <td className={styles.tdNum}>{src.cmc}</td>
+                        <td className={`${styles.tdNum} ${styles.tdNumPrimary}`}>{src.castRate}%</td>
+                        <td className={styles.tdNum}>
                           {src.avgCastTurn !== null ? `T${src.avgCastTurn}` : "—"}
                         </td>
                       </tr>
@@ -543,11 +544,11 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
           {comboStats && comboStats.perCombo.length > 0 && (
             <section
               aria-labelledby="goldfish-combo-heading"
-              className="rounded-xl border border-slate-700 bg-slate-800/50 p-4"
+              className={styles.panel}
             >
               <h4
                 id="goldfish-combo-heading"
-                className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate-300"
+                className={styles.sectionHeading}
               >
                 Combo Assembly
               </h4>
@@ -559,7 +560,7 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
           {milestones.length > 0 && (
             <section
               aria-labelledby="goldfish-milestones-outer-heading"
-              className="rounded-xl border border-slate-700 bg-slate-800/50 p-4"
+              className={styles.panel}
             >
               <span id="goldfish-milestones-outer-heading" className="sr-only">
                 Board State Milestones
@@ -572,11 +573,11 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
           <section aria-labelledby="goldfish-chart-heading">
             <h4
               id="goldfish-chart-heading"
-              className="mb-2 text-sm font-semibold uppercase tracking-wide text-slate-300"
+              className={styles.sectionHeading}
             >
               Mana Development
             </h4>
-            <div className="rounded-xl border border-slate-700 bg-slate-800/50 p-3">
+            <div className={styles.chartWrapper}>
               <GoldfishManaChart stats={stats} turns={config.turns} />
             </div>
           </section>
@@ -591,7 +592,7 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
               />
 
               {displayedGame && (
-                <div className="mt-4">
+                <div className={styles.timelineWrapper}>
                   <GoldfishTurnTimeline game={displayedGame} />
                 </div>
               )}
@@ -602,8 +603,8 @@ export default function GoldfishSimulator({ deck, cardMap }: GoldfishSimulatorPr
 
       {/* Empty state */}
       {!loading && !error && !stats && (
-        <div className="rounded-xl border border-slate-700 bg-slate-800/50 p-8 text-center">
-          <p className="text-slate-400">
+        <div className={styles.emptyPanel}>
+          <p className={styles.emptyText}>
             Simulation starting...
           </p>
         </div>


### PR DESCRIPTION
## Summary

Migrates `GoldfishSimulator.tsx` (613 lines) from slate Tailwind utilities to a co-located CSS Module driven entirely by Astral semantic tokens. Originally produced by a parallel subagent run alongside the SuggestionsPanel migration (#102) — extracted into its own focused PR.

Follows up [#98](https://github.com/MichaelMillsOfficial/deck-evaluator/pull/98) (CollapsiblePanel etc.).

## What changed

- **`StatCard` sub-component** now follows the `<StatTile>` pattern: mono caption label + Spectral serif numeric, with accent variants via `var(--accent-gradient)` / `var(--status-ok)` / `var(--status-watch)` / `var(--status-warn)`
- **Section headings** are mono-uppercase `var(--accent)` eyebrows at `var(--tracking-eyebrow)`
- **Panels** use `var(--card-bg)` + `var(--card-border)` + `blur-sm` (matching the rest of the deck-results chrome)
- **Ramp type badges** use status-token soft fills
- **Progress bar** uses `var(--accent-gradient)` for the filled track
- **Focus rings** follow the design-system spec: `box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent)`
- **Animations** honor `prefers-reduced-motion` via the existing token-driven duration overrides

## Preserved (load-bearing)

Every `data-testid`, `aria-*`, `role`, `id`, button text, `title` attribute, and the exported props interface are preserved exactly. State machines (turn timeline, simulation results) are untouched. `<ManaCost>` rendering inside the simulator is unchanged.

## TDD verification

`e2e/goldfish-tab.spec.ts`: **10/10 passed** (chromium, CI=1, ~20s). Production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)