### PR TITLE
feat: Archidekt URL import + synopsis preview (#15)

### DIFF
--- a/e2e/deck-import-archidekt.spec.ts
+++ b/e2e/deck-import-archidekt.spec.ts
@@ -1,0 +1,171 @@
+import { test, expect } from "./fixtures";
+import type { DeckData } from "../src/lib/types";
+
+const SAMPLE_ARCHIDEKT_DECK: DeckData = {
+  name: "Atraxa Counters",
+  source: "archidekt",
+  url: "https://archidekt.com/decks/123456",
+  commanders: [{ name: "Atraxa, Praetors' Voice", quantity: 1 }],
+  mainboard: [
+    { name: "Sol Ring", quantity: 1 },
+    { name: "Command Tower", quantity: 1 },
+    { name: "Arcane Signet", quantity: 1 },
+    { name: "Swords to Plowshares", quantity: 1 },
+    { name: "Counterspell", quantity: 1 },
+  ],
+  sideboard: [],
+};
+
+test.describe("Deck Import — Archidekt URL Flow", () => {
+  test.beforeEach(async ({ deckPage }) => {
+    await deckPage.goto();
+  });
+
+  test("Archidekt tab shows URL input and hides textarea/load-example/commander/lookup", async ({
+    deckPage,
+  }) => {
+    await deckPage.selectArchidektTab();
+
+    // URL input is visible
+    await expect(deckPage.archidektUrlInput).toBeVisible();
+
+    // Textarea / Load Example / commander input / card lookup all hidden
+    await expect(deckPage.decklistTextarea).toBeHidden();
+    await expect(deckPage.loadExampleButton).toBeHidden();
+    await expect(deckPage.commanderInput).toBeHidden();
+    await expect(deckPage.cardLookupInput).toBeHidden();
+
+    // The Archidekt how-to guide is visible
+    const guide = deckPage.page.getByTestId("archidekt-import-guide");
+    await expect(guide).toBeVisible();
+    await expect(guide).toContainText("archidekt.com");
+  });
+
+  test("submits a valid Archidekt URL and shows the synopsis", async ({
+    deckPage,
+    page,
+  }) => {
+    await page.route("**/api/deck**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...SAMPLE_ARCHIDEKT_DECK, warnings: [] }),
+      });
+    });
+
+    await deckPage.selectArchidektTab();
+    await deckPage.fillArchidektUrl("https://archidekt.com/decks/123456");
+    await deckPage.submitArchidektFetch();
+
+    const synopsis = deckPage.archidektSynopsis;
+    await expect(synopsis).toBeVisible();
+    await expect(synopsis).toContainText("Atraxa Counters");
+    await expect(synopsis).toContainText("Atraxa, Praetors' Voice");
+    // Total cards: 1 commander + 5 mainboard = 6
+    await expect(synopsis).toContainText("6");
+
+    // Link out to the archidekt deck
+    const link = synopsis.getByRole("link", { name: /archidekt/i });
+    await expect(link).toHaveAttribute("href", SAMPLE_ARCHIDEKT_DECK.url);
+    await expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  test("Continue from synopsis navigates to ritual / reading", async ({
+    deckPage,
+    page,
+  }) => {
+    await page.route("**/api/deck**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...SAMPLE_ARCHIDEKT_DECK, warnings: [] }),
+      });
+    });
+
+    await deckPage.selectArchidektTab();
+    await deckPage.fillArchidektUrl("https://archidekt.com/decks/123456");
+    await deckPage.submitArchidektFetch();
+
+    await expect(deckPage.archidektSynopsis).toBeVisible();
+    await deckPage.clickContinueFromSynopsis();
+
+    await page.waitForURL(/\/(ritual|reading)/, { timeout: 15_000 });
+    expect(page.url()).toMatch(/\/(ritual|reading)/);
+  });
+
+  test("Choose another deck returns to URL form without navigating", async ({
+    deckPage,
+    page,
+  }) => {
+    await page.route("**/api/deck**", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...SAMPLE_ARCHIDEKT_DECK, warnings: [] }),
+      });
+    });
+
+    await deckPage.selectArchidektTab();
+    await deckPage.fillArchidektUrl("https://archidekt.com/decks/123456");
+    await deckPage.submitArchidektFetch();
+
+    await expect(deckPage.archidektSynopsis).toBeVisible();
+
+    await page.getByRole("button", { name: /choose another deck/i }).click();
+
+    await expect(deckPage.archidektSynopsis).toBeHidden();
+    await expect(deckPage.archidektUrlInput).toBeVisible();
+    expect(page.url()).not.toMatch(/\/(ritual|reading)/);
+  });
+
+  test("server error surfaces inline without navigating", async ({
+    deckPage,
+    page,
+  }) => {
+    await page.route("**/api/deck**", async (route) => {
+      await route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Archidekt is unavailable" }),
+      });
+    });
+
+    await deckPage.selectArchidektTab();
+    await deckPage.fillArchidektUrl("https://archidekt.com/decks/123456");
+    await deckPage.submitArchidektFetch();
+
+    const error = deckPage.page.getByTestId("archidekt-error");
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/archidekt is unavailable/i);
+
+    expect(page.url()).not.toMatch(/\/(ritual|reading)/);
+    await expect(deckPage.archidektSynopsis).toBeHidden();
+  });
+
+  test("invalid (non-archidekt) URL shows inline error and does not fetch", async ({
+    deckPage,
+    page,
+  }) => {
+    let fetched = false;
+    await page.route("**/api/deck**", async (route) => {
+      fetched = true;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...SAMPLE_ARCHIDEKT_DECK, warnings: [] }),
+      });
+    });
+
+    await deckPage.selectArchidektTab();
+    await deckPage.fillArchidektUrl("https://moxfield.com/decks/abc");
+    await deckPage.submitArchidektFetch();
+
+    const error = deckPage.page.getByTestId("archidekt-error");
+    await expect(error).toBeVisible();
+    await expect(error).toContainText(/archidekt/i);
+
+    // No network call was made
+    expect(fetched).toBe(false);
+    expect(page.url()).not.toMatch(/\/(ritual|reading)/);
+  });
+});

--- a/e2e/deck-import-archidekt.spec.ts
+++ b/e2e/deck-import-archidekt.spec.ts
@@ -171,3 +171,97 @@ test.describe("Deck Import — Archidekt URL Flow", () => {
     expect(page.url()).not.toMatch(/\/(ritual|reading)/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Compare page Archidekt URL flow — locks in inline-mode behavior so the
+// /compare slot's URL import can't silently regress when DeckInput evolves.
+// ---------------------------------------------------------------------------
+
+test.describe("Compare page — Archidekt URL import in slot", () => {
+  test("slot Archidekt tab shows URL input (no textarea) and populates the slot on submit", async ({
+    page,
+  }) => {
+    // Skip the default deckPage fixture so we can stub /api/deck cleanly
+    // without colliding with the home-page enrich mocks in fixtures.ts.
+    await page.route(/\/api\/deck\?/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...SAMPLE_ARCHIDEKT_DECK, warnings: [] }),
+      });
+    });
+    // The Compare slot enriches after import; mock it so we don't hit the
+    // real Scryfall API.
+    await page.route("**/api/deck-enrich", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ cards: {}, notFound: [] }),
+      });
+    });
+
+    await page.goto("/compare");
+
+    const slot = page.getByTestId("compare-slot-a");
+    await expect(slot).toBeVisible();
+
+    // Switch slot A's DeckInput to the Archidekt tab.
+    await slot.getByRole("tab", { name: "Archidekt" }).click();
+
+    // URL input is visible; the legacy textarea is NOT rendered on this tab.
+    await expect(slot.getByLabel(/archidekt deck url/i)).toBeVisible();
+    await expect(slot.getByLabel("Decklist")).toBeHidden();
+
+    // Submit a valid Archidekt URL.
+    await slot.getByLabel(/archidekt deck url/i).fill(
+      "https://archidekt.com/decks/123456"
+    );
+    await slot.getByRole("button", { name: "Import Deck" }).click();
+
+    // The slot replaces the import form with the deck summary card. The
+    // import form's URL input goes away; the source label appears, and
+    // the Clear deck control is rendered.
+    await expect(slot.getByLabel(/archidekt deck url/i)).toBeHidden();
+    await expect(
+      slot.getByRole("button", { name: /clear .*? deck/i })
+    ).toBeVisible();
+
+    // Stays on /compare — no navigation away from the page.
+    expect(page.url()).toMatch(/\/compare$/);
+  });
+
+  test("slot Archidekt tab does NOT show the synopsis card (synopsis is navigate-mode only)", async ({
+    page,
+  }) => {
+    await page.route(/\/api\/deck\?/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...SAMPLE_ARCHIDEKT_DECK, warnings: [] }),
+      });
+    });
+    await page.route("**/api/deck-enrich", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ cards: {}, notFound: [] }),
+      });
+    });
+
+    await page.goto("/compare");
+
+    const slot = page.getByTestId("compare-slot-a");
+    await slot.getByRole("tab", { name: "Archidekt" }).click();
+    await slot.getByLabel(/archidekt deck url/i).fill(
+      "https://archidekt.com/decks/123456"
+    );
+    await slot.getByRole("button", { name: "Import Deck" }).click();
+
+    // Inline mode skips the synopsis pre-confirm step and goes straight to
+    // the slot's deck summary.
+    await expect(page.getByTestId("archidekt-synopsis")).toBeHidden();
+    await expect(
+      slot.getByRole("button", { name: /clear .*? deck/i })
+    ).toBeVisible();
+  });
+});

--- a/e2e/deck-import-archidekt.spec.ts
+++ b/e2e/deck-import-archidekt.spec.ts
@@ -45,7 +45,7 @@ test.describe("Deck Import — Archidekt URL Flow", () => {
     deckPage,
     page,
   }) => {
-    await page.route("**/api/deck**", async (route) => {
+    await page.route(/\/api\/deck\?/, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -62,7 +62,9 @@ test.describe("Deck Import — Archidekt URL Flow", () => {
     await expect(synopsis).toContainText("Atraxa Counters");
     await expect(synopsis).toContainText("Atraxa, Praetors' Voice");
     // Total cards: 1 commander + 5 mainboard = 6
-    await expect(synopsis).toContainText("6");
+    await expect(
+      synopsis.getByText("6", { exact: true })
+    ).toBeVisible();
 
     // Link out to the archidekt deck
     const link = synopsis.getByRole("link", { name: /archidekt/i });
@@ -74,7 +76,7 @@ test.describe("Deck Import — Archidekt URL Flow", () => {
     deckPage,
     page,
   }) => {
-    await page.route("**/api/deck**", async (route) => {
+    await page.route(/\/api\/deck\?/, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -97,7 +99,7 @@ test.describe("Deck Import — Archidekt URL Flow", () => {
     deckPage,
     page,
   }) => {
-    await page.route("**/api/deck**", async (route) => {
+    await page.route(/\/api\/deck\?/, async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -122,7 +124,7 @@ test.describe("Deck Import — Archidekt URL Flow", () => {
     deckPage,
     page,
   }) => {
-    await page.route("**/api/deck**", async (route) => {
+    await page.route(/\/api\/deck\?/, async (route) => {
       await route.fulfill({
         status: 502,
         contentType: "application/json",
@@ -147,7 +149,7 @@ test.describe("Deck Import — Archidekt URL Flow", () => {
     page,
   }) => {
     let fetched = false;
-    await page.route("**/api/deck**", async (route) => {
+    await page.route(/\/api\/deck\?/, async (route) => {
       fetched = true;
       await route.fulfill({
         status: 200,

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -61,6 +61,42 @@ export class DeckPage {
     await this.page.getByRole("tab", { name: tab }).click();
   }
 
+  // ---------------------------------------------------------------------------
+  // Archidekt URL flow
+  // ---------------------------------------------------------------------------
+
+  /** Click the Archidekt import tab */
+  async selectArchidektTab() {
+    await this.selectTab("Archidekt");
+  }
+
+  /** Fill the Archidekt URL input field */
+  async fillArchidektUrl(url: string) {
+    await this.archidektUrlInput.fill(url);
+  }
+
+  /** Submit the Archidekt URL fetch form */
+  async submitArchidektFetch() {
+    await this.page
+      .getByRole("button", { name: /^(import deck|fetch deck)$/i })
+      .click();
+  }
+
+  /** Locator for the Archidekt URL input */
+  get archidektUrlInput() {
+    return this.page.getByLabel(/archidekt deck url/i);
+  }
+
+  /** Locator for the rendered Archidekt synopsis card */
+  get archidektSynopsis() {
+    return this.page.getByTestId("archidekt-synopsis");
+  }
+
+  /** Click the "Continue to reading" button on the Archidekt synopsis */
+  async clickContinueFromSynopsis() {
+    await this.page.getByRole("button", { name: /continue to reading/i }).click();
+  }
+
   /** Fill the decklist textarea */
   async fillDecklist(text: string) {
     await this.page.getByLabel("Decklist").fill(text);

--- a/e2e/tab-navigation.spec.ts
+++ b/e2e/tab-navigation.spec.ts
@@ -32,8 +32,19 @@ test.describe("Tab Navigation", () => {
   test("switches to Archidekt tab", async ({ deckPage }) => {
     await deckPage.selectTab("Archidekt");
 
+    // The Archidekt tab swaps the textarea for a URL input. None of the
+    // text-import affordances (textarea, Load Example, commander input,
+    // card lookup) should be visible.
     await expect(deckPage.loadExampleButton).toBeHidden();
-    await expect(deckPage.decklistTextarea).toBeVisible();
+    await expect(deckPage.decklistTextarea).toBeHidden();
+    await expect(deckPage.commanderInput).toBeHidden();
+    await expect(deckPage.cardLookupInput).toBeHidden();
+
+    // URL input is shown with a how-to guide.
+    await expect(deckPage.archidektUrlInput).toBeVisible();
+    const guide = deckPage.page.getByTestId("archidekt-import-guide");
+    await expect(guide).toBeVisible();
+    await expect(guide).toContainText("archidekt.com");
   });
 
   test("switches back to Manual tab from another tab", async ({

--- a/src/components/ArchidektSynopsis.module.css
+++ b/src/components/ArchidektSynopsis.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   gap: var(--space-7);
   border: 1px solid var(--border);
-  background: rgba(0, 0, 0, 0.3);
+  background: var(--card-bg);
   border-radius: var(--card-radius);
   padding: var(--card-padding);
   backdrop-filter: blur(var(--blur-sm));

--- a/src/components/ArchidektSynopsis.module.css
+++ b/src/components/ArchidektSynopsis.module.css
@@ -1,0 +1,124 @@
+.synopsis {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-7);
+  border: 1px solid var(--border);
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: var(--card-radius);
+  padding: var(--card-padding);
+  backdrop-filter: blur(var(--blur-sm));
+  -webkit-backdrop-filter: blur(var(--blur-sm));
+}
+
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0;
+}
+
+.title {
+  font-family: var(--font-serif);
+  font-size: var(--text-h3);
+  line-height: var(--leading-tight);
+  color: var(--ink-primary);
+  margin: 0;
+}
+
+.deckLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--accent);
+  text-decoration: none;
+  word-break: break-all;
+  transition: color var(--dur-base) var(--ease-out);
+}
+
+.deckLink:hover,
+.deckLink:focus-visible {
+  color: var(--accent-hi);
+  text-decoration: underline;
+  outline: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deckLink {
+    transition: none;
+  }
+}
+
+.commanderRow {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.commanderLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-secondary);
+}
+
+.commanderPills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.commanderPill {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--tag-padding-y) var(--tag-padding-x);
+  border-radius: var(--tag-radius);
+  background: var(--accent-soft);
+  border: 1px solid var(--border-accent);
+  color: var(--accent);
+  font-family: var(--font-serif);
+  font-size: var(--text-sm);
+}
+
+.counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-7);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border);
+}
+
+.countItem {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 80px;
+}
+
+.countLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}
+
+.countValue {
+  font-family: var(--font-serif);
+  font-size: var(--text-h4);
+  color: var(--ink-primary);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border);
+  align-items: center;
+  justify-content: flex-end;
+}

--- a/src/components/ArchidektSynopsis.tsx
+++ b/src/components/ArchidektSynopsis.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import type { DeckData } from "@/lib/types";
+import { Button } from "@/components/ui";
+import styles from "./ArchidektSynopsis.module.css";
+
+interface ArchidektSynopsisProps {
+  deck: DeckData;
+  onContinue: () => void;
+  onChooseAnother: () => void;
+  loading?: boolean;
+}
+
+export default function ArchidektSynopsis({
+  deck,
+  onContinue,
+  onChooseAnother,
+  loading = false,
+}: ArchidektSynopsisProps) {
+  const mainboardCount = deck.mainboard.reduce(
+    (sum, card) => sum + card.quantity,
+    0
+  );
+  const sideboardCount = deck.sideboard.reduce(
+    (sum, card) => sum + card.quantity,
+    0
+  );
+  const commanderCount = deck.commanders.reduce(
+    (sum, card) => sum + card.quantity,
+    0
+  );
+  const totalCount = mainboardCount + sideboardCount + commanderCount;
+
+  return (
+    <section
+      data-testid="archidekt-synopsis"
+      className={styles.synopsis}
+      aria-label="Archidekt deck synopsis"
+    >
+      <div>
+        <p className={styles.eyebrow}>Imported from Archidekt</p>
+        <h3 className={styles.title}>{deck.name}</h3>
+      </div>
+
+      <a
+        href={deck.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.deckLink}
+      >
+        View on archidekt.com
+      </a>
+
+      {deck.commanders.length > 0 && (
+        <div className={styles.commanderRow}>
+          <span className={styles.commanderLabel}>
+            {deck.commanders.length === 1 ? "Commander" : "Commanders"}
+          </span>
+          <div className={styles.commanderPills}>
+            {deck.commanders.map((c) => (
+              <span key={c.name} className={styles.commanderPill}>
+                {c.name}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className={styles.counts}>
+        <div className={styles.countItem}>
+          <span className={styles.countLabel}>Mainboard</span>
+          <span className={styles.countValue}>{mainboardCount}</span>
+        </div>
+        <div className={styles.countItem}>
+          <span className={styles.countLabel}>Sideboard</span>
+          <span className={styles.countValue}>{sideboardCount}</span>
+        </div>
+        <div className={styles.countItem}>
+          <span className={styles.countLabel}>Total</span>
+          <span className={styles.countValue}>{totalCount}</span>
+        </div>
+      </div>
+
+      <div className={styles.actions}>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={onChooseAnother}
+          disabled={loading}
+        >
+          Choose another deck
+        </Button>
+        <Button
+          type="button"
+          variant="primary"
+          onClick={onContinue}
+          disabled={loading}
+        >
+          Continue to reading
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/CompareImportSlot.tsx
+++ b/src/components/CompareImportSlot.tsx
@@ -212,6 +212,7 @@ export default function CompareImportSlot({
             onSubmitUrl={handleFetchDeck}
             onSubmitText={handleParseDeck}
             loading={loading}
+            mode="inline"
           />
 
           {loading && (

--- a/src/components/DeckImportSection.tsx
+++ b/src/components/DeckImportSection.tsx
@@ -113,6 +113,24 @@ export default function DeckImportSection() {
       })
     );
 
+  /**
+   * Called by DeckInput's Archidekt synopsis "Continue" action. The deck
+   * has already been fetched inside DeckInput, so we just persist + route.
+   */
+  const handleConfirmArchidektDeck = (deck: DeckData, warnings: string[]) => {
+    const payload: DeckSessionPayload = {
+      deckId: generateDeckId(),
+      deck,
+      parseWarnings: warnings,
+      cardMap: null,
+      notFoundCount: 0,
+      spellbookCombos: null,
+      createdAt: Date.now(),
+    };
+    setPayload(payload);
+    router.push("/ritual");
+  };
+
   const { loading, error } = state;
 
   return (
@@ -120,7 +138,9 @@ export default function DeckImportSection() {
       <DeckInput
         onSubmitUrl={handleFetchDeck}
         onSubmitText={handleParseDeck}
+        onConfirmArchidektDeck={handleConfirmArchidektDeck}
         loading={loading}
+        mode="navigate"
       />
 
       {loading && (

--- a/src/components/DeckImportSection.tsx
+++ b/src/components/DeckImportSection.tsx
@@ -101,9 +101,6 @@ export default function DeckImportSection() {
     }
   };
 
-  const handleFetchDeck = (url: string) =>
-    handleImport(() => fetch(`/api/deck?url=${encodeURIComponent(url)}`));
-
   const handleParseDeck = (text: string, commanders?: string[]) =>
     handleImport(() =>
       fetch("/api/deck-parse", {
@@ -136,7 +133,6 @@ export default function DeckImportSection() {
   return (
     <div className={styles.layout}>
       <DeckInput
-        onSubmitUrl={handleFetchDeck}
         onSubmitText={handleParseDeck}
         onConfirmArchidektDeck={handleConfirmArchidektDeck}
         loading={loading}

--- a/src/components/DeckInput.module.css
+++ b/src/components/DeckInput.module.css
@@ -187,3 +187,14 @@
   align-items: center;
   gap: var(--space-5);
 }
+
+.inlineError {
+  margin: 0;
+  padding: var(--space-5) var(--space-7);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 134, 160, 0.3);
+  background: var(--status-warn-soft);
+  color: var(--status-warn);
+  font-size: var(--text-sm);
+  line-height: var(--leading-snug);
+}

--- a/src/components/DeckInput.module.css
+++ b/src/components/DeckInput.module.css
@@ -192,7 +192,7 @@
   margin: 0;
   padding: var(--space-5) var(--space-7);
   border-radius: var(--radius-lg);
-  border: 1px solid rgba(255, 134, 160, 0.3);
+  border: 1px solid var(--status-warn);
   background: var(--status-warn-soft);
   color: var(--status-warn);
   font-size: var(--text-sm);

--- a/src/components/DeckInput.tsx
+++ b/src/components/DeckInput.tsx
@@ -3,15 +3,34 @@
 import { useState, useRef, useCallback, type FormEvent } from "react";
 import CommanderInput from "@/components/CommanderInput";
 import CardLookupInput from "@/components/CardLookupInput";
-import { Button, Textarea } from "@/components/ui";
+import ArchidektSynopsis from "@/components/ArchidektSynopsis";
+import { Button, Input, Textarea } from "@/components/ui";
+import { isArchidektUrl } from "@/lib/archidekt";
+import type { DeckData } from "@/lib/types";
 import styles from "./DeckInput.module.css";
 
 type ImportTab = "manual" | "moxfield" | "archidekt";
 
+/**
+ * "navigate" — DeckInput owns the Archidekt fetch and surfaces a synopsis;
+ *   on Continue it calls onConfirmArchidektDeck so the parent can persist
+ *   the deck and route forward.
+ * "inline"   — Legacy behavior: DeckInput just passes the URL string up via
+ *   onSubmitUrl and does not show a synopsis. Used by CompareImportSlot
+ *   which expects the URL submit to flow into its own enrichment pipeline.
+ */
+export type DeckInputMode = "navigate" | "inline";
+
 interface DeckInputProps {
   onSubmitUrl: (url: string) => void | Promise<void>;
   onSubmitText: (text: string, commanders?: string[]) => void | Promise<void>;
+  /**
+   * Called when the user confirms an Archidekt deck from the synopsis card.
+   * Required when mode === "navigate".
+   */
+  onConfirmArchidektDeck?: (deck: DeckData, warnings: string[]) => void;
   loading: boolean;
+  mode?: DeckInputMode;
 }
 
 const EXAMPLE_DECKLIST = `COMMANDER:
@@ -35,13 +54,23 @@ const tabs: { key: ImportTab; label: string }[] = [
 ];
 
 export default function DeckInput({
+  onSubmitUrl,
   onSubmitText,
+  onConfirmArchidektDeck,
   loading,
+  mode = "navigate",
 }: DeckInputProps) {
   const [activeTab, setActiveTab] = useState<ImportTab>("manual");
   const [textValue, setTextValue] = useState("");
   const [commanders, setCommanders] = useState<string[]>([]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Archidekt URL flow state (only used when mode === "navigate")
+  const [archidektUrl, setArchidektUrl] = useState("");
+  const [archidektDeck, setArchidektDeck] = useState<DeckData | null>(null);
+  const [archidektWarnings, setArchidektWarnings] = useState<string[]>([]);
+  const [archidektError, setArchidektError] = useState<string | null>(null);
+  const [archidektLoading, setArchidektLoading] = useState(false);
 
   const handleCardLookup = useCallback(
     (name: string, quantity: number): string => {
@@ -110,11 +139,76 @@ export default function DeckInput({
     []
   );
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+  const handleTextSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const trimmed = textValue.trim();
     if (!trimmed) return;
     onSubmitText(trimmed, commanders.length > 0 ? commanders : undefined);
+  };
+
+  const handleArchidektSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmed = archidektUrl.trim();
+    if (!trimmed) return;
+
+    if (mode === "inline") {
+      // Legacy path: parent handles fetch + state.
+      onSubmitUrl(trimmed);
+      return;
+    }
+
+    if (!isArchidektUrl(trimmed)) {
+      setArchidektError(
+        "Please enter a valid Archidekt deck URL (https://archidekt.com/decks/<id>)."
+      );
+      return;
+    }
+
+    setArchidektLoading(true);
+    setArchidektError(null);
+
+    try {
+      const res = await fetch(
+        `/api/deck?url=${encodeURIComponent(trimmed)}`
+      );
+      const json = await res.json();
+
+      if (!res.ok) {
+        setArchidektError(
+          json.error ?? `Request failed with status ${res.status}`
+        );
+        setArchidektLoading(false);
+        return;
+      }
+
+      const { warnings, ...deckFields } = json as DeckData & {
+        warnings?: string[];
+      };
+      const deck = deckFields as DeckData;
+      setArchidektDeck(deck);
+      setArchidektWarnings(warnings ?? []);
+      setArchidektLoading(false);
+    } catch (err) {
+      setArchidektError(
+        err instanceof Error
+          ? err.message
+          : "An unexpected error occurred. Please try again."
+      );
+      setArchidektLoading(false);
+    }
+  };
+
+  const handleArchidektContinue = () => {
+    if (archidektDeck && onConfirmArchidektDeck) {
+      onConfirmArchidektDeck(archidektDeck, archidektWarnings);
+    }
+  };
+
+  const handleArchidektReset = () => {
+    setArchidektDeck(null);
+    setArchidektWarnings([]);
+    setArchidektError(null);
+    setArchidektUrl("");
   };
 
   const loadExample = () => {
@@ -155,6 +249,10 @@ export default function DeckInput({
       "Paste your Archidekt export here...\n\n1 Sol Ring\n1 Command Tower",
   };
 
+  const isArchidektTab = activeTab === "archidekt";
+  const showArchidektSynopsis =
+    isArchidektTab && mode === "navigate" && archidektDeck !== null;
+
   return (
     <section aria-label="Deck import" className={styles.panel}>
       {/* Tab bar */}
@@ -171,10 +269,16 @@ export default function DeckInput({
             onClick={() => {
               setActiveTab(tab.key);
               setCommanders([]);
+              // Reset Archidekt state when leaving the tab
+              if (tab.key !== "archidekt") {
+                setArchidektDeck(null);
+                setArchidektWarnings([]);
+                setArchidektError(null);
+              }
             }}
             onKeyDown={handleTabKeyDown}
             className={styles.tab}
-            disabled={loading}
+            disabled={loading || archidektLoading}
           >
             {tab.label}
           </button>
@@ -186,124 +290,205 @@ export default function DeckInput({
         id={`tabpanel-${activeTab}`}
         aria-labelledby={`tab-${activeTab}`}
       >
-        <form
-          onSubmit={handleSubmit}
-          aria-busy={loading}
-          className={styles.form}
-        >
-          {/* Moxfield export instructions */}
-          {activeTab === "moxfield" && (
-            <div data-testid="moxfield-export-guide" className={styles.guide}>
-              <p className={styles.guideTitle}>How to import from Moxfield</p>
-              <ol className={styles.guideList}>
-                <li>
-                  Open your deck on{" "}
-                  <span className={styles.guideAccent}>moxfield.com</span>
-                </li>
-                <li>
-                  Click <strong>Export</strong> →{" "}
-                  <strong>Copy for MTGO</strong>
-                </li>
-                <li>Paste the copied text below</li>
-              </ol>
-            </div>
-          )}
-
-          {/* Commander input (optional — hidden on Moxfield tab since MTGO export includes commanders) */}
-          {activeTab !== "moxfield" && (
-            <CommanderInput
-              value={commanders}
-              onChange={setCommanders}
-              disabled={loading}
-            />
-          )}
-
-          {/* Card lookup (manual tab only) */}
-          {activeTab === "manual" && (
-            <CardLookupInput
-              onCardSelected={handleCardLookup}
-              disabled={loading}
-            />
-          )}
-
-          {/* Zone format guide (manual tab only) */}
-          {activeTab === "manual" && (
-            <details data-testid="zone-format-guide" className={styles.zoneGuide}>
-              <summary className={styles.zoneSummary}>
-                Zone headers &amp; decklist format
-              </summary>
-              <div className={styles.zoneBody}>
-                <p>
-                  You can optionally organize your decklist into zones using
-                  headers. Each header marks the start of a section — all cards
-                  below it belong to that zone until the next header.
-                </p>
-                <ul>
-                  <li>
-                    <code>COMMANDER:</code> — your commander(s), max 2
-                  </li>
-                  <li>
-                    <code>MAINBOARD:</code> — the main deck (default if no
-                    header)
-                  </li>
-                  <li>
-                    <code>SIDEBOARD:</code> — sideboard cards
-                  </li>
-                  <li>
-                    <code>COMPANION:</code> — treated as sideboard
-                  </li>
-                </ul>
-                <p>
-                  Cards added via search are always placed in the mainboard. If
-                  no headers are used, all cards default to mainboard. You can
-                  also select your commander using the input above instead of a{" "}
-                  <code>COMMANDER:</code> header.
-                </p>
-              </div>
-            </details>
-          )}
-
-          {/* Decklist textarea */}
-          <div>
-            <label htmlFor="decklist" className={styles.label}>
-              Decklist
-            </label>
-            <Textarea
-              ref={textareaRef}
-              id="decklist"
-              value={textValue}
-              onChange={(e) => setTextValue(e.target.value)}
-              placeholder={placeholders[activeTab]}
-              rows={10}
-              mono
-              disabled={loading}
-              required
-            />
-          </div>
-
-          {/* Actions */}
-          <div className={styles.actions}>
-            <div className={styles.actionsLeft}>
-              {activeTab === "manual" && (
-                <Button
-                  type="button"
-                  variant="secondary"
-                  onClick={loadExample}
-                  disabled={loading}
-                >
-                  Load Example
-                </Button>
-              )}
-            </div>
-            <Button
-              type="submit"
-              variant="primary"
-              disabled={loading || !textValue.trim()}
+        {showArchidektSynopsis && archidektDeck ? (
+          <ArchidektSynopsis
+            deck={archidektDeck}
+            loading={loading}
+            onContinue={handleArchidektContinue}
+            onChooseAnother={handleArchidektReset}
+          />
+        ) : isArchidektTab ? (
+            <form
+              onSubmit={handleArchidektSubmit}
+              aria-busy={archidektLoading || loading}
+              className={styles.form}
             >
-              {loading ? "Loading..." : "Import Deck"}
-            </Button>
-          </div>
-        </form>
+              <div
+                data-testid="archidekt-import-guide"
+                className={styles.guide}
+              >
+                <p className={styles.guideTitle}>
+                  How to import from Archidekt
+                </p>
+                <ol className={styles.guideList}>
+                  <li>
+                    Open your deck on{" "}
+                    <span className={styles.guideAccent}>archidekt.com</span>
+                  </li>
+                  <li>
+                    Copy the URL from your browser
+                    {" "}(<span className={styles.guideAccent}>
+                      https://archidekt.com/decks/&lt;id&gt;
+                    </span>
+                    )
+                  </li>
+                  <li>Paste it below and press Import Deck</li>
+                </ol>
+              </div>
+
+              <div>
+                <label htmlFor="archidekt-url" className={styles.label}>
+                  Archidekt deck URL
+                </label>
+                <Input
+                  id="archidekt-url"
+                  type="url"
+                  inputMode="url"
+                  value={archidektUrl}
+                  onChange={(e) => setArchidektUrl(e.target.value)}
+                  placeholder="https://archidekt.com/decks/123456"
+                  disabled={archidektLoading}
+                  required
+                  invalid={!!archidektError}
+                />
+              </div>
+
+              {archidektError && (
+                <p
+                  role="alert"
+                  data-testid="archidekt-error"
+                  className={styles.inlineError}
+                >
+                  {archidektError}
+                </p>
+              )}
+
+              <div className={styles.actions}>
+                <div className={styles.actionsLeft} />
+                <Button
+                  type="submit"
+                  variant="primary"
+                  disabled={
+                    archidektLoading || loading || !archidektUrl.trim()
+                  }
+                >
+                  {archidektLoading || loading ? "Loading..." : "Import Deck"}
+                </Button>
+              </div>
+            </form>
+        ) : (
+          <form
+            onSubmit={handleTextSubmit}
+            aria-busy={loading}
+            className={styles.form}
+          >
+            {/* Moxfield export instructions */}
+            {activeTab === "moxfield" && (
+              <div data-testid="moxfield-export-guide" className={styles.guide}>
+                <p className={styles.guideTitle}>How to import from Moxfield</p>
+                <ol className={styles.guideList}>
+                  <li>
+                    Open your deck on{" "}
+                    <span className={styles.guideAccent}>moxfield.com</span>
+                  </li>
+                  <li>
+                    Click <strong>Export</strong> →{" "}
+                    <strong>Copy for MTGO</strong>
+                  </li>
+                  <li>Paste the copied text below</li>
+                </ol>
+              </div>
+            )}
+
+            {/* Commander input (optional — hidden on Moxfield tab since MTGO export includes commanders) */}
+            {activeTab !== "moxfield" && (
+              <CommanderInput
+                value={commanders}
+                onChange={setCommanders}
+                disabled={loading}
+              />
+            )}
+
+            {/* Card lookup (manual tab only) */}
+            {activeTab === "manual" && (
+              <CardLookupInput
+                onCardSelected={handleCardLookup}
+                disabled={loading}
+              />
+            )}
+
+            {/* Zone format guide (manual tab only) */}
+            {activeTab === "manual" && (
+              <details
+                data-testid="zone-format-guide"
+                className={styles.zoneGuide}
+              >
+                <summary className={styles.zoneSummary}>
+                  Zone headers &amp; decklist format
+                </summary>
+                <div className={styles.zoneBody}>
+                  <p>
+                    You can optionally organize your decklist into zones using
+                    headers. Each header marks the start of a section — all
+                    cards below it belong to that zone until the next header.
+                  </p>
+                  <ul>
+                    <li>
+                      <code>COMMANDER:</code> — your commander(s), max 2
+                    </li>
+                    <li>
+                      <code>MAINBOARD:</code> — the main deck (default if no
+                      header)
+                    </li>
+                    <li>
+                      <code>SIDEBOARD:</code> — sideboard cards
+                    </li>
+                    <li>
+                      <code>COMPANION:</code> — treated as sideboard
+                    </li>
+                  </ul>
+                  <p>
+                    Cards added via search are always placed in the mainboard.
+                    If no headers are used, all cards default to mainboard. You
+                    can also select your commander using the input above
+                    instead of a <code>COMMANDER:</code> header.
+                  </p>
+                </div>
+              </details>
+            )}
+
+            {/* Decklist textarea */}
+            <div>
+              <label htmlFor="decklist" className={styles.label}>
+                Decklist
+              </label>
+              <Textarea
+                ref={textareaRef}
+                id="decklist"
+                value={textValue}
+                onChange={(e) => setTextValue(e.target.value)}
+                placeholder={placeholders[activeTab]}
+                rows={10}
+                mono
+                disabled={loading}
+                required
+              />
+            </div>
+
+            {/* Actions */}
+            <div className={styles.actions}>
+              <div className={styles.actionsLeft}>
+                {activeTab === "manual" && (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={loadExample}
+                    disabled={loading}
+                  >
+                    Load Example
+                  </Button>
+                )}
+              </div>
+              <Button
+                type="submit"
+                variant="primary"
+                disabled={loading || !textValue.trim()}
+              >
+                {loading ? "Loading..." : "Import Deck"}
+              </Button>
+            </div>
+          </form>
+        )}
       </div>
     </section>
   );

--- a/src/components/DeckInput.tsx
+++ b/src/components/DeckInput.tsx
@@ -22,7 +22,12 @@ type ImportTab = "manual" | "moxfield" | "archidekt";
 export type DeckInputMode = "navigate" | "inline";
 
 interface DeckInputProps {
-  onSubmitUrl: (url: string) => void | Promise<void>;
+  /**
+   * Called when the user submits a URL in inline mode. Required when
+   * mode === "inline" (the parent owns the fetch + state). In navigate
+   * mode the URL is fetched inside DeckInput, so this is unused.
+   */
+  onSubmitUrl?: (url: string) => void | Promise<void>;
   onSubmitText: (text: string, commanders?: string[]) => void | Promise<void>;
   /**
    * Called when the user confirms an Archidekt deck from the synopsis card.
@@ -153,7 +158,7 @@ export default function DeckInput({
 
     if (mode === "inline") {
       // Legacy path: parent handles fetch + state.
-      onSubmitUrl(trimmed);
+      onSubmitUrl?.(trimmed);
       return;
     }
 
@@ -217,6 +222,12 @@ export default function DeckInput({
   };
 
   const handleTabKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+    // Mirror the disabled state on the tab buttons: don't allow keyboard
+    // arrow / Home / End nav while a fetch is in flight, otherwise the
+    // user could leave the Archidekt tab mid-request and trigger a state
+    // update against an unmounted form.
+    if (loading || archidektLoading) return;
+
     const tabKeys = tabs.map((t) => t.key);
     const currentIndex = tabKeys.indexOf(activeTab);
     let newIndex = currentIndex;


### PR DESCRIPTION
## Summary

Replaces the Archidekt tab's free-text textarea with a URL input that fetches the deck via the existing `GET /api/deck` endpoint and shows a confirmation **synopsis** (deck name, commander, counts) before navigating to `/ritual`. The Archidekt-import flow now matches the issue's stated UX (`Users should not see the free text input field, but rather a synopsis on the import.`) and reaches parity with text/Moxfield imports for every downstream reading sub-route.

### Initial implementation (commit `ea77630`)
- New URL input + how-to guide on the Archidekt tab — no textarea, no commander field, no card-lookup, no Load Example
- New `<ArchidektSynopsis>` component shows deck name, link to the deck's archidekt.com URL, commander pills, and mainboard/sideboard/total counts (sums quantities, not row count)
- Two synopsis actions: **Continue to reading** (setPayload + navigate) and **Choose another deck** (reset)
- New `mode: "navigate" | "inline"` prop on `<DeckInput>` so `<CompareImportSlot>` keeps its slot-populates-in-place behavior; navigate mode is the default and is what the import-page flow uses
- 6 e2e tests covering tab UI, valid fetch + synopsis, Continue navigation, Choose-another reset, 502 error path, invalid-URL guard

### Adversarial review fixes (commits `600cacd`, `db24221`, `810c0ea`, `2396773`)
All six blockers from the review pass were addressed:

1. **Mock-glob regression risk fixed** — `'**/api/deck**'` was accidentally intercepting `/api/deck-parse`, `/api/deck-enrich`, and `/api/deck-combos` (Playwright globs do not treat `?` as a literal). Replaced with `RegExp` `/\/api\/deck\?/` everywhere in the spec.
2. **Compare path silent-change covered** — added a Compare-flow describe block: URL form visible (no textarea) on a Compare slot's Archidekt tab, slot populates in place without navigating, synopsis card not shown in inline mode.
3. **Dead `onSubmitUrl` wiring removed** — `onSubmitUrl?` is now optional, called via `?.()` only in inline mode. `<DeckImportSection>` no longer wires `handleFetchDeck`/`onSubmitUrl` (it uses navigate mode and only needs `onConfirmArchidektDeck`).
4. **Type cleanup** — `onSubmitUrl?` and `onConfirmArchidektDeck?` now accurately reflect their per-mode optionality, with a JSDoc note describing the contract. Lighter than a discriminated-union refactor but pins the intent.
5. **Token violations fixed** — `.inlineError`'s `rgba(255,134,160,0.3)` → `var(--status-warn)`; `ArchidektSynopsis.module.css`'s `rgba(0,0,0,0.3)` → `var(--card-bg)`. Both follow existing canonical patterns.
6. **Tab-switch race during fetch fixed** — `handleTabKeyDown` now early-returns when `loading || archidektLoading`, blocking arrow-key tab navigation while a deck fetch is in flight.

Plus the synopsis-count assertion was tightened from `toContainText("6")` to `getByText("6", { exact: true })` to prevent stray-`6` matches.

## Test plan

- [x] `npm test` — **2861 passed, 28 skipped, 0 failed** (388 e2e + 2473 unit)
- [x] 8/8 Archidekt-spec tests passing (6 original + 2 new Compare-flow)
- [x] Compare slot still populates in place via inline mode; CompareImportSlot e2e behavior unchanged
- [x] Adversarial review: mock glob no longer over-matches; dead code removed; tokens compliance restored; tab-switch race closed

## Notes for reviewers

- The design system has no `--shadow-1` / `--card-shadow` token, so the `rgba(0,0,0,0.3)` shadow on the synopsis card was mapped to `var(--card-bg)` (the closest existing semantic). If a darker / dedicated shadow token would be preferred, that could be a follow-up tokens addition.
- Pre-existing TS errors in `tests/unit/*` and a few `e2e/*` specs exist on `master` and are not affected by this PR.

Closes #15

https://claude.ai/code/session_01VTGwUyrCRQMs5TvnXuoHBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTGwUyrCRQMs5TvnXuoHBQ)_