### PR TITLE
fix: stop tagging graveyard-hate cards as board wipes

### DIFF
--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -137,8 +137,11 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Removal: destroy/exile targeting opponents' permanents
   Removal: '(o:"destroy target" or o:"exile target" or o:"return target" o:"hand")',
 
-  // Board Wipe: destroy or exile all (mass removal)
-  "Board Wipe": '(o:"destroy all" or o:"exile all" or o:"all creatures get -")',
+  // Board Wipe: destroy or exile all <battlefield-zone object>. Phrases are
+  // explicit so that "exile all cards from <graveyard/library>" cards
+  // (e.g. Scavenger Grounds, Abstergo Entertainment) don't false-positive.
+  "Board Wipe":
+    '(o:"destroy all creatures" or o:"destroy all nonland" or o:"destroy all nontoken" or o:"destroy all permanents" or o:"destroy all artifacts" or o:"destroy all enchantments" or o:"destroy all planeswalkers" or o:"exile all creatures" or o:"exile all nonland" or o:"exile all nontoken" or o:"exile all permanents" or o:"exile all artifacts" or o:"exile all enchantments" or o:"exile all planeswalkers" or o:"all creatures get -")',
 
   // Counterspell: counter target spell
   Counterspell: '(o:"counter target spell" or o:"counter target" t:instant)',

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -69,8 +69,13 @@ const REMOVAL_TARGET_RE =
   /\b(?:destroy|exile)\s+target\b/i;
 const REMOVAL_BOUNCE_RE = /\breturn target.+?to its owner's hand\b/i;
 const REMOVAL_DAMAGE_RE = /\bdeals?\s+\d+\s+damage to\b.+?\btarget\b/i;
+// Require a battlefield-zone object after "destroy/exile all" so that phrases
+// like "exile all cards from <a graveyard/library>" (Scavenger Grounds, Abstergo
+// Entertainment) don't false-positive as wipes. Allows up to 4 modifier tokens
+// between "all" and the noun (e.g. "destroy all non-Elf creatures", "exile all
+// nonland permanents your opponents control").
 const BOARD_WIPE_RE =
-  /\b(?:destroy|exile)\s+all\b/i;
+  /\b(?:destroy|exile)\s+all\s+(?:\S+\s+){0,4}?(?:creatures?|permanents?|planeswalkers?|artifacts?|enchantments?|lands?|tokens?)\b/i;
 const BOARD_WIPE_BOUNCE_RE = /\breturn all\b.+?\bto their owners' hands\b/i;
 const BOARD_WIPE_MINUS_RE = /\ball creatures get -\d+\/-\d+/i;
 // --- Asymmetric (one-sided) wipe patterns ---

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -111,6 +111,38 @@ test.describe("generateTags — Board Wipe", () => {
     const card = makeCard({ oracleText: "Destroy target creature." });
     expect(generateTags(card)).not.toContain("Board Wipe");
   });
+
+  test("Scavenger Grounds (graveyard hate) → NOT Board Wipe", () => {
+    // "Exile all" matches the literal phrase but the object is "cards from
+    // graveyards" — not a battlefield wipe. Regression guard.
+    const card = makeCard({
+      name: "Scavenger Grounds",
+      typeLine: "Land — Desert",
+      oracleText:
+        "{T}: Add {C}.\n{2}, {T}, Sacrifice a Desert: Exile all cards from all graveyards.",
+    });
+    const tags = generateTags(card);
+    expect(tags).not.toContain("Board Wipe");
+    expect(tags).not.toContain("Removal");
+  });
+
+  test("Abstergo Entertainment (single-graveyard hate) → NOT Board Wipe", () => {
+    // "Exile all cards from target graveyard" — graveyard interaction, not a wipe.
+    const card = makeCard({
+      name: "Abstergo Entertainment",
+      typeLine: "Land",
+      oracleText:
+        "{T}: Add {C}.\n{1}, {T}: Exile all cards from target graveyard.",
+    });
+    expect(generateTags(card)).not.toContain("Board Wipe");
+  });
+
+  test("'exile all cards from your hand' → NOT Board Wipe", () => {
+    const card = makeCard({
+      oracleText: "Exile all cards from your hand face down.",
+    });
+    expect(generateTags(card)).not.toContain("Board Wipe");
+  });
 });
 
 test.describe("generateTags — Asymmetric Wipe", () => {


### PR DESCRIPTION
## Summary

- The board-wipe detection — both the `BOARD_WIPE_RE` regex in `src/lib/card-tags.ts` and the `"Board Wipe"` Scryfall suggestion query in `src/lib/card-suggestions.ts` — matched any card whose oracle text contained the bare phrase `"destroy all"` or `"exile all"`. That swept in graveyard-hate cards like **Scavenger Grounds** (`Exile all cards from all graveyards`) and **Abstergo Entertainment** (`Exile all cards from target graveyard`), which were being shown as boardwipe suggestions.
- Tighten both layers to require a battlefield-zone noun (`creatures | permanents | planeswalkers | artifacts | enchantments | lands | tokens`) within ~4 modifier tokens of `"destroy/exile all"`. The Scryfall query now uses an explicit phrase allowlist instead of bare `o:"destroy all"` / `o:"exile all"`.
- Add regression tests in `tests/unit/card-tags.spec.ts` covering Scavenger Grounds, Abstergo Entertainment, and a generic `"exile all cards from your hand"` case.

## Test plan

- [x] `npm run test:unit` — 2476 passed
- [x] All existing Board Wipe / Asymmetric Wipe positive cases still pass (Wrath of God, Damnation, Plague Wind, In Garruk's Wake, Kindred Dominance, Scourglass, Hour of Reckoning, Cyclonic Rift, Black Sun's Zenith, etc.)
- [x] New negative cases assert Scavenger Grounds and Abstergo Entertainment do NOT receive the `Board Wipe` or `Removal` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)