### PR TITLE
fix(interactions): portal RemovalImpactFloatingPanel to document.body

### DIFF
--- a/src/components/RemovalImpactFloatingPanel.tsx
+++ b/src/components/RemovalImpactFloatingPanel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
 import type { RemovalImpact } from "@/lib/interaction-engine/types";
 import RemovalImpactInspector from "@/components/RemovalImpactInspector";
 
@@ -51,8 +52,14 @@ export default function RemovalImpactFloatingPanel({
   }, [isOpen]);
 
   if (!isOpen) return null;
+  if (typeof document === "undefined") return null;
 
-  return (
+  // Render into document.body so the panel's `position: fixed` is anchored
+  // to the viewport — escaping any ancestor that creates a containing block
+  // via transform, filter, backdrop-filter, will-change, or contain: paint.
+  // Without this portal, the panel was being captured by ancestor
+  // backdrop-filter rules and scrolling away with its parent.
+  return createPortal(
     // No backdrop — panel floats without blocking page interaction.
     // Positioned fixed to the right side of the viewport so it stays
     // visible while the user scrolls or clicks cards in the centrality list.
@@ -123,6 +130,7 @@ export default function RemovalImpactFloatingPanel({
           Press <kbd className="font-mono">Esc</kbd> to dismiss
         </p>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Summary

Restores the sticky-to-viewport behavior of the Card Centrality removal-impact panel.

## Root cause

`RemovalImpactFloatingPanel` uses `position: fixed; right-4 top-20` to stick to the viewport's right edge while the user scrolls the centrality list. Recent design-system migrations added `backdrop-filter: blur(...)` to several ancestor wrappers:

- `DeckImportSection.module.css` `.contentPanel` (#93)
- `CollapsiblePanel.module.css` `.panel` (#98)
- And other migrated chrome elements

Per the CSS containing-block rules, **any ancestor with `transform`, `filter`, `backdrop-filter`, `will-change: transform`, or `contain: paint` creates a containing block** that captures `position: fixed` descendants. The panel was effectively becoming `position: absolute` relative to its content-panel ancestor — so its right/top offsets were measured from the panel's edges, and scrolling the page slid the floating panel away with the surrounding content.

## Fix

Render the panel through `createPortal(..., document.body)` so it escapes every ancestor containing block and the `position: fixed` resolves against the viewport again. This is the same pattern the design-system `<Sheet>` primitive already uses (shipped in #87).

```diff
+ import { createPortal } from \"react-dom\";

  if (!isOpen) return null;
+ if (typeof document === \"undefined\") return null;

- return (
+ return createPortal(
    <div role=\"dialog\" ... className=\"fixed right-4 top-20 z-50 ...\">
      ...
- </div>;
+ </div>,
+   document.body,
+ );
```

10 lines net. Behavior, ARIA, focus management, Esc-to-dismiss, and all `data-testid` contracts unchanged. Added an SSR guard (`typeof document === \"undefined\" → return null`) so the portal call is safe outside the browser.

## TDD

```
✓ 22 passed (13.9s)
   interaction-enhancements (~10) · interactions-tab (~12)
   — including the spec that asserts on the
     `removal-impact-floating-panel` testid
```

Production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)