### PR TITLE
fix: never skip Vercel production deploys in the ignore script

### DIFF
--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -7,6 +7,16 @@
 
 set -euo pipefail
 
+# Always build production deploys. Release pipeline triggers prod via
+# deploy hook; Vercel doesn't set VERCEL_GIT_PREVIOUS_SHA for hook-driven
+# deploys, so the diff fallback below would compare master..master, see
+# zero changed files, and skip the release. Skipping production releases
+# is never the right call.
+if [ "${VERCEL_ENV:-}" = "production" ]; then
+  echo "✓ Production deploy — always proceeding with build"
+  exit 1
+fi
+
 echo "→ Checking if app code changed..."
 
 # Paths that should trigger a build


### PR DESCRIPTION
## Summary

The v1.0.0 release was triggered correctly but Vercel canceled the production build. Build log on the canceled deployment (`dpl_4BUwBSSYbg5gwe1noojytpRbVdms`):

\`\`\`
→ Checking if app code changed...
  No changed files detected — skipping build
The Deployment has been canceled as a result of running the command defined in the \"Ignored Build Step\" setting.
\`\`\`

## Root cause

The release pipeline triggers production via the \`github-release\` deploy hook. Vercel does **not** populate \`VERCEL_GIT_PREVIOUS_SHA\` for hook-driven deploys, so the script's fallback computed \`git merge-base origin/master HEAD\` — which equals HEAD itself when HEAD is on master. The resulting diff was empty, the script exited 0 (\"no changed files\"), and Vercel reported the skipped build as CANCELED.

The same issue would silently bite every future release.

## Fix

Bail out early with \`exit 1\` whenever \`VERCEL_ENV=production\`. The ignore step is meant to skip preview builds for doc-only changes — skipping a production release is never the right call.

## Shipping v1.0.0

Once this lands on master, hit **Redeploy** on \`dpl_4BUwBSSYbg5gwe1noojytpRbVdms\` in the Vercel dashboard (or re-fire the deploy hook). Vercel will re-clone master at HEAD (which now includes this fix), the script sees \`VERCEL_ENV=production\`, exits 1 immediately, and the build proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)