### PR TITLE
Phase 3: verdict-first /reading landing with DeckHero

### DIFF
--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -91,8 +91,36 @@ export class DeckPage {
     return this.page.getByLabel("Decklist");
   }
 
-  /** Wait for the deck header to appear after a successful import */
+  /**
+   * Wait for the deck header to appear after a successful import.
+   *
+   * After Phase 3, /reading is the verdict overview (no deck-header) and
+   * the deck list lives at /reading/cards. Most existing tests expect to
+   * interact with deck-list / tabs / panels — they don't care about the
+   * intermediate overview hop. If we're on /reading, navigate forward to
+   * /reading/cards before waiting. Tests that explicitly want the
+   * overview don't call waitForDeckDisplay; they assert reading-hero
+   * directly.
+   */
   async waitForDeckDisplay() {
+    // Wait for the post-submit navigation to settle on any /reading URL.
+    // submitImport() returns before router.push completes, so checking the
+    // URL too early would still see / or /ritual.
+    await this.page.waitForURL(/\/reading/, { timeout: 15_000 });
+    // /reading is the verdict overview (no deck-header); deck-header lives
+    // on /reading/cards. Click the Cards section link to soft-navigate
+    // there. (page.goto would do a full page reload, remounting the
+    // DeckSessionProvider and dropping in-memory error state — that
+    // breaks tests that probe the post-error retry UI.)
+    const url = new URL(this.page.url());
+    if (url.pathname === "/reading" || url.pathname === "/reading/") {
+      await this.page
+        .getByTestId("reading-section-grid")
+        .getByRole("link", { name: /cards/i })
+        .first()
+        .click();
+      await this.page.waitForURL(/\/reading\/cards/, { timeout: 5_000 });
+    }
     await this.page
       .getByTestId("deck-header")
       .waitFor({ timeout: 15_000 });

--- a/e2e/reading-overview.spec.ts
+++ b/e2e/reading-overview.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, SAMPLE_DECKLIST } from "./fixtures";
+
+test.describe("/reading overview (verdict landing)", () => {
+  test.beforeEach(async ({ deckPage }) => {
+    await deckPage.goto();
+    await deckPage.fillDecklist(SAMPLE_DECKLIST);
+    await deckPage.submitImport();
+    await deckPage.page.waitForURL(/\/reading(\/|$|\?)/, { timeout: 15_000 });
+  });
+
+  test("shows the deck name as a serif hero title", async ({ deckPage }) => {
+    const hero = deckPage.page.getByTestId("reading-hero");
+    await expect(hero).toBeVisible();
+    await expect(
+      hero.getByRole("heading", { name: "Imported Decklist" })
+    ).toBeVisible();
+  });
+
+  test("shows the READING eyebrow", async ({ deckPage }) => {
+    const hero = deckPage.page.getByTestId("reading-hero");
+    await expect(hero.getByText("READING", { exact: false })).toBeVisible();
+  });
+
+  test("shows a non-empty italic tagline", async ({ deckPage }) => {
+    const tagline = deckPage.page.getByTestId("reading-tagline");
+    await expect(tagline).toBeVisible();
+    const text = (await tagline.textContent()) ?? "";
+    expect(text.trim().length).toBeGreaterThan(0);
+    expect(text.trim()).toMatch(/[.!?]$/);
+  });
+
+  test("renders stat tiles for bracket, power level, and total cost", async ({
+    deckPage,
+  }) => {
+    const stats = deckPage.page.getByTestId("reading-stats");
+    await expect(stats).toBeVisible();
+    await expect(stats.getByText(/bracket/i)).toBeVisible();
+    await expect(stats.getByText(/power level/i)).toBeVisible();
+  });
+
+  test("renders a section grid linking into the reading", async ({
+    deckPage,
+  }) => {
+    const grid = deckPage.page.getByTestId("reading-section-grid");
+    await expect(grid).toBeVisible();
+    // At minimum, the Cards section is reachable in Phase 3.
+    await expect(grid.getByRole("link", { name: /cards/i }).first()).toBeVisible();
+  });
+
+  test("clicking the Cards section navigates to /reading/cards", async ({
+    deckPage,
+  }) => {
+    const grid = deckPage.page.getByTestId("reading-section-grid");
+    await grid.getByRole("link", { name: /cards/i }).first().click();
+    await deckPage.page.waitForURL(/\/reading\/cards/, { timeout: 5_000 });
+    await deckPage.waitForDeckDisplay();
+  });
+});

--- a/e2e/reading-routing.spec.ts
+++ b/e2e/reading-routing.spec.ts
@@ -7,7 +7,11 @@ test.describe("/reading routing", () => {
     await deckPage.submitImport();
 
     await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
-    await deckPage.waitForDeckDisplay();
+    // After Phase 3, /reading is the verdict overview; deck-display lives at
+    // /reading/cards. Confirm the overview hero is visible instead.
+    await expect(deckPage.page.getByTestId("reading-hero")).toBeVisible({
+      timeout: 15_000,
+    });
   });
 
   test("the / page no longer renders a deck after import", async ({
@@ -32,12 +36,34 @@ test.describe("/reading routing", () => {
     await deckPage.fillDecklist(SAMPLE_DECKLIST);
     await deckPage.submitImport();
     await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
-    await deckPage.waitForDeckDisplay();
+    await expect(deckPage.page.getByTestId("reading-hero")).toBeVisible({
+      timeout: 15_000,
+    });
 
     await deckPage.page.reload();
+    await expect(deckPage.page.getByTestId("reading-hero")).toBeVisible({
+      timeout: 15_000,
+    });
+    // Hero should show the deck name as its serif title.
+    await expect(
+      deckPage.page
+        .getByTestId("reading-hero")
+        .getByRole("heading", { name: "Imported Decklist" })
+    ).toBeVisible();
+  });
+
+  test("refreshing /reading/cards rehydrates from sessionStorage", async ({
+    deckPage,
+  }) => {
+    await deckPage.goto();
+    await deckPage.fillDecklist(SAMPLE_DECKLIST);
+    await deckPage.submitImport();
+    await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
+
+    await deckPage.page.goto("/reading/cards");
     await deckPage.waitForDeckDisplay();
     await expect(
-      deckPage.deckDisplay.getByText("Atraxa, Praetors' Voice")
+      deckPage.deckDisplay.getByRole("button", { name: "Atraxa, Praetors' Voice" })
     ).toBeVisible();
   });
 
@@ -53,14 +79,16 @@ test.describe("/reading routing", () => {
     await expect(deckPage.decklistTextarea).toBeVisible();
   });
 
-  test("clearing the session via 'new reading' returns to /", async ({
+  test("'new reading' from /reading overview returns to /", async ({
     deckPage,
   }) => {
     await deckPage.goto();
     await deckPage.fillDecklist(SAMPLE_DECKLIST);
     await deckPage.submitImport();
     await deckPage.page.waitForURL(/\/reading(\/|$|\?)/);
-    await deckPage.waitForDeckDisplay();
+    await expect(deckPage.page.getByTestId("reading-hero")).toBeVisible({
+      timeout: 15_000,
+    });
 
     await deckPage.page
       .getByRole("button", { name: /new reading/i })

--- a/src/app/reading/cards/page.tsx
+++ b/src/app/reading/cards/page.tsx
@@ -1,0 +1,5 @@
+import DeckReadingView from "@/components/DeckReadingView";
+
+export default function ReadingCardsPage() {
+  return <DeckReadingView />;
+}

--- a/src/app/reading/page.tsx
+++ b/src/app/reading/page.tsx
@@ -1,5 +1,5 @@
-import DeckReadingView from "@/components/DeckReadingView";
+import ReadingOverview from "@/components/reading/ReadingOverview";
 
 export default function ReadingPage() {
-  return <DeckReadingView />;
+  return <ReadingOverview />;
 }

--- a/src/components/reading/ReadingHero.module.css
+++ b/src/components/reading/ReadingHero.module.css
@@ -1,0 +1,57 @@
+.hero {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: var(--space-7);
+  padding: var(--space-16) var(--space-12) var(--space-12);
+  margin-bottom: var(--space-14);
+}
+
+.title {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: var(--text-display);
+  font-weight: var(--weight-medium);
+  line-height: 1.05;
+  letter-spacing: -0.01em;
+  color: var(--ink-primary);
+  text-wrap: balance;
+  max-width: 30ch;
+}
+
+.tagline {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-lg);
+  line-height: var(--leading-relaxed);
+  color: var(--ink-secondary);
+  max-width: 36ch;
+}
+
+.commanderRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: var(--text-md);
+  color: var(--ink-tertiary);
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-5);
+  width: 100%;
+  max-width: 720px;
+  margin-top: var(--space-7);
+}
+
+@media (min-width: 640px) {
+  .stats {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}

--- a/src/components/reading/ReadingHero.tsx
+++ b/src/components/reading/ReadingHero.tsx
@@ -1,0 +1,79 @@
+import type { DeckData } from "@/lib/types";
+import type { DeckAnalysisResults } from "@/lib/deck-analysis-aggregate";
+import { Eyebrow, StatTile } from "@/components/ui";
+import { deckTagline } from "@/lib/deck-tagline";
+import styles from "./ReadingHero.module.css";
+
+export interface ReadingHeroProps {
+  deck: DeckData;
+  analysis: DeckAnalysisResults;
+  /** Wall-clock timestamp at deck import. Used for the READING · DATE eyebrow. */
+  createdAt: number;
+}
+
+function formatReadingDate(timestamp: number): string {
+  const d = new Date(timestamp);
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  const yy = String(d.getFullYear()).slice(-2);
+  return `${mm}.${dd}.${yy}`;
+}
+
+export default function ReadingHero({
+  deck,
+  analysis,
+  createdAt,
+}: ReadingHeroProps) {
+  const tagline = deckTagline(deck, analysis);
+  const date = formatReadingDate(createdAt);
+  const commanderNames = deck.commanders.map((c) => c.name);
+  const topTheme = analysis.synergyAnalysis.deckThemes[0];
+
+  return (
+    <section data-testid="reading-hero" className={styles.hero}>
+      <Eyebrow>{`READING · ${date}`}</Eyebrow>
+
+      <h1 className={styles.title}>{deck.name}</h1>
+
+      <p data-testid="reading-tagline" className={styles.tagline}>
+        {tagline}
+      </p>
+
+      {commanderNames.length > 0 && (
+        <p className={styles.commanderRow}>
+          led by {commanderNames.join(" & ")}
+        </p>
+      )}
+
+      <div data-testid="reading-stats" className={styles.stats}>
+        <StatTile
+          label="Bracket"
+          value={`B${analysis.bracketResult.bracket}`}
+          sub={analysis.bracketResult.bracketName}
+        />
+        <StatTile
+          label="Power Level"
+          value={`PL${analysis.powerLevel.powerLevel}`}
+          sub={analysis.powerLevel.bandLabel}
+          accent
+        />
+        <StatTile
+          label="Total Cost"
+          value={analysis.budgetAnalysis.totalCostFormatted}
+          sub="USD"
+        />
+        <StatTile
+          label="Top Theme"
+          value={topTheme?.axisName ?? "Goodstuff"}
+          sub={
+            topTheme?.detail
+              ? topTheme.detail
+              : topTheme
+                ? `${topTheme.cardCount} cards`
+                : "no dominant theme"
+          }
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/reading/ReadingOverview.module.css
+++ b/src/components/reading/ReadingOverview.module.css
@@ -1,0 +1,146 @@
+.shell {
+  position: relative;
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: var(--space-12) var(--space-8) var(--space-20);
+}
+
+.newReadingAction {
+  position: absolute;
+  top: var(--space-7);
+  right: var(--space-7);
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--ink-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.newReadingAction:hover {
+  color: var(--accent);
+  border-color: var(--border-accent);
+  background: var(--accent-soft);
+}
+
+.newReadingAction:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.gridLabel {
+  display: block;
+  text-align: center;
+  margin-bottom: var(--space-6);
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: var(--space-5);
+}
+
+@media (min-width: 480px) {
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+.tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-8);
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  border-radius: var(--card-radius);
+  color: var(--ink-primary);
+  text-decoration: none;
+  cursor: pointer;
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+  transition:
+    border-color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out),
+    transform var(--dur-fast) var(--ease-out);
+}
+
+.tile:hover {
+  border-color: var(--border-accent);
+  background: var(--accent-soft);
+  transform: translateY(-1px);
+}
+
+.tile:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--bg-base), 0 0 0 4px var(--accent);
+}
+
+.tileEyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0.8;
+}
+
+.tileTitle {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: var(--text-h3);
+  font-weight: var(--weight-medium);
+  color: var(--ink-primary);
+}
+
+.tileDesc {
+  margin: 0;
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+  color: var(--ink-tertiary);
+}
+
+.tilePending {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.tilePendingBadge {
+  align-self: flex-start;
+  margin-top: var(--space-2);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}

--- a/src/components/reading/ReadingOverview.tsx
+++ b/src/components/reading/ReadingOverview.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useDeckSession } from "@/contexts/DeckSessionContext";
+import ReadingHero from "@/components/reading/ReadingHero";
+import styles from "./ReadingOverview.module.css";
+
+interface SectionTile {
+  /** Unique slug; phase 4 will turn this into a real route under /reading/<slug>. */
+  slug: string;
+  /** Eyebrow text shown above the tile title. */
+  eyebrow: string;
+  /** Display title (Spectral). */
+  title: string;
+  /** One-line description. */
+  description: string;
+  /** Set true while the route doesn't exist yet — tile renders disabled. */
+  pending?: boolean;
+}
+
+const SECTION_TILES: SectionTile[] = [
+  {
+    slug: "cards",
+    eyebrow: "Cards",
+    title: "The Decklist",
+    description: "Every card grouped by zone with mana cost and tags.",
+  },
+  {
+    slug: "composition",
+    eyebrow: "Composition",
+    title: "The Shape of the Deck",
+    description: "Mana curve, color distribution, and land base efficiency.",
+    pending: true,
+  },
+  {
+    slug: "synergy",
+    eyebrow: "Synergies",
+    title: "How the Cards Read Together",
+    description: "Top synergies, anti-synergies, combos, and interactions.",
+    pending: true,
+  },
+  {
+    slug: "goldfish",
+    eyebrow: "Simulation",
+    title: "Goldfish Reading",
+    description: "Mulligan rates, openers, and turn-by-turn simulations.",
+    pending: true,
+  },
+  {
+    slug: "suggestions",
+    eyebrow: "Recommendations",
+    title: "What to Cut, What to Add",
+    description: "Heuristic suggestions based on composition and themes.",
+    pending: true,
+  },
+  {
+    slug: "add",
+    eyebrow: "Candidates",
+    title: "Possible Additions",
+    description: "Cards that match the deck's themes but aren't included.",
+    pending: true,
+  },
+  {
+    slug: "compare",
+    eyebrow: "Compare",
+    title: "Side by Side",
+    description: "Diff this list against another for overlap and divergence.",
+    pending: true,
+  },
+  {
+    slug: "share",
+    eyebrow: "Share",
+    title: "Take It Elsewhere",
+    description: "Export the reading as a link, image, or Discord post.",
+    pending: true,
+  },
+];
+
+export default function ReadingOverview() {
+  const { payload, analysisResults, clearSession } = useDeckSession();
+  const router = useRouter();
+
+  if (!payload) return null;
+
+  const handleNewReading = () => {
+    clearSession();
+    router.push("/");
+  };
+
+  return (
+    <div className={styles.shell}>
+      <button
+        type="button"
+        data-testid="new-reading-button"
+        onClick={handleNewReading}
+        className={styles.newReadingAction}
+        aria-label="Start a new reading"
+      >
+        + New Reading
+      </button>
+
+      {analysisResults && (
+        <ReadingHero
+          deck={payload.deck}
+          analysis={analysisResults}
+          createdAt={payload.createdAt}
+        />
+      )}
+
+      <span className={styles.gridLabel}>What's Inside</span>
+
+      <div data-testid="reading-section-grid" className={styles.grid}>
+        {SECTION_TILES.map((tile) => {
+          const className = [
+            styles.tile,
+            tile.pending && styles.tilePending,
+          ]
+            .filter(Boolean)
+            .join(" ");
+
+          if (tile.pending) {
+            return (
+              <div
+                key={tile.slug}
+                className={className}
+                aria-disabled="true"
+              >
+                <span className={styles.tileEyebrow}>{tile.eyebrow}</span>
+                <h2 className={styles.tileTitle}>{tile.title}</h2>
+                <p className={styles.tileDesc}>{tile.description}</p>
+                <span className={styles.tilePendingBadge}>Coming next</span>
+              </div>
+            );
+          }
+
+          return (
+            <Link
+              key={tile.slug}
+              href={`/reading/${tile.slug}`}
+              className={className}
+              aria-label={`${tile.eyebrow} — ${tile.title}`}
+            >
+              <span className={styles.tileEyebrow}>{tile.eyebrow}</span>
+              <h2 className={styles.tileTitle}>{tile.title}</h2>
+              <p className={styles.tileDesc}>{tile.description}</p>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/deck-tagline.ts
+++ b/src/lib/deck-tagline.ts
@@ -1,0 +1,130 @@
+import type { DeckData } from "@/lib/types";
+import type { DeckAnalysisResults } from "@/lib/deck-analysis-aggregate";
+
+/**
+ * Synthesize a one-line italic tagline summarizing the deck's character.
+ *
+ * The tagline lives in the verdict-first /reading hero. It should read
+ * editorial — like the lede of a magazine review of the deck — not
+ * a stat readout. Examples:
+ *
+ *   "A relentless landfall engine that wins decisively."
+ *   "An Elf tribal swarm pressing wide for kills."
+ *   "A patient lifegain build that scales over time."
+ *   "A casual midrange list with broad answers."
+ *   "A combo deck angling for a 2-piece kill."
+ *
+ * Pure function — no I/O, no randomness. Same input always yields the
+ * same string so screenshots and snapshots stay stable.
+ */
+export function deckTagline(
+  _deck: DeckData,
+  analysis: DeckAnalysisResults
+): string {
+  const themes = analysis.synergyAnalysis.deckThemes;
+  const topTheme = themes[0];
+  const power = analysis.powerLevel.powerLevel;
+  const knownCombos = analysis.synergyAnalysis.knownCombos;
+
+  // ─── Power adjective ────────────────────────────────────────────────
+  // Reads as the speed/sophistication of the deck. Used as the leading
+  // word for theme-based taglines.
+  const powerAdj = (() => {
+    if (power >= 9) return "A relentless";
+    if (power >= 7) return "An optimized";
+    if (power >= 5) return "A focused";
+    if (power >= 3) return "A patient";
+    return "A casual";
+  })();
+
+  // ─── Combo callout ──────────────────────────────────────────────────
+  // Only mentioned when there's a meaningful combo present and either no
+  // theme exists or the theme isn't graveyard/sacrifice (where the combo
+  // is implicit in the theme phrase).
+  const comboPhrase = knownCombos.length > 0
+    ? `${knownCombos.length}-piece combo finish`
+    : null;
+
+  // ─── No-theme fallbacks ─────────────────────────────────────────────
+  if (!topTheme) {
+    if (comboPhrase) {
+      return `A combo deck angling for a ${comboPhrase}.`;
+    }
+    if (power >= 7) {
+      return "An optimized goodstuff toolbox with broad answers.";
+    }
+    if (power <= 3) {
+      return "A casual midrange list with broad answers.";
+    }
+    return "A focused midrange goodstuff list.";
+  }
+
+  // ─── Theme-driven taglines ──────────────────────────────────────────
+  const tribe = topTheme.detail?.toLowerCase() ?? "";
+
+  switch (topTheme.axisId) {
+    case "landfall":
+      return power >= 7
+        ? `${powerAdj} landfall engine that wins decisively.`
+        : `${powerAdj} landfall ramp build that scales over time.`;
+
+    case "tribal": {
+      const tribeWord = tribe || "creature";
+      return power >= 7
+        ? `${powerAdj} ${tribeWord} tribal swarm pressing wide for kills.`
+        : `${powerAdj} ${tribeWord} tribal build that snowballs through the table.`;
+    }
+
+    case "tokens":
+      return power >= 7
+        ? `${powerAdj} go-wide token machine, fragile to sweepers.`
+        : "Aggressive go-wide tokens, fragile to sweepers.";
+
+    case "graveyard":
+      return comboPhrase
+        ? `${powerAdj} graveyard reanimator with a ${comboPhrase}.`
+        : `${powerAdj} graveyard reanimator that recurs threats relentlessly.`;
+
+    case "sacrifice":
+      return `${powerAdj} sacrifice loop grinding value over time.`;
+
+    case "spellslinger":
+      return `${powerAdj} spellslinger that turns instants into wins.`;
+
+    case "artifacts":
+      return power >= 7
+        ? `${powerAdj} artifact engine with explosive starts.`
+        : `${powerAdj} artifact synergy build with steady payoffs.`;
+
+    case "enchantments":
+      return `${powerAdj} enchantment shell stacking permanents.`;
+
+    case "lifegain":
+      return power >= 7
+        ? `${powerAdj} lifegain payoff list closing through the air.`
+        : `${powerAdj} lifegain build that scales over time.`;
+
+    case "counters":
+      return `${powerAdj} +1/+1 counter machine snowballing on the battlefield.`;
+
+    case "discard":
+      return `${powerAdj} discard control deck stripping the table early.`;
+
+    case "spellslinger":
+      return `${powerAdj} spell-dense list that punches above its curve.`;
+
+    case "supertypeMatter":
+      return `${powerAdj} supertype-matters build leveraging legendary payoffs.`;
+
+    case "keywordMatters":
+      return `${powerAdj} keyword-matters list rewarding stacked abilities.`;
+
+    case "graveyardHate":
+      return `${powerAdj} graveyard-hate shell punishing recursive strategies.`;
+
+    default:
+      // Theme exists but we don't have a custom phrase — describe by
+      // theme name with the power adjective.
+      return `${powerAdj} ${topTheme.axisName.toLowerCase()} build.`;
+  }
+}

--- a/tests/unit/deck-tagline.spec.ts
+++ b/tests/unit/deck-tagline.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect } from "@playwright/test";
+import type { DeckData } from "@/lib/types";
+import type { DeckAnalysisResults } from "@/lib/deck-analysis-aggregate";
+import type { DeckTheme, SynergyPair } from "@/lib/types";
+import { deckTagline } from "@/lib/deck-tagline";
+
+// ---------------------------------------------------------------------------
+// Helpers — minimal DeckAnalysisResults stubs for tagline branches
+// ---------------------------------------------------------------------------
+
+function makeAnalysis(partial: {
+  themes?: DeckTheme[];
+  powerLevel?: number;
+  knownCombos?: SynergyPair[];
+}): DeckAnalysisResults {
+  return {
+    manaCurve: [],
+    colorDistribution: {} as DeckAnalysisResults["colorDistribution"],
+    manaBaseMetrics: {} as DeckAnalysisResults["manaBaseMetrics"],
+    commanderIdentity: new Set() as DeckAnalysisResults["commanderIdentity"],
+    landEfficiency: {} as DeckAnalysisResults["landEfficiency"],
+    manaRecommendations: {} as DeckAnalysisResults["manaRecommendations"],
+    powerLevel: {
+      powerLevel: partial.powerLevel ?? 5,
+    } as DeckAnalysisResults["powerLevel"],
+    bracketResult: {} as DeckAnalysisResults["bracketResult"],
+    budgetAnalysis: {} as DeckAnalysisResults["budgetAnalysis"],
+    synergyAnalysis: {
+      cardScores: {},
+      topSynergies: [],
+      antiSynergies: [],
+      knownCombos: partial.knownCombos ?? [],
+      deckThemes: partial.themes ?? [],
+    },
+    compositionScorecard: {} as DeckAnalysisResults["compositionScorecard"],
+    creatureTypes: [],
+    supertypes: [],
+    simulationStats: {} as DeckAnalysisResults["simulationStats"],
+  };
+}
+
+const EMPTY_DECK: DeckData = {
+  name: "Test Deck",
+  source: "text",
+  url: "",
+  commanders: [],
+  mainboard: [],
+  sideboard: [],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("deckTagline", () => {
+  test("never returns an empty string", () => {
+    const tagline = deckTagline(EMPTY_DECK, makeAnalysis({}));
+    expect(tagline.length).toBeGreaterThan(0);
+  });
+
+  test("always ends with a sentence-final punctuation", () => {
+    const tagline = deckTagline(EMPTY_DECK, makeAnalysis({}));
+    expect(tagline).toMatch(/[.!?]$/);
+  });
+
+  test("landfall theme produces a landfall tagline", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [
+          { axisId: "landfall", axisName: "Landfall", strength: 0.8, cardCount: 12 },
+        ],
+        powerLevel: 7,
+      })
+    );
+    expect(tagline.toLowerCase()).toContain("landfall");
+  });
+
+  test("tribal theme includes the tribe name when provided", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [
+          {
+            axisId: "tribal",
+            axisName: "Tribal",
+            strength: 0.7,
+            cardCount: 18,
+            detail: "Elf",
+          },
+        ],
+      })
+    );
+    expect(tagline.toLowerCase()).toContain("elf");
+    expect(tagline.toLowerCase()).toContain("tribal");
+  });
+
+  test("tokens theme produces a go-wide tagline", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [
+          { axisId: "tokens", axisName: "Tokens", strength: 0.6, cardCount: 14 },
+        ],
+      })
+    );
+    expect(tagline.toLowerCase()).toMatch(/token|go-wide|swarm/);
+  });
+
+  test("graveyard theme produces a graveyard tagline", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [
+          { axisId: "graveyard", axisName: "Graveyard", strength: 0.7, cardCount: 16 },
+        ],
+      })
+    );
+    expect(tagline.toLowerCase()).toMatch(/graveyard|recur|reanimat/);
+  });
+
+  test("artifacts theme produces an artifact-flavoured tagline", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [
+          {
+            axisId: "artifacts",
+            axisName: "Artifacts",
+            strength: 0.65,
+            cardCount: 22,
+          },
+        ],
+      })
+    );
+    expect(tagline.toLowerCase()).toContain("artifact");
+  });
+
+  test("known combo with no theme calls out the combo finish", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [],
+        knownCombos: [
+          {
+            cards: ["Thassa's Oracle", "Demonic Consultation"],
+            axisId: null,
+            type: "combo",
+            strength: 1,
+            description: "Win the game.",
+          },
+        ],
+      })
+    );
+    expect(tagline.toLowerCase()).toContain("combo");
+  });
+
+  test("high power level (8+) reads as relentless / optimized", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [
+          { axisId: "landfall", axisName: "Landfall", strength: 0.8, cardCount: 14 },
+        ],
+        powerLevel: 9,
+      })
+    );
+    expect(tagline.toLowerCase()).toMatch(/relentless|optimi[sz]ed|high-power|cedh/);
+  });
+
+  test("low power level (1-3) reads as casual / patient", () => {
+    const tagline = deckTagline(
+      EMPTY_DECK,
+      makeAnalysis({
+        themes: [
+          { axisId: "lifegain", axisName: "Lifegain", strength: 0.6, cardCount: 10 },
+        ],
+        powerLevel: 2,
+      })
+    );
+    expect(tagline.toLowerCase()).toMatch(/casual|patient|gentle|relaxed/);
+  });
+
+  test("no theme + no combo + mid power → midrange/goodstuff fallback", () => {
+    const tagline = deckTagline(EMPTY_DECK, makeAnalysis({ powerLevel: 5 }));
+    expect(tagline.toLowerCase()).toMatch(/midrange|goodstuff|broad|toolbox/);
+  });
+});


### PR DESCRIPTION
## Summary

Replace the temporary Phase 1+2 \`/reading\` (which was just the full results UI) with the design system's intended **verdict-first landing**: editorial hero with eyebrow, serif deck name, italic tagline, four StatTiles, and a \"What's Inside\" section grid. The existing analysis surfaces move under \`/reading/cards\`.

This is **Phase 3 of 5** in [\`docs/plans/astral-journey-restructure.md\`](docs/plans/astral-journey-restructure.md). Phase 4 will turn the seven \"Coming next\" tiles into real routes (\`/reading/composition\`, \`/reading/synergy\`, \`/reading/goldfish\`, etc.).

## What's new

**\`src/lib/deck-tagline.ts\`** — Pure heuristic that synthesizes a one-line italic tagline from the deck's archetype (top synergy theme), power level, and known combos. Reads like a magazine lede:

- *\"A relentless landfall engine that wins decisively.\"*
- *\"An Elf tribal swarm pressing wide for kills.\"*
- *\"A patient lifegain build that scales over time.\"*
- *\"A combo deck angling for a 2-piece kill.\"*

11 unit tests cover archetype branches + punctuation invariants.

**\`ReadingHero\`** — Eyebrow \`READING · MM.DD.YY\`, serif h1 deck name, italic Spectral tagline, \"led by …\" commander row, four StatTiles: Bracket / Power Level (accent) / Total Cost / Top Theme.

**\`ReadingOverview\`** — ReadingHero + 8-tile section grid (Cards, Composition, Synergies, Simulation, Recommendations, Candidates, Compare, Share). Only \"Cards\" is live in this PR — the rest render as \"Coming next\" pills that Phase 4 turns into routes. Top-right \`+ New Reading\` pill clears the session.

**\`/reading/cards/page.tsx\`** — Hosts the existing \`DeckReadingView\` (sidebar + drawer + view-tabs). The full pre-Phase-3 results UI lives here.

## Files

**New**
- \`src/lib/deck-tagline.ts\`
- \`src/components/reading/ReadingHero.{tsx,module.css}\`
- \`src/components/reading/ReadingOverview.{tsx,module.css}\`
- \`src/app/reading/cards/page.tsx\`
- \`tests/unit/deck-tagline.spec.ts\` — 11 tagline assertions
- \`e2e/reading-overview.spec.ts\` — 6 hero + grid + click-through tests

**Modified**
- \`src/app/reading/page.tsx\` → renders \`ReadingOverview\` instead of \`DeckReadingView\`
- \`e2e/reading-routing.spec.ts\` — assertions updated for the new /reading shape; added a \`/reading/cards\` refresh-rehydration test
- \`e2e/fixtures.ts waitForDeckDisplay\` — soft-navigates to \`/reading/cards\` via the section grid link when on the overview, so existing tests that probe deck-list / tabs keep working unchanged. Soft-nav avoids the \`page.goto\` trap (full reload remounts the provider and drops in-memory error state, breaking the enrichment-error retry tests)

## Test plan

- [x] \`npm run build\` clean — \`/reading/cards\` registered alongside \`/reading\`
- [x] \`npm run test:unit\` — 2473/2473 pass (was 2462, +11 tagline tests)
- [x] Full \`npx playwright test\` — 400/400 pass in 1.7m

## Open questions for next phases

- Phase 4 (sub-route fan-out) needs to decide tab-to-route mapping. The current \`DeckReadingView\` packs all view-tabs (List / Analysis / Synergy / Hands / Additions / Interactions / Suggestions / Goldfish) into \`/reading/cards\`. Phase 4 will likely keep cards-only at \`/cards\` and split the rest into \`/composition\`, \`/synergy\`, \`/goldfish\`, etc.
- The tagline heuristic produces good text for most archetypes but lacks color identity nuance. Phase 5 polish could add tribe/color-aware variants without changing the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)