### PR TITLE
Phase 1: routing skeleton + sessionStorage-backed deck context

### DIFF
--- a/docs/plans/astral-journey-restructure.md
+++ b/docs/plans/astral-journey-restructure.md
@@ -1,0 +1,283 @@
+# Astral Journey Restructure
+
+## Context
+
+The Astral design system migration is complete at the surface level — every slate
+Tailwind module has been swapped for semantic tokens, fonts, and primitives. But
+we adopted only the *tone* of the design system, not its *journey*. The handoff
+in `design-system/CLAUDE.md` and `design-system/README.md` describes a deliberate
+narrative arc — **Import → Loading ritual → Reading (verdict-first) → Drill-down
+sub-routes** — that the current app does not deliver. Today the user pastes a
+deck and is dropped into a single long scrolling page with 12 collapsible
+analysis panels and no synthesis moment.
+
+This plan reworks the app to match the design system's journey:
+
+- A dedicated import screen at `/`
+- A cosmic `/loading` ritual with a minimum visible floor
+- A verdict-first `/reading` landing — eyebrow, serif deck name, italic
+  tagline, power dial, headline stat tiles — using the already-built but
+  unused `<DeckHero>` primitive
+- Real sub-routes for every drill-down: `/reading/cards`, `/reading/goldfish`,
+  `/reading/suggestions`, `/reading/add`, `/reading/compare`, `/reading/share`
+- Editorial header pattern (eyebrow + serif title + italic tagline) on every
+  sub-route, matching the design-system rhythm
+
+The vision is the full look-and-feel refresh promised by the design system, not
+just the surface tokens. All sub-routes are in scope — compare, add, and share
+are first-class deliverables, not stubs.
+
+### User decisions captured up-front
+
+- **Deck state across routes**: persist parsed + enriched deck to
+  `sessionStorage`, keyed by a deck id. A refresh on `/reading/cards` rehydrates
+  rather than kicking back to `/`. Cleared on explicit "new reading."
+- **Loading screen**: real ritual with a **minimum floor of ~2s** — if analysis
+  finishes faster, the loader keeps animating until the floor elapses; if it
+  takes longer, the loader stays visible until done. The 12s figure in the
+  design system is the *prototype* upper bound, not a target.
+- **Scope**: full rework. `/reading/compare`, `/reading/add`,
+  `/reading/share` are all in scope, not deferred.
+
+## Phased delivery
+
+Each phase ships as one PR (or a small parallelizable cluster), is merged
+independently, and leaves the app in a working state. Per established pattern:
+branch off `master` per phase, open PR, merge, pull, continue.
+
+### Phase 1 — Routing skeleton & shared deck store
+
+Move the existing results UI under `/reading` without changing visuals. Set
+up the shared deck store and route shell.
+
+- [ ] Create `src/lib/deck-session.ts` — typed sessionStorage helpers
+  (`saveDeckSession`, `loadDeckSession`, `clearDeckSession`) keyed by a
+  generated deck id. Stores `{ deck, cardMap, analysisResults, spellbookCombos,
+  createdAt }`.
+- [ ] Create `src/contexts/DeckSessionContext.tsx` — React context that
+  hydrates from sessionStorage on mount, exposes deck + cardMap + analysis
+  results to descendants, and re-renders consumers on session change.
+- [ ] Create `src/app/reading/layout.tsx` — wraps children in
+  `DeckSessionProvider`; redirects to `/` if no session present.
+- [ ] Create `src/app/reading/page.tsx` — temporary stub that renders the
+  *current* full results view (everything from today's `page.tsx` post-import).
+  Visual parity with today.
+- [ ] Update `src/app/page.tsx` — strip the post-import results view; on
+  successful import, save to sessionStorage and `router.push("/reading")`.
+- [ ] Convert sidebar section nav from in-page anchors to `<Link>` routes
+  (placeholder routes for now — they all resolve to `/reading` until Phase 4).
+- [ ] Add Playwright e2e: import a deck, assert URL transitions to `/reading`,
+  refresh page, assert deck still rendered (sessionStorage hydration).
+
+**Files**
+
+| File | Action |
+|---|---|
+| `src/lib/deck-session.ts` | Create |
+| `src/contexts/DeckSessionContext.tsx` | Create |
+| `src/app/reading/layout.tsx` | Create |
+| `src/app/reading/page.tsx` | Create |
+| `src/app/page.tsx` | Modify — remove results, push on submit |
+| `src/components/DeckSidebar.tsx` | Modify — links instead of anchors |
+| `e2e/reading-routing.spec.ts` | Create |
+
+**Verification**: import a deck, observe URL becomes `/reading`, refresh,
+deck persists; click sidebar items, URL updates; clear session via "new
+reading" button, get redirected to `/`.
+
+### Phase 2 — Loading ritual at `/loading`
+
+Add the cosmic loader between import and reading, with a 2s minimum floor.
+
+- [ ] Create `src/app/loading-ritual/page.tsx` (avoid Next's reserved
+  `loading.tsx` filename — use a distinct route segment, e.g.
+  `/reading/loading` or `/ritual`).
+- [ ] Create `src/components/ritual/CosmicLoader.tsx` — full-bleed cosmos
+  background, centered gradient orb pulsing on `--accent-gradient`, three
+  staggered eyebrow phrases cycling: `DRAWING THE STARS`, `READING THE LANDS`,
+  `COUNTING THE SIGNS`. Honors `prefers-reduced-motion` (static text + orb,
+  no pulse).
+- [ ] Update import submit flow: parse + enrich + analyze → save to
+  sessionStorage with a `status: "ready"` flag → loader polls / subscribes,
+  waits until both `status === "ready"` and `Date.now() - startedAt >= 2000`,
+  then routes to `/reading`.
+- [ ] If parse/enrich errors, save `status: "error"` with message; loader
+  shows the existing alert pattern and a "back to import" button.
+- [ ] Playwright e2e: import → URL is loading route briefly → eventually
+  `/reading`. Use a polling assertion not a fixed sleep.
+
+**Files**
+
+| File | Action |
+|---|---|
+| `src/app/ritual/page.tsx` | Create |
+| `src/app/ritual/ritual.module.css` | Create |
+| `src/components/ritual/CosmicLoader.tsx` | Create |
+| `src/components/ritual/CosmicLoader.module.css` | Create |
+| `src/lib/deck-session.ts` | Extend with `status` field |
+| `src/app/page.tsx` | Modify — push to `/ritual` not `/reading` |
+| `e2e/loading-ritual.spec.ts` | Create |
+
+**Verification**: import a deck, observe loader visible for at least 2s with
+animated phrases; reduced-motion users see static loader; error states show
+recover-friendly message.
+
+### Phase 3 — Verdict-first `/reading` landing
+
+Replace the temporary stub with the real DeckHero verdict screen — the
+synthesis moment the design system was built around.
+
+- [ ] Create `src/lib/deck-tagline.ts` — heuristic that synthesizes a one-line
+  italic tagline from existing analysis: archetype/classification + power
+  level + dominant synergy axis + win-condition count. Examples:
+  "A landfall engine that wins decisively." / "A patient control shell with
+  a single combo finish." / "Aggressive go-wide tokens, fragile to sweepers."
+  Pure function, unit-tested.
+- [ ] Create `src/components/reading/ReadingHero.tsx` — wraps `<DeckHero>`
+  with deck name, tagline, READING eyebrow with date, power dial, and a
+  StatTile row: bracket, power level, total cost, win-condition count.
+- [ ] Create `src/components/reading/ReadingOverview.tsx` — the new `/reading`
+  index. Above the fold: ReadingHero. Below: a short "what's inside" grid
+  linking to each sub-route (cards, goldfish, suggestions, etc.) with a
+  one-line summary per section.
+- [ ] Replace `src/app/reading/page.tsx` stub with ReadingOverview.
+- [ ] Move all existing collapsible analysis panels (commander, composition,
+  mana curve, color distribution, etc.) into `/reading/cards` (Phase 4 will
+  reorganize further; for this phase they're consolidated under `/cards`).
+- [ ] Unit tests for `deck-tagline.ts` covering each archetype branch.
+- [ ] Playwright e2e: `/reading` shows hero + stat tiles + section grid; each
+  section link navigates to its sub-route; tagline matches expected pattern
+  for sample fixtures.
+
+**Files**
+
+| File | Action |
+|---|---|
+| `src/lib/deck-tagline.ts` | Create |
+| `src/components/reading/ReadingHero.tsx` | Create |
+| `src/components/reading/ReadingHero.module.css` | Create |
+| `src/components/reading/ReadingOverview.tsx` | Create |
+| `src/components/reading/ReadingOverview.module.css` | Create |
+| `src/components/DeckHero.tsx` | Modify — wire to ReadingHero if needed |
+| `src/app/reading/page.tsx` | Replace stub with ReadingOverview |
+| `src/app/reading/cards/page.tsx` | Create — host current panels |
+| `tests/unit/deck-tagline.spec.ts` | Create |
+| `e2e/reading-overview.spec.ts` | Create |
+
+**Verification**: import a deck, land on `/reading`, see deck name in serif
+display type, italic tagline, four stat tiles, section grid below; click any
+section card, URL updates and detail loads.
+
+### Phase 4 — Sub-route fan-out (parallelizable)
+
+Each sub-route gets its own page with the editorial header pattern (eyebrow
++ serif title + italic tagline) and existing functionality migrated in. These
+are independent enough to delegate to subagents in parallel via worktrees.
+
+- [ ] **`/reading/cards`** — full card list. Today's `DeckList` +
+  `EnrichedCardRow` move here. Header: `CARDS` eyebrow, "The Sixty-Three"
+  (or count-aware) serif title, italic descriptive tagline.
+- [ ] **`/reading/goldfish`** — host `GoldfishSimulator`. Header:
+  `SIMULATION` eyebrow, "Goldfish Reading" title, italic tagline noting
+  iteration count.
+- [ ] **`/reading/suggestions`** — host `SuggestionsPanel` +
+  `AdditionsPanel` summary. Header: `RECOMMENDATIONS` eyebrow, "What to
+  Cut, What to Add" title.
+- [ ] **`/reading/synergy`** — host `SynergySection` + `InteractionSection`
+  (centrality, chains, loops). Header: `SYNERGIES` eyebrow, "How the Cards
+  Read Together" title.
+- [ ] **`/reading/composition`** — host the analysis panels currently in
+  DeckAnalysis (mana curve, color dist, land efficiency, hypergeometric,
+  budget). Header: `COMPOSITION` eyebrow, "The Shape of the Deck" title.
+- [ ] **`/reading/compare`** — A vs B compare flow. Wire to existing
+  `deck-comparison` infrastructure. Header: `COMPARE` eyebrow.
+- [ ] **`/reading/add`** — candidate finder. Wire to existing
+  `card-swap-suggestions` infrastructure. Header: `CANDIDATES` eyebrow.
+- [ ] **`/reading/share`** — share card export (image + URL + copy). New
+  build using existing analysis data. Header: `SHARE` eyebrow.
+- [ ] Sidebar updates to highlight active route via `usePathname()`.
+- [ ] Playwright e2e per route: header pattern present, key content renders,
+  sidebar marks the active route.
+
+**Files** (per sub-route, repeated)
+
+| File pattern | Action |
+|---|---|
+| `src/app/reading/<slug>/page.tsx` | Create |
+| `src/app/reading/<slug>/<slug>.module.css` | Create (if needed) |
+| `src/components/reading/<Slug>Header.tsx` | Create — eyebrow+title+tagline |
+| `e2e/reading-<slug>.spec.ts` | Create |
+
+**Verification**: every sidebar entry resolves to its own URL; refresh on any
+sub-route rehydrates from sessionStorage; every route renders the editorial
+header; reduced-motion still honored.
+
+### Phase 5 — Polish & retire legacy surfaces
+
+- [ ] Remove the old single-page results layout entirely.
+- [ ] Remove `DeckViewTabs` if it's been superseded by routing.
+- [ ] Update `design-system/CLAUDE.md` and `README.md` to reflect what was
+  actually built — mark the journey items "done," update the route table.
+- [ ] Lighthouse audit: each route ≥ 90 mobile Performance + Accessibility +
+  Best Practices.
+- [ ] Reduced-motion sweep across new components.
+- [ ] Update top-level CLAUDE.md with the new route map and data-flow notes.
+
+**Verification**: no dead code paths, all e2e tests pass, Lighthouse mobile
+≥ 90 on every route, reduced-motion users get static experiences end-to-end.
+
+## Files to create (summary)
+
+| File | Phase |
+|---|---|
+| `src/lib/deck-session.ts` | 1 |
+| `src/lib/deck-tagline.ts` | 3 |
+| `src/contexts/DeckSessionContext.tsx` | 1 |
+| `src/app/reading/layout.tsx` | 1 |
+| `src/app/reading/page.tsx` | 1, 3 |
+| `src/app/reading/cards/page.tsx` | 3, 4 |
+| `src/app/reading/goldfish/page.tsx` | 4 |
+| `src/app/reading/suggestions/page.tsx` | 4 |
+| `src/app/reading/synergy/page.tsx` | 4 |
+| `src/app/reading/composition/page.tsx` | 4 |
+| `src/app/reading/compare/page.tsx` | 4 |
+| `src/app/reading/add/page.tsx` | 4 |
+| `src/app/reading/share/page.tsx` | 4 |
+| `src/app/ritual/page.tsx` | 2 |
+| `src/components/ritual/CosmicLoader.tsx` | 2 |
+| `src/components/reading/ReadingHero.tsx` | 3 |
+| `src/components/reading/ReadingOverview.tsx` | 3 |
+| `src/components/reading/<Slug>Header.tsx` | 4 |
+| `tests/unit/deck-tagline.spec.ts` | 3 |
+| `e2e/reading-routing.spec.ts` | 1 |
+| `e2e/loading-ritual.spec.ts` | 2 |
+| `e2e/reading-overview.spec.ts` | 3 |
+| `e2e/reading-<slug>.spec.ts` | 4 (per route) |
+
+## Files to modify (summary)
+
+| File | Phase | Reason |
+|---|---|---|
+| `src/app/page.tsx` | 1, 2 | Strip results, push to `/ritual` on submit |
+| `src/components/DeckSidebar.tsx` | 1, 4 | Links + active route highlighting |
+| `src/components/DeckHero.tsx` | 3 | Wire into ReadingHero |
+| `design-system/CLAUDE.md` | 5 | Update journey items as done |
+| `design-system/README.md` | 5 | Update route map |
+| `CLAUDE.md` (project root) | 5 | New route map + data-flow notes |
+
+## Risks & open questions
+
+- **Reading hero tagline quality**: heuristic taglines can feel canned. If
+  results aren't compelling, consider a small templated bank with archetype-
+  + power-aware variants rather than generation. Re-evaluate after Phase 3
+  user testing.
+- **Compare flow**: existing comparison infrastructure (`deck-comparison.spec.ts`)
+  expects current single-page layout. Phase 4 compare needs a dedicated audit
+  to confirm the diff engine is reusable as-is.
+- **Share card image export**: Phase 4 share is the only genuinely new
+  capability — needs a sub-plan (canvas vs SVG vs server-side render).
+  Consider promoting to its own plan doc before Phase 4 begins.
+- **Sidebar collapse on sub-routes**: the current sidebar is built around
+  in-page section nav. With routes, do we keep persistent sidebar across
+  `/reading/*` (recommended) or collapse to top-tabs on narrow viewports?
+  Confirm at Phase 1 start.

--- a/e2e/deck-enrichment.spec.ts
+++ b/e2e/deck-enrichment.spec.ts
@@ -147,12 +147,12 @@ test.describe("Deck Enrichment", () => {
     releaseEnrichment?.();
   });
 
-  test("form re-enables immediately after deck data loads", async ({
+  test("import flow does not block on enrichment", async ({
     deckPage,
   }) => {
     const { page } = deckPage;
 
-    // Hold enrichment until we assert the form state.
+    // Hold enrichment until we assert the navigation has completed.
     let releaseEnrichment: (() => void) | null = null;
     await page.route("**/api/deck-enrich", async (route) => {
       await new Promise<void>((resolve) => {
@@ -169,13 +169,12 @@ test.describe("Deck Enrichment", () => {
     await deckPage.goto();
     await deckPage.fillDecklist("1 Sol Ring");
     await deckPage.submitImport();
+
+    // Navigation to /reading should complete even though enrichment is still in-flight.
+    await page.waitForURL(/\/reading(\/|$|\?)/);
     await deckPage.waitForDeckDisplay();
 
-    // Form should be re-enabled even though enrichment is still loading
-    await expect(deckPage.importButton).toBeEnabled();
-    await expect(page.locator("textarea#decklist")).toBeEnabled();
-
-    // Release so the test completes cleanly
+    // Release so the test completes cleanly.
     releaseEnrichment?.();
   });
 

--- a/e2e/reading-routing.spec.ts
+++ b/e2e/reading-routing.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, SAMPLE_DECKLIST } from "./fixtures";
+
+test.describe("/reading routing", () => {
+  test("import navigates from / to /reading", async ({ deckPage }) => {
+    await deckPage.goto();
+    await deckPage.fillDecklist(SAMPLE_DECKLIST);
+    await deckPage.submitImport();
+
+    await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
+    await deckPage.waitForDeckDisplay();
+  });
+
+  test("the / page no longer renders a deck after import", async ({
+    deckPage,
+  }) => {
+    await deckPage.goto();
+    await deckPage.fillDecklist(SAMPLE_DECKLIST);
+    await deckPage.submitImport();
+    await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
+
+    await deckPage.page.goto("/");
+    // Import form is visible on /
+    await expect(deckPage.decklistTextarea).toBeVisible();
+    // Deck display is NOT visible on /
+    await expect(deckPage.deckDisplay).toBeHidden();
+  });
+
+  test("refreshing /reading rehydrates from sessionStorage", async ({
+    deckPage,
+  }) => {
+    await deckPage.goto();
+    await deckPage.fillDecklist(SAMPLE_DECKLIST);
+    await deckPage.submitImport();
+    await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
+    await deckPage.waitForDeckDisplay();
+
+    await deckPage.page.reload();
+    await deckPage.waitForDeckDisplay();
+    await expect(
+      deckPage.deckDisplay.getByText("Atraxa, Praetors' Voice")
+    ).toBeVisible();
+  });
+
+  test("visiting /reading without a session redirects to /", async ({
+    deckPage,
+  }) => {
+    // Ensure session is empty
+    await deckPage.page.goto("/");
+    await deckPage.page.evaluate(() => sessionStorage.clear());
+
+    await deckPage.page.goto("/reading");
+    await deckPage.page.waitForURL(/\/$|\/\?/);
+    await expect(deckPage.decklistTextarea).toBeVisible();
+  });
+
+  test("clearing the session via 'new reading' returns to /", async ({
+    deckPage,
+  }) => {
+    await deckPage.goto();
+    await deckPage.fillDecklist(SAMPLE_DECKLIST);
+    await deckPage.submitImport();
+    await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
+    await deckPage.waitForDeckDisplay();
+
+    await deckPage.page
+      .getByRole("button", { name: /new reading/i })
+      .first()
+      .click();
+    await deckPage.page.waitForURL(/\/$|\/\?/);
+    await expect(deckPage.decklistTextarea).toBeVisible();
+  });
+});

--- a/src/app/reading/layout.tsx
+++ b/src/app/reading/layout.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { DeckSessionProvider, useDeckSession } from "@/contexts/DeckSessionContext";
+
+function ReadingHydrationGate({ children }: { children: React.ReactNode }) {
+  const { hydration } = useDeckSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (hydration === "absent") {
+      router.replace("/");
+    }
+  }, [hydration, router]);
+
+  // While hydration is pending the SessionProvider has not yet read sessionStorage,
+  // so we render nothing rather than flash a "no deck" state. The provider's
+  // useEffect resolves on the very next tick, so this is invisible in practice.
+  if (hydration !== "hydrated") return null;
+
+  return <>{children}</>;
+}
+
+export default function ReadingLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <DeckSessionProvider>
+      <ReadingHydrationGate>{children}</ReadingHydrationGate>
+    </DeckSessionProvider>
+  );
+}

--- a/src/app/reading/page.tsx
+++ b/src/app/reading/page.tsx
@@ -1,0 +1,5 @@
+import DeckReadingView from "@/components/DeckReadingView";
+
+export default function ReadingPage() {
+  return <DeckReadingView />;
+}

--- a/src/components/DeckImportSection.tsx
+++ b/src/components/DeckImportSection.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import { useReducer, useRef, useEffect, useCallback, useMemo } from "react";
-import type { DeckData, EnrichedCard } from "@/lib/types";
-import type { SpellbookCombo } from "@/lib/commander-spellbook";
-import { validateCommanderLegality } from "@/lib/commander-validation";
+import { useReducer } from "react";
+import { useRouter } from "next/navigation";
+import type { DeckData } from "@/lib/types";
 import {
-  computeAllAnalyses,
-  type DeckAnalysisResults,
-} from "@/lib/deck-analysis-aggregate";
-import { encodeCompactDeckPayload } from "@/lib/deck-codec";
+  generateDeckId,
+  saveDeckSession,
+  type DeckSessionPayload,
+} from "@/lib/deck-session";
 import DeckInput from "@/components/DeckInput";
-import DeckViewTabs from "@/components/DeckViewTabs";
-import { DeckSidebar, DeckDrawer } from "@/components/DeckSidebar";
-import DeckMobileTopBar from "@/components/DeckMobileTopBar";
-import DiscordExportModal from "@/components/DiscordExportModal";
-import type { ViewTab } from "@/lib/view-tabs";
 import styles from "./DeckImportSection.module.css";
 
 function AlertIcon() {
@@ -34,293 +28,37 @@ function AlertIcon() {
   );
 }
 
-function DismissIcon() {
-  return (
-    <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
-    </svg>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// State & Actions
-// ---------------------------------------------------------------------------
-
-interface DeckImportState {
-  deckData: DeckData | null;
+interface ImportFormState {
   loading: boolean;
   error: string | null;
-  cardMap: Record<string, EnrichedCard> | null;
-  enrichLoading: boolean;
-  enrichError: string | null;
-  notFoundCount: number;
-  spellbookCombos: { exactCombos: SpellbookCombo[]; nearCombos: SpellbookCombo[] } | null;
-  spellbookLoading: boolean;
-  parseWarnings: string[];
-  commanderWarning: string | null;
-  activeTab: ViewTab;
-  discordModalOpen: boolean;
-  shareUrl: string | null;
-  drawerOpen: boolean;
 }
 
-type DeckImportAction =
-  | { type: "IMPORT_START" }
-  | { type: "IMPORT_SUCCESS"; deck: DeckData; warnings: string[] }
-  | { type: "IMPORT_ERROR"; error: string }
-  | { type: "ENRICH_START" }
-  | { type: "ENRICH_SUCCESS"; cardMap: Record<string, EnrichedCard>; notFoundCount: number }
-  | { type: "ENRICH_ERROR"; error: string }
-  | { type: "SPELLBOOK_START" }
-  | { type: "SPELLBOOK_SUCCESS"; combos: { exactCombos: SpellbookCombo[]; nearCombos: SpellbookCombo[] } }
-  | { type: "SPELLBOOK_ERROR" }
-  | { type: "SET_COMMANDER_WARNING"; warning: string | null }
-  | { type: "SET_TAB"; tab: ViewTab }
-  | { type: "SET_SHARE_URL"; url: string | null }
-  | { type: "TOGGLE_DISCORD_MODAL"; open: boolean }
-  | { type: "DISMISS_PARSE_WARNINGS" }
-  | { type: "DISMISS_NOT_FOUND" }
-  | { type: "DISMISS_ENRICH_ERROR" }
-  | { type: "TOGGLE_DRAWER"; open: boolean };
+type ImportFormAction =
+  | { type: "START" }
+  | { type: "ERROR"; error: string }
+  | { type: "RESET" };
 
-const initialState: DeckImportState = {
-  deckData: null,
-  loading: false,
-  error: null,
-  cardMap: null,
-  enrichLoading: false,
-  enrichError: null,
-  notFoundCount: 0,
-  spellbookCombos: null,
-  spellbookLoading: false,
-  parseWarnings: [],
-  commanderWarning: null,
-  activeTab: "list",
-  discordModalOpen: false,
-  shareUrl: null,
-  drawerOpen: false,
-};
+const initialState: ImportFormState = { loading: false, error: null };
 
-function reducer(state: DeckImportState, action: DeckImportAction): DeckImportState {
+function reducer(state: ImportFormState, action: ImportFormAction): ImportFormState {
   switch (action.type) {
-    case "IMPORT_START":
-      return {
-        ...initialState,
-        loading: true,
-      };
-    case "IMPORT_SUCCESS":
-      return {
-        ...state,
-        loading: false,
-        deckData: action.deck,
-        parseWarnings: action.warnings,
-      };
-    case "IMPORT_ERROR":
-      return { ...state, loading: false, error: action.error };
-    case "ENRICH_START":
-      return {
-        ...state,
-        enrichLoading: true,
-        enrichError: null,
-        cardMap: null,
-        notFoundCount: 0,
-      };
-    case "ENRICH_SUCCESS":
-      return {
-        ...state,
-        enrichLoading: false,
-        cardMap: action.cardMap,
-        notFoundCount: action.notFoundCount,
-      };
-    case "ENRICH_ERROR":
-      return { ...state, enrichLoading: false, enrichError: action.error };
-    case "SPELLBOOK_START":
-      return { ...state, spellbookLoading: true, spellbookCombos: null };
-    case "SPELLBOOK_SUCCESS":
-      return { ...state, spellbookLoading: false, spellbookCombos: action.combos };
-    case "SPELLBOOK_ERROR":
-      return {
-        ...state,
-        spellbookLoading: false,
-        spellbookCombos: { exactCombos: [], nearCombos: [] },
-      };
-    case "SET_COMMANDER_WARNING":
-      return { ...state, commanderWarning: action.warning };
-    case "SET_TAB":
-      return { ...state, activeTab: action.tab };
-    case "SET_SHARE_URL":
-      return { ...state, shareUrl: action.url };
-    case "TOGGLE_DISCORD_MODAL":
-      return { ...state, discordModalOpen: action.open };
-    case "DISMISS_PARSE_WARNINGS":
-      return { ...state, parseWarnings: [] };
-    case "DISMISS_NOT_FOUND":
-      return { ...state, notFoundCount: 0 };
-    case "DISMISS_ENRICH_ERROR":
-      return { ...state, enrichError: null };
-    case "TOGGLE_DRAWER":
-      return { ...state, drawerOpen: action.open };
+    case "START":
+      return { loading: true, error: null };
+    case "ERROR":
+      return { loading: false, error: action.error };
+    case "RESET":
+      return initialState;
     default:
       return state;
   }
 }
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
-
 export default function DeckImportSection() {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const deckResultRef = useRef<HTMLDivElement>(null);
-  const enrichAbortRef = useRef<AbortController | null>(null);
-  const spellbookAbortRef = useRef<AbortController | null>(null);
-
-  const {
-    deckData, loading, error, cardMap, enrichLoading, enrichError,
-    notFoundCount, spellbookCombos, spellbookLoading, parseWarnings,
-    commanderWarning, activeTab, discordModalOpen, shareUrl, drawerOpen,
-  } = state;
-
-  useEffect(() => {
-    if (deckData && deckResultRef.current) {
-      deckResultRef.current.focus();
-    }
-  }, [deckData]);
-
-  // Post-enrichment commander legality check
-  useEffect(() => {
-    if (!deckData || !cardMap || enrichLoading) {
-      dispatch({ type: "SET_COMMANDER_WARNING", warning: null });
-      return;
-    }
-    if (deckData.commanders.length === 0) return;
-
-    const { warnings } = validateCommanderLegality(
-      deckData.commanders.map((c) => c.name),
-      cardMap
-    );
-    dispatch({
-      type: "SET_COMMANDER_WARNING",
-      warning: warnings.length > 0 ? warnings.join(" ") : null,
-    });
-  }, [deckData, cardMap, enrichLoading]);
-
-  // Compute analysis results when cardMap is available
-  const analysisResults: DeckAnalysisResults | null = useMemo(
-    () =>
-      deckData && cardMap
-        ? computeAllAnalyses({ deck: deckData, cardMap, spellbookCombos })
-        : null,
-    [deckData, cardMap, spellbookCombos]
-  );
-
-  const enrichDeck = useCallback(async (deck: DeckData) => {
-    const allCards = [
-      ...deck.commanders,
-      ...deck.mainboard,
-      ...deck.sideboard,
-    ];
-    const uniqueNames = [...new Set(allCards.map((c) => c.name))];
-
-    if (uniqueNames.length === 0) return;
-
-    // Abort any in-flight enrichment request
-    enrichAbortRef.current?.abort();
-    const controller = new AbortController();
-    enrichAbortRef.current = controller;
-
-    dispatch({ type: "ENRICH_START" });
-
-    try {
-      const res = await fetch("/api/deck-enrich", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ cardNames: uniqueNames }),
-        signal: AbortSignal.any([
-          controller.signal,
-          AbortSignal.timeout(30_000),
-        ]),
-      });
-
-      if (!res.ok) {
-        dispatch({
-          type: "ENRICH_ERROR",
-          error: res.status === 502
-            ? "Card data service temporarily unavailable"
-            : "Could not load card details",
-        });
-        return;
-      }
-
-      const json = await res.json();
-      dispatch({
-        type: "ENRICH_SUCCESS",
-        cardMap: json.cards as Record<string, EnrichedCard>,
-        notFoundCount: json.notFound?.length ?? 0,
-      });
-    } catch (err) {
-      // Don't update state for aborted requests
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      dispatch({
-        type: "ENRICH_ERROR",
-        error: err instanceof TypeError
-          ? "Network error — could not reach card data service"
-          : "Could not load card details",
-      });
-    }
-  }, []);
-
-  const fetchCombos = useCallback(async (deck: DeckData) => {
-    const allCards = [
-      ...deck.commanders,
-      ...deck.mainboard,
-    ];
-    const uniqueNames = [...new Set(allCards.map((c) => c.name))];
-
-    if (uniqueNames.length === 0) return;
-
-    // Abort any in-flight spellbook request
-    spellbookAbortRef.current?.abort();
-    const controller = new AbortController();
-    spellbookAbortRef.current = controller;
-
-    dispatch({ type: "SPELLBOOK_START" });
-
-    try {
-      const res = await fetch("/api/deck-combos", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          cardNames: uniqueNames,
-          commanders: deck.commanders.map((c) => c.name),
-        }),
-        signal: AbortSignal.any([
-          controller.signal,
-          AbortSignal.timeout(20_000),
-        ]),
-      });
-
-      if (!res.ok) {
-        dispatch({ type: "SPELLBOOK_ERROR" });
-        return;
-      }
-
-      const json = await res.json();
-      dispatch({
-        type: "SPELLBOOK_SUCCESS",
-        combos: {
-          exactCombos: json.exactCombos ?? [],
-          nearCombos: json.nearCombos ?? [],
-        },
-      });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      dispatch({ type: "SPELLBOOK_ERROR" });
-    }
-  }, []);
+  const router = useRouter();
 
   const handleImport = async (fetcher: () => Promise<Response>) => {
-    dispatch({ type: "IMPORT_START" });
+    dispatch({ type: "START" });
 
     try {
       const res = await fetcher();
@@ -328,23 +66,36 @@ export default function DeckImportSection() {
 
       if (!res.ok) {
         dispatch({
-          type: "IMPORT_ERROR",
+          type: "ERROR",
           error: json.error ?? `Request failed with status ${res.status}`,
         });
         return;
       }
 
-      const { warnings: w, ...deckFields } = json as DeckData & { warnings?: string[] };
+      const { warnings: w, ...deckFields } = json as DeckData & {
+        warnings?: string[];
+      };
       const deck = deckFields as DeckData;
-      dispatch({ type: "IMPORT_SUCCESS", deck, warnings: w ?? [] });
-      enrichDeck(deck);
-      fetchCombos(deck);
+
+      const payload: DeckSessionPayload = {
+        deckId: generateDeckId(),
+        deck,
+        parseWarnings: w ?? [],
+        cardMap: null,
+        notFoundCount: 0,
+        spellbookCombos: null,
+        createdAt: Date.now(),
+      };
+
+      saveDeckSession(payload);
+      router.push("/reading");
     } catch (err) {
       dispatch({
-        type: "IMPORT_ERROR",
-        error: err instanceof Error
-          ? err.message
-          : "An unexpected error occurred. Please try again.",
+        type: "ERROR",
+        error:
+          err instanceof Error
+            ? err.message
+            : "An unexpected error occurred. Please try again.",
       });
     }
   };
@@ -361,38 +112,10 @@ export default function DeckImportSection() {
       })
     );
 
-  // Compute share URL after enrichment completes (v2 compact codec)
-  useEffect(() => {
-    if (!deckData || !cardMap) {
-      dispatch({ type: "SET_SHARE_URL", url: null });
-      return;
-    }
-    let cancelled = false;
-    (async () => {
-      try {
-        const encoded = await encodeCompactDeckPayload(deckData, cardMap);
-        if (!cancelled) {
-          dispatch({ type: "SET_SHARE_URL", url: `${window.location.origin}/shared?d=${encoded}` });
-        }
-      } catch {
-        // Encoding error — leave shareUrl null
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [deckData, cardMap]);
-
-  const handleCopyShareLink = useCallback(async () => {
-    if (!shareUrl) return;
-    try {
-      await navigator.clipboard.writeText(shareUrl);
-    } catch {
-      // Clipboard error — silently fail
-    }
-  }, [shareUrl]);
+  const { loading, error } = state;
 
   return (
-    <>
-      <div className={styles.layout}>
+    <div className={styles.layout}>
       <DeckInput
         onSubmitUrl={handleFetchDeck}
         onSubmitText={handleParseDeck}
@@ -418,208 +141,6 @@ export default function DeckImportSection() {
           </div>
         </div>
       )}
-
-      {parseWarnings.length > 0 && !loading && (
-        <div
-          data-testid="parse-warnings"
-          role="alert"
-          className={`${styles.alert} ${styles.alertWatch}`}
-        >
-          <div className={styles.alertContent}>
-            <AlertIcon />
-            <div className={styles.alertBody}>
-              <p className={styles.alertTitle}>
-                Some lines could not be parsed and were skipped:
-              </p>
-              <ul className={styles.alertList}>
-                {parseWarnings.slice(0, 5).map((w) => (
-                  <li key={w}>{w}</li>
-                ))}
-                {parseWarnings.length > 5 && (
-                  <li>...and {parseWarnings.length - 5} more</li>
-                )}
-              </ul>
-            </div>
-          </div>
-          <div className={styles.alertActions}>
-            <button
-              type="button"
-              onClick={() => dispatch({ type: "DISMISS_PARSE_WARNINGS" })}
-              className={styles.dismissButton}
-              aria-label="Dismiss parse warnings"
-            >
-              <DismissIcon />
-            </button>
-          </div>
-        </div>
-      )}
-
-      </div>{/* end layout wrapper for import form */}
-
-      {deckData && !loading && (
-        <div
-          ref={deckResultRef}
-          tabIndex={-1}
-          className={styles.results}
-          aria-label="Deck import results"
-        >
-          {/* Mobile top bar (only visible below md) */}
-          <DeckMobileTopBar
-            deckName={deckData.name}
-            enrichLoading={enrichLoading}
-            cardMap={cardMap}
-            enrichError={enrichError}
-            hasAnalysis={!!analysisResults}
-            onOpenDrawer={() => dispatch({ type: "TOGGLE_DRAWER", open: true })}
-            onShare={handleCopyShareLink}
-          />
-
-          {/* Mobile drawer */}
-          <DeckDrawer
-            open={drawerOpen}
-            onClose={() => dispatch({ type: "TOGGLE_DRAWER", open: false })}
-            deck={deckData}
-            cardMap={cardMap}
-            enrichLoading={enrichLoading}
-            enrichError={enrichError}
-            activeTab={activeTab}
-            onTabChange={(tab) => {
-              dispatch({ type: "SET_TAB", tab });
-              dispatch({ type: "TOGGLE_DRAWER", open: false });
-            }}
-            analysisResults={analysisResults}
-            onOpenDiscordModal={() => dispatch({ type: "TOGGLE_DISCORD_MODAL", open: true })}
-            onCopyShareLink={handleCopyShareLink}
-          />
-
-          {/* Desktop layout: sidebar + content */}
-          <div className={styles.resultsLayout}>
-            {/* Desktop sidebar */}
-            <DeckSidebar
-              deck={deckData}
-              cardMap={cardMap}
-              enrichLoading={enrichLoading}
-              enrichError={enrichError}
-              activeTab={activeTab}
-              onTabChange={(tab) => dispatch({ type: "SET_TAB", tab })}
-              analysisResults={analysisResults}
-              onOpenDiscordModal={() => dispatch({ type: "TOGGLE_DISCORD_MODAL", open: true })}
-              onCopyShareLink={handleCopyShareLink}
-            />
-
-            {/* Content area */}
-            <div className={styles.contentPanel}>
-              <div className={styles.contentPanelInner}>
-                <DeckViewTabs
-                  deck={deckData}
-                  cardMap={cardMap}
-                  enrichLoading={enrichLoading}
-                  spellbookCombos={spellbookCombos}
-                  spellbookLoading={spellbookLoading}
-                  activeTab={activeTab}
-                  onTabChange={(tab) => dispatch({ type: "SET_TAB", tab })}
-                  analysisResults={analysisResults}
-                />
-              </div>
-            </div>
-          </div>
-
-          {enrichError && !enrichLoading && (
-            <div role="alert" className={`${styles.alert} ${styles.alertWatch}`}>
-              <div className={styles.alertContent}>
-                <AlertIcon />
-                <div className={styles.alertBody}>
-                  {enrichError}. The basic decklist is still available.
-                </div>
-              </div>
-              <div className={styles.alertActions}>
-                <button
-                  type="button"
-                  data-testid="enrich-retry-btn"
-                  disabled={enrichLoading}
-                  onClick={() => {
-                    if (deckData) enrichDeck(deckData);
-                  }}
-                  className={styles.retryButton}
-                >
-                  Try Again
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    dispatch({ type: "DISMISS_ENRICH_ERROR" });
-                    deckResultRef.current?.focus();
-                  }}
-                  className={styles.dismissButton}
-                  aria-label="Dismiss warning"
-                >
-                  <DismissIcon />
-                </button>
-              </div>
-            </div>
-          )}
-
-          {notFoundCount > 0 && !enrichError && !enrichLoading && (
-            <div role="alert" className={`${styles.alert} ${styles.alertWatch}`}>
-              <div className={styles.alertContent}>
-                <AlertIcon />
-                <div className={styles.alertBody}>
-                  {notFoundCount} {notFoundCount === 1 ? "card" : "cards"} could
-                  not be found and {notFoundCount === 1 ? "is" : "are"} shown
-                  without details
-                </div>
-              </div>
-              <div className={styles.alertActions}>
-                <button
-                  type="button"
-                  onClick={() => dispatch({ type: "DISMISS_NOT_FOUND" })}
-                  className={styles.dismissButton}
-                  aria-label="Dismiss warning"
-                >
-                  <DismissIcon />
-                </button>
-              </div>
-            </div>
-          )}
-
-          {commanderWarning && !enrichLoading && (
-            <div role="alert" className={`${styles.alert} ${styles.alertWatch}`}>
-              <div className={styles.alertContent}>
-                <AlertIcon />
-                <div className={styles.alertBody}>{commanderWarning}</div>
-              </div>
-              <div className={styles.alertActions}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    dispatch({ type: "SET_COMMANDER_WARNING", warning: null });
-                    deckResultRef.current?.focus();
-                  }}
-                  className={styles.dismissButton}
-                  aria-label="Dismiss commander warning"
-                >
-                  <DismissIcon />
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Visually-hidden announcement for screen readers when enrichment completes */}
-          <p className="sr-only" role="status" aria-live="polite">
-            {cardMap && !enrichLoading ? "Card details loaded" : ""}
-          </p>
-        </div>
-      )}
-
-      {deckData && analysisResults && (
-        <DiscordExportModal
-          open={discordModalOpen}
-          onClose={() => dispatch({ type: "TOGGLE_DISCORD_MODAL", open: false })}
-          analysisResults={analysisResults}
-          deck={deckData}
-          shareUrl={shareUrl ?? undefined}
-        />
-      )}
-    </>
+    </div>
   );
 }

--- a/src/components/DeckReadingView.module.css
+++ b/src/components/DeckReadingView.module.css
@@ -1,0 +1,163 @@
+.results {
+  outline: none;
+}
+
+.resultsLayout {
+  display: flex;
+  min-height: 0;
+}
+
+.contentPanel {
+  flex: 1;
+  min-width: 0;
+  border: 1px solid var(--card-border);
+  background: var(--card-bg);
+  border-radius: var(--card-radius);
+  overflow: hidden;
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+@media (min-width: 768px) {
+  .contentPanel {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    border-left: none;
+  }
+}
+
+.contentPanelInner {
+  padding: var(--space-12);
+}
+
+.alert {
+  margin-top: var(--space-14);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-7);
+  padding: var(--space-7) var(--space-8);
+  border-radius: var(--radius-xl);
+  border: 1px solid;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.alertContent {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-5);
+  min-width: 0;
+  flex: 1;
+}
+
+.alertIcon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.alertBody {
+  min-width: 0;
+}
+
+.alertTitle {
+  font-weight: var(--weight-semibold);
+  margin: 0 0 var(--space-2);
+}
+
+.alertList {
+  list-style: disc inside;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.alertActions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+}
+
+.alertWatch {
+  background: var(--status-watch-soft);
+  border-color: rgba(253, 230, 138, 0.3);
+  color: var(--status-watch);
+}
+
+.dismissButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  background: transparent;
+  color: inherit;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  opacity: 0.85;
+  transition:
+    opacity var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.dismissButton:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.dismissButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px currentColor;
+}
+
+.dismissButton svg {
+  width: 14px;
+  height: 14px;
+}
+
+.retryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 26px;
+  padding: 0 var(--space-6);
+  background: rgba(253, 230, 138, 0.18);
+  color: var(--status-watch);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  border: 1px solid rgba(253, 230, 138, 0.35);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.retryButton:hover:not(:disabled) {
+  background: rgba(253, 230, 138, 0.28);
+}
+
+.retryButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--status-watch);
+}
+
+.retryButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.parseWarnings {
+  background: var(--status-watch-soft);
+  border-color: rgba(253, 230, 138, 0.3);
+  color: var(--status-watch);
+}

--- a/src/components/DeckReadingView.tsx
+++ b/src/components/DeckReadingView.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useDeckSession } from "@/contexts/DeckSessionContext";
+import { encodeCompactDeckPayload } from "@/lib/deck-codec";
+import type { ViewTab } from "@/lib/view-tabs";
+import DeckViewTabs from "@/components/DeckViewTabs";
+import { DeckSidebar, DeckDrawer } from "@/components/DeckSidebar";
+import DeckMobileTopBar from "@/components/DeckMobileTopBar";
+import DiscordExportModal from "@/components/DiscordExportModal";
+import styles from "./DeckReadingView.module.css";
+
+function AlertIcon() {
+  return (
+    <svg
+      className={styles.alertIcon}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.168 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+function DismissIcon() {
+  return (
+    <svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+      <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
+    </svg>
+  );
+}
+
+export default function DeckReadingView() {
+  const router = useRouter();
+  const {
+    payload,
+    enrichLoading,
+    enrichError,
+    spellbookLoading,
+    commanderWarning,
+    analysisResults,
+    retryEnrichment,
+    dismissEnrichError,
+    dismissNotFound,
+    dismissCommanderWarning,
+    clearSession,
+  } = useDeckSession();
+
+  const [activeTab, setActiveTab] = useState<ViewTab>("list");
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [discordModalOpen, setDiscordModalOpen] = useState(false);
+  const [parseWarningsDismissed, setParseWarningsDismissed] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const deck = payload?.deck ?? null;
+  const cardMap = payload?.cardMap ?? null;
+  const spellbookCombos = payload?.spellbookCombos ?? null;
+  const parseWarnings = payload?.parseWarnings ?? [];
+  const notFoundCount = payload?.notFoundCount ?? 0;
+
+  // Focus the results container on mount so screen readers land here.
+  useEffect(() => {
+    if (deck) {
+      containerRef.current?.focus();
+    }
+  }, [deck]);
+
+  // Generate the share URL once cardMap is available.
+  useEffect(() => {
+    if (!deck || !cardMap) {
+      setShareUrl(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const encoded = await encodeCompactDeckPayload(deck, cardMap);
+        if (!cancelled) {
+          setShareUrl(`${window.location.origin}/shared?d=${encoded}`);
+        }
+      } catch {
+        // Encoding error — leave shareUrl null.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [deck, cardMap]);
+
+  const handleCopyShareLink = useCallback(async () => {
+    if (!shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+    } catch {
+      // Clipboard error — silently fail.
+    }
+  }, [shareUrl]);
+
+  const handleNewReading = useCallback(() => {
+    clearSession();
+    router.push("/");
+  }, [clearSession, router]);
+
+  if (!deck) return null;
+
+  return (
+    <>
+      <div
+        ref={containerRef}
+        tabIndex={-1}
+        className={styles.results}
+        aria-label="Deck import results"
+      >
+        <DeckMobileTopBar
+          deckName={deck.name}
+          enrichLoading={enrichLoading}
+          cardMap={cardMap}
+          enrichError={enrichError}
+          hasAnalysis={!!analysisResults}
+          onOpenDrawer={() => setDrawerOpen(true)}
+          onShare={handleCopyShareLink}
+        />
+
+        <DeckDrawer
+          open={drawerOpen}
+          onClose={() => setDrawerOpen(false)}
+          deck={deck}
+          cardMap={cardMap}
+          enrichLoading={enrichLoading}
+          enrichError={enrichError}
+          activeTab={activeTab}
+          onTabChange={(tab) => {
+            setActiveTab(tab);
+            setDrawerOpen(false);
+          }}
+          analysisResults={analysisResults}
+          onOpenDiscordModal={() => setDiscordModalOpen(true)}
+          onCopyShareLink={handleCopyShareLink}
+          onNewReading={handleNewReading}
+        />
+
+        <div className={styles.resultsLayout}>
+          <DeckSidebar
+            deck={deck}
+            cardMap={cardMap}
+            enrichLoading={enrichLoading}
+            enrichError={enrichError}
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            analysisResults={analysisResults}
+            onOpenDiscordModal={() => setDiscordModalOpen(true)}
+            onCopyShareLink={handleCopyShareLink}
+            onNewReading={handleNewReading}
+          />
+
+          <div className={styles.contentPanel}>
+            <div className={styles.contentPanelInner}>
+              <DeckViewTabs
+                deck={deck}
+                cardMap={cardMap}
+                enrichLoading={enrichLoading}
+                spellbookCombos={spellbookCombos}
+                spellbookLoading={spellbookLoading}
+                activeTab={activeTab}
+                onTabChange={setActiveTab}
+                analysisResults={analysisResults}
+              />
+            </div>
+          </div>
+        </div>
+
+        {parseWarnings.length > 0 && !parseWarningsDismissed && (
+          <div
+            data-testid="parse-warnings"
+            role="alert"
+            className={`${styles.alert} ${styles.parseWarnings}`}
+          >
+            <div className={styles.alertContent}>
+              <AlertIcon />
+              <div className={styles.alertBody}>
+                <p className={styles.alertTitle}>
+                  Some lines could not be parsed and were skipped:
+                </p>
+                <ul className={styles.alertList}>
+                  {parseWarnings.slice(0, 5).map((w) => (
+                    <li key={w}>{w}</li>
+                  ))}
+                  {parseWarnings.length > 5 && (
+                    <li>...and {parseWarnings.length - 5} more</li>
+                  )}
+                </ul>
+              </div>
+            </div>
+            <div className={styles.alertActions}>
+              <button
+                type="button"
+                onClick={() => setParseWarningsDismissed(true)}
+                className={styles.dismissButton}
+                aria-label="Dismiss parse warnings"
+              >
+                <DismissIcon />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {enrichError && !enrichLoading && (
+          <div role="alert" className={`${styles.alert} ${styles.alertWatch}`}>
+            <div className={styles.alertContent}>
+              <AlertIcon />
+              <div className={styles.alertBody}>
+                {enrichError}. The basic decklist is still available.
+              </div>
+            </div>
+            <div className={styles.alertActions}>
+              <button
+                type="button"
+                data-testid="enrich-retry-btn"
+                disabled={enrichLoading}
+                onClick={retryEnrichment}
+                className={styles.retryButton}
+              >
+                Try Again
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  dismissEnrichError();
+                  containerRef.current?.focus();
+                }}
+                className={styles.dismissButton}
+                aria-label="Dismiss warning"
+              >
+                <DismissIcon />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {notFoundCount > 0 && !enrichError && !enrichLoading && (
+          <div role="alert" className={`${styles.alert} ${styles.alertWatch}`}>
+            <div className={styles.alertContent}>
+              <AlertIcon />
+              <div className={styles.alertBody}>
+                {notFoundCount} {notFoundCount === 1 ? "card" : "cards"} could
+                not be found and {notFoundCount === 1 ? "is" : "are"} shown
+                without details
+              </div>
+            </div>
+            <div className={styles.alertActions}>
+              <button
+                type="button"
+                onClick={dismissNotFound}
+                className={styles.dismissButton}
+                aria-label="Dismiss warning"
+              >
+                <DismissIcon />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {commanderWarning && !enrichLoading && (
+          <div role="alert" className={`${styles.alert} ${styles.alertWatch}`}>
+            <div className={styles.alertContent}>
+              <AlertIcon />
+              <div className={styles.alertBody}>{commanderWarning}</div>
+            </div>
+            <div className={styles.alertActions}>
+              <button
+                type="button"
+                onClick={() => {
+                  dismissCommanderWarning();
+                  containerRef.current?.focus();
+                }}
+                className={styles.dismissButton}
+                aria-label="Dismiss commander warning"
+              >
+                <DismissIcon />
+              </button>
+            </div>
+          </div>
+        )}
+
+        <p className="sr-only" role="status" aria-live="polite">
+          {cardMap && !enrichLoading ? "Card details loaded" : ""}
+        </p>
+      </div>
+
+      {analysisResults && (
+        <DiscordExportModal
+          open={discordModalOpen}
+          onClose={() => setDiscordModalOpen(false)}
+          analysisResults={analysisResults}
+          deck={deck}
+          shareUrl={shareUrl ?? undefined}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/DeckSidebar.module.css
+++ b/src/components/DeckSidebar.module.css
@@ -424,6 +424,62 @@
   border-top: 1px solid var(--border);
 }
 
+/* ─── New Reading button ─── */
+.newReadingSection {
+  padding: var(--space-3) var(--space-3) var(--space-5);
+}
+
+.newReadingButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  width: 100%;
+  height: 32px;
+  padding: 0 var(--space-7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: transparent;
+  color: var(--ink-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.newReadingButton:hover {
+  color: var(--accent);
+  border-color: var(--border-accent);
+  background: var(--accent-soft);
+}
+
+.newReadingButton:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.newReadingButtonCollapsed {
+  padding: 0;
+  width: 32px;
+  height: 32px;
+  gap: 0;
+}
+
+.newReadingButtonCollapsed .newReadingLabel {
+  display: none;
+}
+
+.newReadingIcon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
 .copyFeedback {
   display: block;
   margin-bottom: var(--space-2);

--- a/src/components/DeckSidebar.tsx
+++ b/src/components/DeckSidebar.tsx
@@ -413,6 +413,7 @@ interface SidebarContentProps {
   onOpenDiscordModal?: () => void;
   onCopyShareLink?: () => void;
   onSaveImage?: () => void;
+  onNewReading?: () => void;
   collapsed: boolean;
   onClose?: () => void;
 }
@@ -428,6 +429,7 @@ function SidebarContent({
   onOpenDiscordModal,
   onCopyShareLink,
   onSaveImage,
+  onNewReading,
   collapsed,
   onClose,
 }: SidebarContentProps) {
@@ -745,6 +747,36 @@ function SidebarContent({
           {imageStatus === "error" && "Image generation failed."}
         </div>
       </div>
+
+      {onNewReading && (
+        <div className={styles.newReadingSection}>
+          <button
+            type="button"
+            data-testid="new-reading-button"
+            onClick={onNewReading}
+            className={[
+              styles.newReadingButton,
+              collapsed && styles.newReadingButtonCollapsed,
+            ]
+              .filter(Boolean)
+              .join(" ")}
+            title={collapsed ? "New reading" : undefined}
+            aria-label={collapsed ? "New reading" : undefined}
+          >
+            <svg
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              className={styles.newReadingIcon}
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 10h12M10 4v12" />
+            </svg>
+            <span className={styles.newReadingLabel}>New Reading</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 }
@@ -764,6 +796,7 @@ export interface DeckSidebarProps {
   onOpenDiscordModal?: () => void;
   onCopyShareLink?: () => void;
   onSaveImage?: () => void;
+  onNewReading?: () => void;
 }
 
 export function DeckSidebar({
@@ -777,6 +810,7 @@ export function DeckSidebar({
   onOpenDiscordModal,
   onCopyShareLink,
   onSaveImage,
+  onNewReading,
 }: DeckSidebarProps) {
   const [collapsed, setCollapsed] = useSidebarCollapsed();
 
@@ -797,6 +831,7 @@ export function DeckSidebar({
         onOpenDiscordModal={onOpenDiscordModal}
         onCopyShareLink={onCopyShareLink}
         onSaveImage={onSaveImage}
+        onNewReading={onNewReading}
         collapsed={collapsed}
       />
 
@@ -836,6 +871,7 @@ export function DeckDrawer({
   onOpenDiscordModal,
   onCopyShareLink,
   onSaveImage,
+  onNewReading,
 }: DeckDrawerProps) {
   const drawerRef = useRef<HTMLDivElement>(null);
   useFocusTrap(drawerRef, open);
@@ -890,6 +926,7 @@ export function DeckDrawer({
             onOpenDiscordModal={onOpenDiscordModal}
             onCopyShareLink={onCopyShareLink}
             onSaveImage={onSaveImage}
+            onNewReading={onNewReading}
             collapsed={false}
             onClose={onClose}
           />

--- a/src/contexts/DeckSessionContext.tsx
+++ b/src/contexts/DeckSessionContext.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  type ReactNode,
+} from "react";
+import type { DeckData, EnrichedCard } from "@/lib/types";
+import type { SpellbookCombo } from "@/lib/commander-spellbook";
+import { validateCommanderLegality } from "@/lib/commander-validation";
+import {
+  computeAllAnalyses,
+  type DeckAnalysisResults,
+} from "@/lib/deck-analysis-aggregate";
+import {
+  loadDeckSession,
+  saveDeckSession,
+  clearDeckSession,
+  type DeckSessionPayload,
+} from "@/lib/deck-session";
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+type Hydration = "pending" | "hydrated" | "absent";
+
+interface State {
+  hydration: Hydration;
+  payload: DeckSessionPayload | null;
+  enrichLoading: boolean;
+  enrichError: string | null;
+  spellbookLoading: boolean;
+  commanderWarning: string | null;
+}
+
+type Action =
+  | { type: "HYDRATE"; payload: DeckSessionPayload | null }
+  | { type: "SET_PAYLOAD"; payload: DeckSessionPayload }
+  | { type: "ENRICH_START" }
+  | {
+      type: "ENRICH_SUCCESS";
+      cardMap: Record<string, EnrichedCard>;
+      notFoundCount: number;
+    }
+  | { type: "ENRICH_ERROR"; error: string }
+  | { type: "SPELLBOOK_START" }
+  | {
+      type: "SPELLBOOK_SUCCESS";
+      combos: { exactCombos: SpellbookCombo[]; nearCombos: SpellbookCombo[] };
+    }
+  | { type: "SPELLBOOK_ERROR" }
+  | { type: "SET_COMMANDER_WARNING"; warning: string | null }
+  | { type: "DISMISS_ENRICH_ERROR" }
+  | { type: "DISMISS_NOT_FOUND" }
+  | { type: "CLEAR" };
+
+const initialState: State = {
+  hydration: "pending",
+  payload: null,
+  enrichLoading: false,
+  enrichError: null,
+  spellbookLoading: false,
+  commanderWarning: null,
+};
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "HYDRATE":
+      return {
+        ...state,
+        hydration: action.payload ? "hydrated" : "absent",
+        payload: action.payload,
+      };
+    case "SET_PAYLOAD":
+      return { ...state, hydration: "hydrated", payload: action.payload };
+    case "ENRICH_START":
+      return { ...state, enrichLoading: true, enrichError: null };
+    case "ENRICH_SUCCESS":
+      return {
+        ...state,
+        enrichLoading: false,
+        payload: state.payload && {
+          ...state.payload,
+          cardMap: action.cardMap,
+          notFoundCount: action.notFoundCount,
+        },
+      };
+    case "ENRICH_ERROR":
+      return { ...state, enrichLoading: false, enrichError: action.error };
+    case "SPELLBOOK_START":
+      return { ...state, spellbookLoading: true };
+    case "SPELLBOOK_SUCCESS":
+      return {
+        ...state,
+        spellbookLoading: false,
+        payload: state.payload && {
+          ...state.payload,
+          spellbookCombos: action.combos,
+        },
+      };
+    case "SPELLBOOK_ERROR":
+      return {
+        ...state,
+        spellbookLoading: false,
+        payload: state.payload && {
+          ...state.payload,
+          spellbookCombos: state.payload.spellbookCombos ?? {
+            exactCombos: [],
+            nearCombos: [],
+          },
+        },
+      };
+    case "SET_COMMANDER_WARNING":
+      return { ...state, commanderWarning: action.warning };
+    case "DISMISS_ENRICH_ERROR":
+      return { ...state, enrichError: null };
+    case "DISMISS_NOT_FOUND":
+      return {
+        ...state,
+        payload: state.payload && { ...state.payload, notFoundCount: 0 },
+      };
+    case "CLEAR":
+      return {
+        ...initialState,
+        hydration: "absent",
+        payload: null,
+      };
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context value
+// ---------------------------------------------------------------------------
+
+interface DeckSessionContextValue {
+  hydration: Hydration;
+  payload: DeckSessionPayload | null;
+  enrichLoading: boolean;
+  enrichError: string | null;
+  spellbookLoading: boolean;
+  commanderWarning: string | null;
+  analysisResults: DeckAnalysisResults | null;
+  retryEnrichment: () => void;
+  dismissEnrichError: () => void;
+  dismissNotFound: () => void;
+  dismissCommanderWarning: () => void;
+  clearSession: () => void;
+}
+
+const DeckSessionContext = createContext<DeckSessionContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function DeckSessionProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const enrichAbortRef = useRef<AbortController | null>(null);
+  const spellbookAbortRef = useRef<AbortController | null>(null);
+
+  // Hydrate from sessionStorage on mount.
+  useEffect(() => {
+    const payload = loadDeckSession();
+    dispatch({ type: "HYDRATE", payload });
+  }, []);
+
+  // Persist payload changes back to sessionStorage so refreshes are stable.
+  useEffect(() => {
+    if (state.hydration === "hydrated" && state.payload) {
+      saveDeckSession(state.payload);
+    }
+  }, [state.hydration, state.payload]);
+
+  const enrich = useCallback(async (deck: DeckData) => {
+    const allCards = [
+      ...deck.commanders,
+      ...deck.mainboard,
+      ...deck.sideboard,
+    ];
+    const uniqueNames = [...new Set(allCards.map((c) => c.name))];
+    if (uniqueNames.length === 0) return;
+
+    enrichAbortRef.current?.abort();
+    const controller = new AbortController();
+    enrichAbortRef.current = controller;
+
+    dispatch({ type: "ENRICH_START" });
+
+    try {
+      const res = await fetch("/api/deck-enrich", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cardNames: uniqueNames }),
+        signal: AbortSignal.any([
+          controller.signal,
+          AbortSignal.timeout(30_000),
+        ]),
+      });
+
+      if (!res.ok) {
+        dispatch({
+          type: "ENRICH_ERROR",
+          error:
+            res.status === 502
+              ? "Card data service temporarily unavailable"
+              : "Could not load card details",
+        });
+        return;
+      }
+
+      const json = await res.json();
+      dispatch({
+        type: "ENRICH_SUCCESS",
+        cardMap: json.cards as Record<string, EnrichedCard>,
+        notFoundCount: json.notFound?.length ?? 0,
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      dispatch({
+        type: "ENRICH_ERROR",
+        error:
+          err instanceof TypeError
+            ? "Network error — could not reach card data service"
+            : "Could not load card details",
+      });
+    }
+  }, []);
+
+  const fetchCombos = useCallback(async (deck: DeckData) => {
+    const allCards = [...deck.commanders, ...deck.mainboard];
+    const uniqueNames = [...new Set(allCards.map((c) => c.name))];
+    if (uniqueNames.length === 0) return;
+
+    spellbookAbortRef.current?.abort();
+    const controller = new AbortController();
+    spellbookAbortRef.current = controller;
+
+    dispatch({ type: "SPELLBOOK_START" });
+
+    try {
+      const res = await fetch("/api/deck-combos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cardNames: uniqueNames,
+          commanders: deck.commanders.map((c) => c.name),
+        }),
+        signal: AbortSignal.any([
+          controller.signal,
+          AbortSignal.timeout(20_000),
+        ]),
+      });
+
+      if (!res.ok) {
+        dispatch({ type: "SPELLBOOK_ERROR" });
+        return;
+      }
+
+      const json = await res.json();
+      dispatch({
+        type: "SPELLBOOK_SUCCESS",
+        combos: {
+          exactCombos: json.exactCombos ?? [],
+          nearCombos: json.nearCombos ?? [],
+        },
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      dispatch({ type: "SPELLBOOK_ERROR" });
+    }
+  }, []);
+
+  // After hydration, kick off enrichment + combos if missing.
+  // Track which deckId we've fetched for so we don't refetch on every render.
+  const enrichedDeckIdRef = useRef<string | null>(null);
+  const combosDeckIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (state.hydration !== "hydrated" || !state.payload) return;
+    const { deckId, deck, cardMap } = state.payload;
+
+    if (cardMap === null && enrichedDeckIdRef.current !== deckId) {
+      enrichedDeckIdRef.current = deckId;
+      void enrich(deck);
+    }
+  }, [state.hydration, state.payload, enrich]);
+
+  useEffect(() => {
+    if (state.hydration !== "hydrated" || !state.payload) return;
+    const { deckId, deck, spellbookCombos } = state.payload;
+
+    if (spellbookCombos === null && combosDeckIdRef.current !== deckId) {
+      combosDeckIdRef.current = deckId;
+      void fetchCombos(deck);
+    }
+  }, [state.hydration, state.payload, fetchCombos]);
+
+  // Commander legality check — runs after enrichment completes.
+  useEffect(() => {
+    const payload = state.payload;
+    if (!payload || !payload.cardMap || state.enrichLoading) {
+      dispatch({ type: "SET_COMMANDER_WARNING", warning: null });
+      return;
+    }
+    if (payload.deck.commanders.length === 0) return;
+    const { warnings } = validateCommanderLegality(
+      payload.deck.commanders.map((c) => c.name),
+      payload.cardMap
+    );
+    dispatch({
+      type: "SET_COMMANDER_WARNING",
+      warning: warnings.length > 0 ? warnings.join(" ") : null,
+    });
+  }, [state.payload, state.enrichLoading]);
+
+  // Memoized analysis derived from deck + cardMap + combos.
+  const analysisResults: DeckAnalysisResults | null = useMemo(() => {
+    const payload = state.payload;
+    if (!payload?.cardMap) return null;
+    return computeAllAnalyses({
+      deck: payload.deck,
+      cardMap: payload.cardMap,
+      spellbookCombos: payload.spellbookCombos ?? null,
+    });
+  }, [state.payload]);
+
+  const retryEnrichment = useCallback(() => {
+    if (state.payload) {
+      enrichedDeckIdRef.current = null;
+      void enrich(state.payload.deck);
+    }
+  }, [state.payload, enrich]);
+
+  const dismissEnrichError = useCallback(() => {
+    dispatch({ type: "DISMISS_ENRICH_ERROR" });
+  }, []);
+
+  const dismissNotFound = useCallback(() => {
+    dispatch({ type: "DISMISS_NOT_FOUND" });
+  }, []);
+
+  const dismissCommanderWarning = useCallback(() => {
+    dispatch({ type: "SET_COMMANDER_WARNING", warning: null });
+  }, []);
+
+  const clearSession = useCallback(() => {
+    enrichAbortRef.current?.abort();
+    spellbookAbortRef.current?.abort();
+    enrichedDeckIdRef.current = null;
+    combosDeckIdRef.current = null;
+    clearDeckSession();
+    dispatch({ type: "CLEAR" });
+  }, []);
+
+  const value = useMemo<DeckSessionContextValue>(
+    () => ({
+      hydration: state.hydration,
+      payload: state.payload,
+      enrichLoading: state.enrichLoading,
+      enrichError: state.enrichError,
+      spellbookLoading: state.spellbookLoading,
+      commanderWarning: state.commanderWarning,
+      analysisResults,
+      retryEnrichment,
+      dismissEnrichError,
+      dismissNotFound,
+      dismissCommanderWarning,
+      clearSession,
+    }),
+    [
+      state.hydration,
+      state.payload,
+      state.enrichLoading,
+      state.enrichError,
+      state.spellbookLoading,
+      state.commanderWarning,
+      analysisResults,
+      retryEnrichment,
+      dismissEnrichError,
+      dismissNotFound,
+      dismissCommanderWarning,
+      clearSession,
+    ]
+  );
+
+  return (
+    <DeckSessionContext.Provider value={value}>
+      {children}
+    </DeckSessionContext.Provider>
+  );
+}
+
+export function useDeckSession(): DeckSessionContextValue {
+  const ctx = useContext(DeckSessionContext);
+  if (!ctx) {
+    throw new Error("useDeckSession must be used within a DeckSessionProvider");
+  }
+  return ctx;
+}

--- a/src/lib/deck-session.ts
+++ b/src/lib/deck-session.ts
@@ -1,0 +1,75 @@
+import type { DeckData, EnrichedCard } from "@/lib/types";
+import type { SpellbookCombo } from "@/lib/commander-spellbook";
+
+const SESSION_KEY = "astral.deck-session.v1";
+
+/**
+ * Snapshot of an in-progress deck reading. Persisted to sessionStorage so the
+ * /reading routes can hydrate after navigation or refresh without re-importing.
+ *
+ * Lifecycle:
+ *   - `/` import success     → save({ deck, parseWarnings, status: "ready" })
+ *   - `/reading` mount       → load(); if cardMap missing, fetch enrichment + combos
+ *   - enrichment completes   → save with cardMap + spellbookCombos populated
+ *   - "new reading" pressed  → clear()
+ */
+export interface DeckSessionPayload {
+  /** Stable id for this reading. Generated at import time. */
+  deckId: string;
+  /** Parsed deck. */
+  deck: DeckData;
+  /** Non-fatal parse warnings shown as a banner on /reading. */
+  parseWarnings: string[];
+  /** Scryfall-enriched cards keyed by name. Null until enrichment completes. */
+  cardMap: Record<string, EnrichedCard> | null;
+  /** Number of cards Scryfall could not resolve. 0 until enrichment completes. */
+  notFoundCount: number;
+  /** Commander Spellbook combos. Null until /api/deck-combos resolves. */
+  spellbookCombos: {
+    exactCombos: SpellbookCombo[];
+    nearCombos: SpellbookCombo[];
+  } | null;
+  /** Wall-clock timestamp at import. Used for the "READING · 04.27.26" eyebrow. */
+  createdAt: number;
+}
+
+const isBrowser = () => typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
+
+export function loadDeckSession(): DeckSessionPayload | null {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.sessionStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as DeckSessionPayload;
+    if (!parsed?.deck || !parsed?.deckId) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function saveDeckSession(payload: DeckSessionPayload): void {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(payload));
+  } catch {
+    // sessionStorage can throw on quota exceeded or in private modes that
+    // restrict writes — fail silently; the in-memory context is still valid.
+  }
+}
+
+export function clearDeckSession(): void {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.removeItem(SESSION_KEY);
+  } catch {
+    // Ignore.
+  }
+}
+
+export function generateDeckId(): string {
+  if (isBrowser() && typeof window.crypto?.randomUUID === "function") {
+    return window.crypto.randomUUID();
+  }
+  return `deck-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}


### PR DESCRIPTION
## Summary
- Move the post-import results UI off `/` and onto a new `/reading` route, backed by sessionStorage so refreshes rehydrate without re-importing.
- Add `DeckSessionProvider` that owns enrichment + Spellbook combos as side effects and persists every state change back to sessionStorage.
- Strip the results block from `DeckImportSection` — on import success, save the session and `router.push(\"/reading\")`. Errors still render on `/`.
- Add a \"New Reading\" button at the bottom of the sidebar/drawer that clears the session and routes back to `/`.

This is **Phase 1 of 5** in [\`docs/plans/astral-journey-restructure.md\`](docs/plans/astral-journey-restructure.md). Visual parity with today — no design changes yet. Phase 2 will insert the `/ritual` cosmic loader between submit and `/reading`; Phase 3 introduces the verdict-first DeckHero landing; Phase 4 fans the sub-tabs out to real routes.

## Files
**New**
- `src/lib/deck-session.ts` — typed save/load/clear sessionStorage helpers + deck-id generation
- `src/contexts/DeckSessionContext.tsx` — hydrating provider, enrichment effects, analysis memoization
- `src/app/reading/layout.tsx` — provider wrapper + redirect-to-`/` gate
- `src/app/reading/page.tsx` — renders `DeckReadingView`
- `src/components/DeckReadingView.tsx` + `.module.css` — extracted results JSX (sidebar, drawer, mobile top bar, alerts, Discord modal, share-link computation)
- `e2e/reading-routing.spec.ts` — covers import navigation, refresh rehydration, direct-route-without-session redirect, and new-reading flow

**Modified**
- `src/components/DeckImportSection.tsx` — form-only after this PR
- `src/components/DeckSidebar.{tsx,module.css}` — `onNewReading` prop + button at the bottom of `SidebarContent`
- `e2e/deck-enrichment.spec.ts` — \"form re-enables\" test rewritten as a navigation-timing assertion since the form is no longer present on the same page after submit

## Test plan
- [x] `npm run build` — clean, `/reading` registered
- [x] `npm run test:unit` — 2462 pass
- [x] `npx playwright test e2e/reading-routing.spec.ts` — 5 pass (new)
- [x] `npx playwright test e2e/deck-enrichment.spec.ts e2e/reading-routing.spec.ts e2e/tab-navigation.spec.ts e2e/deck-import.spec.ts e2e/deck-display.spec.ts` — 48 pass
- [x] `npx playwright test e2e/deck-header.spec.ts e2e/deck-analysis.spec.ts e2e/synergy-ui.spec.ts e2e/interactions-tab.spec.ts e2e/suggestions-tab.spec.ts` — 106 pass
- [x] `npm run test:e2e` — 381 pass, 7 skipped, 0 regressions (8 transient Scryfall 429 flakes from suite-wide concurrency all pass when re-run individually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)