### PR TITLE
feat(card-tags): tag fixes and 8 new tags for #56

### DIFF
--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -173,6 +173,9 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Fog: mass combat damage prevention
   Fog: '(o:"prevent all combat damage" o:"this turn")',
 
+  // Hatebear / Tax: cost-tax permanents that disrupt opponents
+  "Hatebear / Tax": '(o:"spells cost" o:"more" or o:"opponents" o:"pay")',
+
   // Sacrifice Outlet: sacrifice effects
   "Sacrifice Outlet": '(o:"sacrifice" o:":" or o:"sacrifice a")',
 };

--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -167,6 +167,9 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Token Payoff: ETB triggers that scale with creature count
   "Token Payoff": '(o:"whenever" o:"creature enters" o:"deals")',
 
+  // Flicker: exile-and-return blink effects
+  Flicker: '(o:"exile target" o:"return" o:"battlefield")',
+
   // Sacrifice Outlet: sacrifice effects
   "Sacrifice Outlet": '(o:"sacrifice" o:":" or o:"sacrifice a")',
 };

--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -161,6 +161,9 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Token Multiplier: doublers (Anointed Procession, Parallel Lives, etc.)
   "Token Multiplier": '(o:"twice that many" o:"tokens")',
 
+  // Mana Reduction: pay life rather than mana (Defiler cycle)
+  "Mana Reduction": '(o:"pay" o:"life" o:"costs" o:"less")',
+
   // Sacrifice Outlet: sacrifice effects
   "Sacrifice Outlet": '(o:"sacrifice" o:":" or o:"sacrifice a")',
 };

--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -158,6 +158,9 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Token Generator: create tokens
   "Token Generator": '(o:"create" o:"token")',
 
+  // Token Multiplier: doublers (Anointed Procession, Parallel Lives, etc.)
+  "Token Multiplier": '(o:"twice that many" o:"tokens")',
+
   // Sacrifice Outlet: sacrifice effects
   "Sacrifice Outlet": '(o:"sacrifice" o:":" or o:"sacrifice a")',
 };

--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -176,6 +176,9 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Hatebear / Tax: cost-tax permanents that disrupt opponents
   "Hatebear / Tax": '(o:"spells cost" o:"more" or o:"opponents" o:"pay")',
 
+  // Artifact Hate: destroy/exile artifacts
+  "Artifact Hate": '(o:"destroy target artifact" or o:"destroy all artifacts" or o:"exile target artifact")',
+
   // Sacrifice Outlet: sacrifice effects
   "Sacrifice Outlet": '(o:"sacrifice" o:":" or o:"sacrifice a")',
 };

--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -164,6 +164,9 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Mana Reduction: pay life rather than mana (Defiler cycle)
   "Mana Reduction": '(o:"pay" o:"life" o:"costs" o:"less")',
 
+  // Token Payoff: ETB triggers that scale with creature count
+  "Token Payoff": '(o:"whenever" o:"creature enters" o:"deals")',
+
   // Sacrifice Outlet: sacrifice effects
   "Sacrifice Outlet": '(o:"sacrifice" o:":" or o:"sacrifice a")',
 };

--- a/src/lib/card-suggestions.ts
+++ b/src/lib/card-suggestions.ts
@@ -170,6 +170,9 @@ export const TAG_TO_SCRYFALL_QUERY: Record<string, string> = {
   // Flicker: exile-and-return blink effects
   Flicker: '(o:"exile target" o:"return" o:"battlefield")',
 
+  // Fog: mass combat damage prevention
+  Fog: '(o:"prevent all combat damage" o:"this turn")',
+
   // Sacrifice Outlet: sacrifice effects
   "Sacrifice Outlet": '(o:"sacrifice" o:":" or o:"sacrifice a")',
 };

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -384,10 +384,14 @@ const FLICKER_LEAVES_EXCLUSION_RE =
 
 // --- Fog (#56 phase 2) ---
 // Mass damage prevention: "Prevent all combat damage that would be dealt
-// this turn" (Fog, Holy Day, Angelsong) and the rarer "by sources" form.
-// Healing Salve uses "Prevent the next N damage" (single-source) — NOT a fog.
+// this turn" (Fog, Holy Day, Angelsong) and the rarer "by [class of
+// sources]" form. Healing Salve ("Prevent the next N damage") and
+// Awe-Strike ("by target creature") are single-source prevention — NOT a
+// fog. The "by ..." branch requires the source to be a CLASS (all
+// creatures, all sources, creatures you control / opponents control /
+// attacking / blocking), not a specific target.
 const FOG_RE =
-  /\bprevent all (?:combat )?damage that would be dealt (?:this turn|by[^.]+this turn)\b/i;
+  /\bprevent all (?:combat )?damage that would be dealt (?:this turn|by\s+(?:all (?:creatures|sources)|(?:creatures|sources)\s+(?:you (?:do not |don'?t )?control|attacking|blocking))[^.]+this turn)\b/i;
 
 // --- Hatebear / Tax (#56 phase 2) ---
 // Asymmetric tax effects only: the cost increase / payment must explicitly

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -44,6 +44,8 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   Prepare: { bg: "bg-cyan-500/20", text: "text-cyan-300" },
   Book: { bg: "bg-amber-500/20", text: "text-amber-300" },
   Converge: { bg: "bg-indigo-500/20", text: "text-indigo-300" },
+  // #56 phase 2 functional tags
+  "Token Generator": { bg: "bg-lime-500/20", text: "text-lime-200" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -303,6 +305,14 @@ const SELF_DISCARD_ADDITIONAL_RE = /\bas an additional cost[^.]*discard/i;
 const SELF_DISCARD_UPKEEP_RE =
   /\b(?:at the beginning of|during) your upkeep[^.]*discard/i;
 const SELF_DISCARD_KEYWORDS = new Set(["Cycling", "Connive"]);
+
+// --- Token Generator (#56 phase 2) ---
+// "create ... tokens" — covers creature, Treasure, Clue, Food, etc. tokens.
+// Also matches the passive replacement form on token-doubling enchantments
+// ("...tokens would be created..." / "...tokens are created..." on
+// Anointed Procession, Parallel Lives, Doubling Season).
+const TOKEN_GENERATOR_RE =
+  /\bcreate\b[^.]*\btokens?\b|\btokens?\b[^.]*\b(?:would be created|are created)\b/i;
 
 // Discard Payoff — triggers on discard events
 const DISCARD_PAYOFF_TRIGGER_RE = /\bwhenever[^.]*discards?\b/i;
@@ -700,6 +710,12 @@ export function generateTags(card: EnrichedCard): string[] {
         break;
       }
     }
+  }
+
+  // --- Token Generator (#56 phase 2) ---
+  // Any "create ... token(s)" effect: creature tokens, Treasure, Clue, Food.
+  if (TOKEN_GENERATOR_RE.test(text)) {
+    tags.add("Token Generator");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -51,6 +51,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   "Token Payoff": { bg: "bg-rose-500/20", text: "text-rose-300" },
   Flicker: { bg: "bg-sky-500/20", text: "text-sky-200" },
   Fog: { bg: "bg-stone-500/20", text: "text-stone-200" },
+  "Hatebear / Tax": { bg: "bg-yellow-500/20", text: "text-yellow-200" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -371,6 +372,23 @@ const FLICKER_RE =
 // Healing Salve uses "Prevent the next N damage" (single-source) — NOT a fog.
 const FOG_RE =
   /\bprevent all (?:combat )?damage that would be dealt (?:this turn|by[^.]+this turn)\b/i;
+
+// --- Hatebear / Tax (#56 phase 2) ---
+// "Spells cost {N} more to cast" / "opponents pay N more / additional" plus
+// a name allow-list of canonical hatebear / tax pieces whose text doesn't
+// fit a generic regex (Drannith Magistrate, Grand Abolisher, etc.).
+const HATEBEAR_TAX_RE =
+  /\b(?:(?:noncreature\s+|creature\s+)?spells?\s+(?:your opponents control\s+)?cost\s+\{?\d?\}?\s+more|opponents?[^.]+pays?\s+\{?\d?\}?\s+(?:more|additional))/i;
+const HATEBEAR_TAX_NAMES = new Set<string>([
+  "Aven Interruptor",
+  "Thalia, Guardian of Thraben",
+  "Grand Abolisher",
+  "Esper Sentinel",
+  "Kambal, Consul of Allocation",
+  "Drannith Magistrate",
+  "Sphere of Resistance",
+  "Thorn of Amethyst",
+]);
 
 // Discard Payoff — triggers on discard events
 const DISCARD_PAYOFF_TRIGGER_RE = /\bwhenever[^.]*discards?\b/i;
@@ -814,6 +832,14 @@ export function generateTags(card: EnrichedCard): string[] {
   // single-source prevention spells like Healing Salve.
   if (FOG_RE.test(text)) {
     tags.add("Fog");
+  }
+
+  // --- Hatebear / Tax (#56 phase 2) ---
+  // Permanents that tax opponents' resources or restrict their plays.
+  // Combines a generic "spells cost more" / "opponents pay more" regex with
+  // a name allow-list of canonical staples whose text varies.
+  if (HATEBEAR_TAX_RE.test(text) || HATEBEAR_TAX_NAMES.has(card.name)) {
+    tags.add("Hatebear / Tax");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -390,11 +390,13 @@ const FOG_RE =
   /\bprevent all (?:combat )?damage that would be dealt (?:this turn|by[^.]+this turn)\b/i;
 
 // --- Hatebear / Tax (#56 phase 2) ---
-// "Spells cost {N} more to cast" / "opponents pay N more / additional" plus
-// a name allow-list of canonical hatebear / tax pieces whose text doesn't
-// fit a generic regex (Drannith Magistrate, Grand Abolisher, etc.).
+// Asymmetric tax effects only: the cost increase / payment must explicitly
+// target opponents. Symmetric anthem-debuffs ("creature spells cost {1}
+// more") are NOT hatebears — they hit both players. Canonical staples
+// whose oracle text is symmetric in print (Sphere of Resistance, Thorn of
+// Amethyst) are admitted via HATEBEAR_TAX_NAMES instead.
 const HATEBEAR_TAX_RE =
-  /\b(?:(?:noncreature\s+|creature\s+)?spells?\s+(?:your opponents control\s+)?cost\s+\{?\d?\}?\s+more|opponents?[^.]+pays?\s+\{?\d?\}?\s+(?:more|additional))/i;
+  /\b(?:spells\s+(?:your opponents control|your opponents cast|opponents cast|of opponents)|opponents'?\s+spells)[^.]*\bcost\s+\{?\d?\}?\s+more\b|\bopponents?[^.]+pays?\s+\{?\d?\}?\s+(?:more|additional)/i;
 
 // --- Artifact Hate (#56 phase 2) ---
 // Spells / permanents that destroy or exile artifacts (Vandalblast, Bane of

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -315,11 +315,19 @@ const SELF_DISCARD_KEYWORDS = new Set(["Cycling", "Connive"]);
 
 // --- Token Generator (#56 phase 2) ---
 // "create ... tokens" — covers creature, Treasure, Clue, Food, etc. tokens.
-// Also matches the passive replacement form on token-doubling enchantments
-// ("...tokens would be created..." / "...tokens are created..." on
-// Anointed Procession, Parallel Lives, Doubling Season).
-const TOKEN_GENERATOR_RE =
-  /\bcreate\b[^.]*\btokens?\b|\btokens?\b[^.]*\b(?:would be created|are created)\b/i;
+// We deliberately use only the active "create" form. Passive forms
+// ("...tokens would be created...") are too easy to misfire on token
+// PAYOFF cards that trigger off token creation but don't generate any
+// tokens themselves. Token-doubler staples (Anointed Procession,
+// Doubling Season, etc.) are admitted via TOKEN_GENERATOR_NAMES.
+const TOKEN_GENERATOR_RE = /\bcreate\b[^.]*\btokens?\b/i;
+const TOKEN_GENERATOR_NAMES = new Set<string>([
+  "Anointed Procession",
+  "Doubling Season",
+  "Parallel Lives",
+  "Mondrak, Glory Dominus",
+  "Adrix and Nev, Twincasters",
+]);
 
 // --- Token Multiplier (#56 phase 2) ---
 // Cards that double / multiply token creation. Covers the "twice that many"
@@ -800,7 +808,15 @@ export function generateTags(card: EnrichedCard): string[] {
 
   // --- Token Generator (#56 phase 2) ---
   // Any "create ... token(s)" effect: creature tokens, Treasure, Clue, Food.
-  if (TOKEN_GENERATOR_RE.test(text)) {
+  // The name allow-list covers token-doubler staples (Anointed Procession,
+  // Doubling Season, Parallel Lives, Mondrak, Adrix and Nev) whose oracle
+  // text uses the passive "tokens would be created" wording — that wording
+  // alone is too ambiguous to match by regex without false positives on
+  // token PAYOFF cards.
+  if (
+    TOKEN_GENERATOR_RE.test(text) ||
+    TOKEN_GENERATOR_NAMES.has(card.name)
+  ) {
     tags.add("Token Generator");
   }
 

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -49,6 +49,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   "Token Multiplier": { bg: "bg-fuchsia-500/20", text: "text-fuchsia-300" },
   "Mana Reduction": { bg: "bg-emerald-500/20", text: "text-emerald-200" },
   "Token Payoff": { bg: "bg-rose-500/20", text: "text-rose-300" },
+  Flicker: { bg: "bg-sky-500/20", text: "text-sky-200" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -350,6 +351,18 @@ const MANA_REDUCTION_DEFILER_RE =
 // effect, otherwise we'd pull in static buffs that aren't payoffs.
 const TOKEN_PAYOFF_RE =
   /\bwhenever\b[^.]*\bcreatures?\s+(?:enters|enter)\b[^.]*(?:deals?\s+\d+|deals?\s+damage|loses?\s+\d+\s+life|gains?\s+\d+\s+life|create|puts?\s+a|draws?\s+(?:a|\d+)\s+cards?)/i;
+
+// --- Flicker (#56 phase 2) ---
+// Self-bounce / blink: exile a creature/permanent then return it to the
+// battlefield. Distinct from removal-style "Exile target creature" (Path to
+// Exile, Swords to Plowshares) which never returns the exiled card.
+// Pattern allows the exile clause and the return clause to be in the same
+// sentence (Cloudshift) or in adjacent sentences (Eerie Interlude:
+// "Exile ... creatures ... . Return those cards to the battlefield...").
+// We forbid the second-clause start from being "Its controller" — that's the
+// hallmark of removal-with-rider (Path to Exile / Swords to Plowshares).
+const FLICKER_RE =
+  /\bexile (?:any number of |another |target |that )(?:[a-z-]+ )*(?:creatures?|permanents?|artifacts?)[^.]*?(?:\.\s+(?!Its controller|It deals|Its owner)[^.]*)?\b(?:return|then return)[^.]*\b(?:to the battlefield|under (?:its|their) owner'?s control)\b/i;
 
 // Discard Payoff — triggers on discard events
 const DISCARD_PAYOFF_TRIGGER_RE = /\bwhenever[^.]*discards?\b/i;
@@ -780,6 +793,12 @@ export function generateTags(card: EnrichedCard): string[] {
   // synergizes with Token Generator decks that flood the board.
   if (TOKEN_PAYOFF_RE.test(text)) {
     tags.add("Token Payoff");
+  }
+
+  // --- Flicker (#56 phase 2) ---
+  // Exile-and-return effects (Cloudshift, Ephemerate, Conjurer's Closet).
+  if (FLICKER_RE.test(text)) {
+    tags.add("Flicker");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -56,11 +56,33 @@ const RAMP_ANY_COLOR_RE =
   /\{T\}.*?[Aa]dd\s+(?:one\s+mana\s+of\s+any|mana\s+of\s+any\s+(?:one\s+)?(?:color|type))\b/;
 const RAMP_AMOUNT_RE = /\{T\}.*?[Aa]dd\s+(?:an\s+amount\s+of\s+|X\s+)\{[WUBRGC]\}/;
 const RAMP_ADDITIONAL_LAND_RE = /\badditional lands?\b/i;
+// Upkeep mana effects — Braid of Fire's "cumulative upkeep — Add {R}" and
+// similar "at the beginning of your upkeep, add {X}" upkeep ramp.
+const RAMP_UPKEEP_ADD_RE =
+  /\b(?:at the beginning of (?:your )?upkeep[^.]*\badd\s+\{[WUBRGC]\}|cumulative upkeep[^.]*\badd\s+\{[WUBRGC]\})/i;
+// Ritual / "Add {X} for each ..." spells (Mana Geyser, Pyretic Ritual,
+// Seething Song). Per issue #56, classifying rituals as Ramp is intentional.
+const RAMP_RITUAL_FOR_EACH_RE = /\badd\s+\{[WUBRGC]\}\s+for each\b/i;
+// Treasure-token generators — non-land permanents that ETB or trigger to
+// create Treasure tokens (Generous Plunderer, Smothering Tithe, etc.).
+const RAMP_TREASURE_RE = /\bcreate[^.]+treasure token/i;
 // Matches mana-producing spell effects (rituals) — excludes tap abilities via
 // negative lookbehind. The Instant/Sorcery type-line gate in the goldfish
 // simulator is the primary filter; this regex is a secondary safety net.
 export const RITUAL_MANA_ADD_RE = /(?<!\{T\}[^.]*)[Aa]dd\s+\{[WUBRGC]\}/;
-const CARD_DRAW_RE = /\bdraw\b.+?\bcards?\b|\bdraw a card\b/i;
+// Card Draw — matches "draw a card", "draw N cards", or "draws N cards"
+// (the plural form covers "Target player draws two cards" on Sign in Blood).
+const CARD_DRAW_RE = /\bdraws?\b.+?\bcards?\b|\bdraws? a card\b/i;
+// Pattern used to locate individual draw clauses for the opponent-recipient
+// filter. Matches "draws? ... card(s)" or "draws? a card".
+const CARD_DRAW_CLAUSE_RE = /\bdraws?\b[^.]*?\bcards?\b/gi;
+// Opponent-recipient phrases that should suppress a Card Draw clause when
+// they appear before the "draw" verb in the same sentence. (Dewdrop Cure's
+// Gift reminder: "you may promise an opponent a gift ... they draw a card".)
+// Note: "target player" is intentionally NOT in this list — Sign in Blood
+// self-targets and is a real draw spell.
+const CARD_DRAW_OPPONENT_RECIPIENT_RE =
+  /\b(?:target opponent|each opponent|an opponent|each other player)\b/i;
 const CARD_ADVANTAGE_RE =
   /\b(?:look at|reveal)\b.+?\bput\b.+?\binto your hand\b/i;
 const CARD_ADVANTAGE_IMPULSE_RE =
@@ -68,11 +90,31 @@ const CARD_ADVANTAGE_IMPULSE_RE =
 const REMOVAL_TARGET_RE =
   /\b(?:destroy|exile)\s+target\b/i;
 const REMOVAL_BOUNCE_RE = /\breturn target.+?to its owner's hand\b/i;
-const REMOVAL_DAMAGE_RE = /\bdeals?\s+\d+\s+damage to\b.+?\btarget\b/i;
+// Single-target damage removal — accepts \d+ or X as the damage amount.
+// The "deals N damage" clause is the anchor; a separate same-clause check
+// requires the target to be a creature / planeswalker / permanent / battle,
+// "any target", or a modal target list that includes a creature/planeswalker.
+// Damage dealt ONLY to "target player" / "target opponent" is NOT removal
+// (Abraded Bluffs is the canonical false-positive).
+const REMOVAL_DAMAGE_AMOUNT_RE =
+  /\bdeals?\s+(?:\d+|X|that much)\s+damage\b/i;
+const REMOVAL_DAMAGE_VALID_TARGET_RE =
+  /\b(?:any target\b|target\s+(?:creatures?|planeswalkers?|permanents?|battles?|attacking|blocking)\b|target\s+creature\s+or\s+(?:player|planeswalker)\b|target\s+creature,\s*player,?\s*(?:or\s+planeswalker)?\b)/i;
 const BOARD_WIPE_RE =
   /\b(?:destroy|exile)\s+all\b/i;
+// Conditional board wipe — "destroy each ... nonland permanent ... mana value"
+// covers Karn's Sylex / Toxic Deluge-style X-cost wipes that say "each" rather
+// than "all" and gate on mana value or some condition.
+const BOARD_WIPE_CONDITIONAL_RE =
+  /\bdestroy each\b[^.]*\bnonland permanent[^.]*\bmana value\b/i;
 const BOARD_WIPE_BOUNCE_RE = /\breturn all\b.+?\bto their owners' hands\b/i;
 const BOARD_WIPE_MINUS_RE = /\ball creatures get -\d+\/-\d+/i;
+// Card names whose oracle text incidentally matches a board-wipe pattern but
+// which are not actually permanent wipes. Pyre of the World Tree's front face
+// "exile all cards from your hand" is a hand-exile, not a board wipe.
+const BOARD_WIPE_NAME_DENYLIST = new Set<string>([
+  "Invasion of Kaldheim // Pyre of the World Tree",
+]);
 // --- Asymmetric (one-sided) wipe patterns ---
 // Universal: "all <modifier?> creatures/permanents/planeswalkers you don't control" etc.
 // Anchored to "all" so single-target clauses ("target creature you don't control") on modal
@@ -201,6 +243,12 @@ const EXTRA_TURN_RE = /\bextra turn\b/i;
 const FULL_MLD_RE = /\bdestroy all\b[^.]*\blands\b/i;
 const SACRIFICE_MLD_RE =
   /\beach player\b[^.]*(?:\bsacrifices?\b[^.]*\bland|\bland[^.]*\bsacrifices?\b)/i;
+// "(nonbasic) lands don't untap" — Stasis-style untap denial on lands.
+const MLD_DONT_UNTAP_RE = /\b(?:nonbasic )?lands? don'?t untap\b/i;
+// Forced-sacrifice removal — "target player/opponent sacrifices a creature/permanent/nonland".
+// Allows optional modifiers ("an attacking creature", "a nonland permanent").
+const REMOVAL_FORCE_SAC_RE =
+  /\btarget (?:player|opponent) sacrifices?\s+(?:a |an )?(?:\w+\s+)?(?:creature|permanent|nonland)/i;
 // --- Tribal tag patterns ---
 const LORD_TYPE_SPECIFIC_RE = new RegExp(
   `(?:other )?(?:${CREATURE_TYPE_PATTERN})(?:s| creatures?) you control get \\+`,
@@ -288,6 +336,7 @@ const RESOURCE_DENIAL_NAMES = new Set([
   "Rising Waters",
   "Hokori, Dust Drinker",
   "Tanglewire",
+  "Winter Moon",
 ]);
 
 // Patterns to strip when detecting Utility Land —
@@ -307,6 +356,52 @@ const UTILITY_STRIP_PATTERNS = [
   /\w[\w',\s-]* enters the battlefield tapped\./gi, // "X enters tapped."
 ];
 
+/**
+ * Returns true if the oracle text contains at least one card-draw clause
+ * whose recipient is NOT explicitly an opponent. Filters out:
+ *   - "target opponent draws"
+ *   - "each opponent draws" / "an opponent draws"
+ *   - "they draw a card" where "opponent" was the most recently named
+ *     actor (Dewdrop Cure Gift reminder text — the "they" refers to
+ *     the opponent who was promised a gift).
+ * Keeps:
+ *   - "you (may) draw" — the controller draws (Rhystic Study)
+ *   - "Target player draws" (Sign in Blood self-targets)
+ *   - imperative "Draw N cards" / "Draw a card" (Concentrate, Brainstorm)
+ *   - "Whenever an opponent casts a spell, you may draw a card" — the
+ *     opponent is the trigger condition, "you" is the explicit subject.
+ */
+function hasNonOpponentCardDraw(text: string): boolean {
+  if (!CARD_DRAW_RE.test(text)) return false;
+  // Quick win: any "you (may) draw" anywhere means the controller draws.
+  if (/\byou(?:\s+may)?\s+draws?\b/i.test(text)) return true;
+  // Walk every draw clause across the full text.
+  CARD_DRAW_CLAUSE_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = CARD_DRAW_CLAUSE_RE.exec(text)) !== null) {
+    const before = text.slice(0, m.index);
+    const matchedClause = m[0];
+    // Skip if the clause itself is gated by an opponent recipient
+    // ("target opponent draws", "each opponent draws", etc.).
+    const last120 = before.slice(-120);
+    if (CARD_DRAW_OPPONENT_RECIPIENT_RE.test(last120)) continue;
+    // Skip "they draw" when an "opponent" was the most recently named actor
+    // (within the last 120 chars). Covers Dewdrop Cure's Gift reminder
+    // where "they" anaphorically refers to the opponent.
+    const immediateBefore = before.slice(-30);
+    if (
+      /\bthey\s*$/i.test(immediateBefore) &&
+      /\bopponent\b/i.test(last120)
+    ) {
+      continue;
+    }
+    // Suppress unused-variable warning — matchedClause is intentional context.
+    void matchedClause;
+    return true;
+  }
+  return false;
+}
+
 export function generateTags(card: EnrichedCard): string[] {
   const tags = new Set<string>();
   const text = card.oracleText;
@@ -322,14 +417,30 @@ export function generateTags(card: EnrichedCard): string[] {
       RAMP_AMOUNT_RE.test(text);
     const hasLandSearch = RAMP_LAND_SEARCH_RE.test(text);
     const hasAdditionalLand = !isLand && RAMP_ADDITIONAL_LAND_RE.test(text);
+    // Non-tap, non-land-search ramp: upkeep mana (Braid of Fire), ritual-style
+    // "Add {X} for each ..." (Mana Geyser), and Treasure-token generators
+    // (Generous Plunderer). Skip on lands — land-side mana is handled above.
+    const hasUpkeepAdd = !isLand && RAMP_UPKEEP_ADD_RE.test(text);
+    const hasRitualForEach = !isLand && RAMP_RITUAL_FOR_EACH_RE.test(text);
+    const hasTreasureToken = !isLand && RAMP_TREASURE_RE.test(text);
 
-    if ((!isLand && hasTapForMana) || hasLandSearch || hasAdditionalLand) {
+    if (
+      (!isLand && hasTapForMana) ||
+      hasLandSearch ||
+      hasAdditionalLand ||
+      hasUpkeepAdd ||
+      hasRitualForEach ||
+      hasTreasureToken
+    ) {
       tags.add("Ramp");
     }
   }
 
-  // Card Draw
-  if (CARD_DRAW_RE.test(text)) {
+  // Card Draw — must have at least one draw clause that is NOT explicitly
+  // an opponent recipient. (Dewdrop Cure's Gift reminder text reads
+  // "you may promise an opponent a gift ... they draw a card" — that "they"
+  // refers to the opponent and should not count as your draw.)
+  if (hasNonOpponentCardDraw(text)) {
     tags.add("Card Draw");
   }
 
@@ -344,11 +455,16 @@ export function generateTags(card: EnrichedCard): string[] {
     }
   }
 
-  // Board Wipe (check before single-target removal)
+  // Board Wipe (check before single-target removal). Cards on the name
+  // denylist incidentally match BOARD_WIPE_RE via non-permanent text
+  // ("exile all cards from your hand") — skip them entirely.
+  const onBoardWipeDenylist = BOARD_WIPE_NAME_DENYLIST.has(card.name);
   if (
-    BOARD_WIPE_RE.test(text) ||
-    BOARD_WIPE_BOUNCE_RE.test(text) ||
-    BOARD_WIPE_MINUS_RE.test(text)
+    !onBoardWipeDenylist &&
+    (BOARD_WIPE_RE.test(text) ||
+      BOARD_WIPE_BOUNCE_RE.test(text) ||
+      BOARD_WIPE_MINUS_RE.test(text) ||
+      BOARD_WIPE_CONDITIONAL_RE.test(text))
   ) {
     tags.add("Board Wipe");
     tags.add("Removal");
@@ -360,11 +476,16 @@ export function generateTags(card: EnrichedCard): string[] {
     }
   }
 
-  // Single-target Removal
+  // Single-target Removal — destroy/exile target, bounce target, force-sacrifice,
+  // or "deals N damage" combined with a valid (creature/planeswalker/etc.) target.
+  const hasDamageRemoval =
+    REMOVAL_DAMAGE_AMOUNT_RE.test(text) &&
+    REMOVAL_DAMAGE_VALID_TARGET_RE.test(text);
   if (
     REMOVAL_TARGET_RE.test(text) ||
     REMOVAL_BOUNCE_RE.test(text) ||
-    REMOVAL_DAMAGE_RE.test(text)
+    hasDamageRemoval ||
+    REMOVAL_FORCE_SAC_RE.test(text)
   ) {
     tags.add("Removal");
   }
@@ -486,6 +607,7 @@ export function generateTags(card: EnrichedCard): string[] {
   if (
     FULL_MLD_RE.test(text) ||
     SACRIFICE_MLD_RE.test(text) ||
+    MLD_DONT_UNTAP_RE.test(text) ||
     RESOURCE_DENIAL_NAMES.has(card.name)
   ) {
     tags.add("Mass Land Denial");

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -50,6 +50,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   "Mana Reduction": { bg: "bg-emerald-500/20", text: "text-emerald-200" },
   "Token Payoff": { bg: "bg-rose-500/20", text: "text-rose-300" },
   Flicker: { bg: "bg-sky-500/20", text: "text-sky-200" },
+  Fog: { bg: "bg-stone-500/20", text: "text-stone-200" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -363,6 +364,13 @@ const TOKEN_PAYOFF_RE =
 // hallmark of removal-with-rider (Path to Exile / Swords to Plowshares).
 const FLICKER_RE =
   /\bexile (?:any number of |another |target |that )(?:[a-z-]+ )*(?:creatures?|permanents?|artifacts?)[^.]*?(?:\.\s+(?!Its controller|It deals|Its owner)[^.]*)?\b(?:return|then return)[^.]*\b(?:to the battlefield|under (?:its|their) owner'?s control)\b/i;
+
+// --- Fog (#56 phase 2) ---
+// Mass damage prevention: "Prevent all combat damage that would be dealt
+// this turn" (Fog, Holy Day, Angelsong) and the rarer "by sources" form.
+// Healing Salve uses "Prevent the next N damage" (single-source) — NOT a fog.
+const FOG_RE =
+  /\bprevent all (?:combat )?damage that would be dealt (?:this turn|by[^.]+this turn)\b/i;
 
 // Discard Payoff — triggers on discard events
 const DISCARD_PAYOFF_TRIGGER_RE = /\bwhenever[^.]*discards?\b/i;
@@ -799,6 +807,13 @@ export function generateTags(card: EnrichedCard): string[] {
   // Exile-and-return effects (Cloudshift, Ephemerate, Conjurer's Closet).
   if (FLICKER_RE.test(text)) {
     tags.add("Flicker");
+  }
+
+  // --- Fog (#56 phase 2) ---
+  // Combat damage prevention (Fog, Holy Day, Constant Mists). Distinct from
+  // single-source prevention spells like Healing Salve.
+  if (FOG_RE.test(text)) {
+    tags.add("Fog");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -47,6 +47,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   // #56 phase 2 functional tags
   "Token Generator": { bg: "bg-lime-500/20", text: "text-lime-200" },
   "Token Multiplier": { bg: "bg-fuchsia-500/20", text: "text-fuchsia-300" },
+  "Mana Reduction": { bg: "bg-emerald-500/20", text: "text-emerald-200" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -328,6 +329,18 @@ const TOKEN_MULTIPLIER_NAMES = new Set<string>([
   "Mondrak, Glory Dominus",
   "Adrix and Nev, Twincasters",
 ]);
+
+// --- Mana Reduction (#56 phase 2) ---
+// Cards that let you pay an alternative resource (life, generic mana) in
+// place of a colored mana symbol — e.g. the Phyrexia: All Will Be One Defiler
+// cycle ("you may pay 2 life. If you do, that spell costs {W} less to cast").
+// Distinct from Cost Reduction, which is general "cost {X} less" effects.
+const MANA_REDUCTION_RATHER_THAN_RE =
+  /\byou may pay (?:\d+ life|\{[WUBRGC]\})\s+(?:rather than|instead of)\b/i;
+// Defiler-style: "pay N life. If you do, that spell costs {C} less to cast"
+// (the life payment substitutes for a single colored pip).
+const MANA_REDUCTION_DEFILER_RE =
+  /\bpay\s+\d+\s+life\b[^.]*\.\s*If you do,[^.]*\bcosts?\s+\{[WUBRGC]\}\s+less\b/i;
 
 // Discard Payoff — triggers on discard events
 const DISCARD_PAYOFF_TRIGGER_RE = /\bwhenever[^.]*discards?\b/i;
@@ -741,6 +754,16 @@ export function generateTags(card: EnrichedCard): string[] {
     TOKEN_MULTIPLIER_NAMES.has(card.name)
   ) {
     tags.add("Token Multiplier");
+  }
+
+  // --- Mana Reduction (#56 phase 2) ---
+  // "Pay X life rather than {C}" alternative-cost spells, plus the Defiler
+  // cycle that pays life to discount a colored pip.
+  if (
+    MANA_REDUCTION_RATHER_THAN_RE.test(text) ||
+    MANA_REDUCTION_DEFILER_RE.test(text)
+  ) {
+    tags.add("Mana Reduction");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -48,6 +48,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   "Token Generator": { bg: "bg-lime-500/20", text: "text-lime-200" },
   "Token Multiplier": { bg: "bg-fuchsia-500/20", text: "text-fuchsia-300" },
   "Mana Reduction": { bg: "bg-emerald-500/20", text: "text-emerald-200" },
+  "Token Payoff": { bg: "bg-rose-500/20", text: "text-rose-300" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -341,6 +342,14 @@ const MANA_REDUCTION_RATHER_THAN_RE =
 // (the life payment substitutes for a single colored pip).
 const MANA_REDUCTION_DEFILER_RE =
   /\bpay\s+\d+\s+life\b[^.]*\.\s*If you do,[^.]*\bcosts?\s+\{[WUBRGC]\}\s+less\b/i;
+
+// --- Token Payoff (#56 phase 2) ---
+// "Whenever <subject> creature(s) enter(s) the battlefield, <payoff>" —
+// triggers that fire on creature ETB, especially relevant in token decks.
+// The payoff clause must be a damage / life-change / token / counter / draw
+// effect, otherwise we'd pull in static buffs that aren't payoffs.
+const TOKEN_PAYOFF_RE =
+  /\bwhenever\b[^.]*\bcreatures?\s+(?:enters|enter)\b[^.]*(?:deals?\s+\d+|deals?\s+damage|loses?\s+\d+\s+life|gains?\s+\d+\s+life|create|puts?\s+a|draws?\s+(?:a|\d+)\s+cards?)/i;
 
 // Discard Payoff — triggers on discard events
 const DISCARD_PAYOFF_TRIGGER_RE = /\bwhenever[^.]*discards?\b/i;
@@ -764,6 +773,13 @@ export function generateTags(card: EnrichedCard): string[] {
     MANA_REDUCTION_DEFILER_RE.test(text)
   ) {
     tags.add("Mana Reduction");
+  }
+
+  // --- Token Payoff (#56 phase 2) ---
+  // Creature-ETB triggers with a damage / life / token / draw payoff —
+  // synergizes with Token Generator decks that flood the board.
+  if (TOKEN_PAYOFF_RE.test(text)) {
+    tags.add("Token Payoff");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -76,13 +76,14 @@ const CARD_DRAW_RE = /\bdraws?\b.+?\bcards?\b|\bdraws? a card\b/i;
 // Pattern used to locate individual draw clauses for the opponent-recipient
 // filter. Matches "draws? ... card(s)" or "draws? a card".
 const CARD_DRAW_CLAUSE_RE = /\bdraws?\b[^.]*?\bcards?\b/gi;
-// Opponent-recipient phrases that should suppress a Card Draw clause when
-// they appear before the "draw" verb in the same sentence. (Dewdrop Cure's
-// Gift reminder: "you may promise an opponent a gift ... they draw a card".)
-// Note: "target player" is intentionally NOT in this list — Sign in Blood
+// Opponent-recipient phrases that, when the IMMEDIATE subject of the draw
+// verb, suppress the Card Draw tag. Trigger conditions like "Whenever an
+// opponent casts a spell, draw a card" are not affected because the opponent
+// reference is far from the draw verb.
+// Note: "target player" is intentionally NOT included — Sign in Blood
 // self-targets and is a real draw spell.
 const CARD_DRAW_OPPONENT_RECIPIENT_RE =
-  /\b(?:target opponent|each opponent|an opponent|each other player)\b/i;
+  /\b(?:target opponent|each opponent|an opponent|each other player)\s*$/i;
 const CARD_ADVANTAGE_RE =
   /\b(?:look at|reveal)\b.+?\bput\b.+?\binto your hand\b/i;
 const CARD_ADVANTAGE_IMPULSE_RE =
@@ -375,28 +376,25 @@ function hasNonOpponentCardDraw(text: string): boolean {
   if (!CARD_DRAW_RE.test(text)) return false;
   // Quick win: any "you (may) draw" anywhere means the controller draws.
   if (/\byou(?:\s+may)?\s+draws?\b/i.test(text)) return true;
-  // Walk every draw clause across the full text.
+  // Walk every draw clause across the full text. CARD_DRAW_CLAUSE_RE has the
+  // /g flag — reset lastIndex before use.
   CARD_DRAW_CLAUSE_RE.lastIndex = 0;
   let m: RegExpExecArray | null;
   while ((m = CARD_DRAW_CLAUSE_RE.exec(text)) !== null) {
     const before = text.slice(0, m.index);
-    const matchedClause = m[0];
-    // Skip if the clause itself is gated by an opponent recipient
-    // ("target opponent draws", "each opponent draws", etc.).
-    const last120 = before.slice(-120);
-    if (CARD_DRAW_OPPONENT_RECIPIENT_RE.test(last120)) continue;
-    // Skip "they draw" when an "opponent" was the most recently named actor
-    // (within the last 120 chars). Covers Dewdrop Cure's Gift reminder
-    // where "they" anaphorically refers to the opponent.
-    const immediateBefore = before.slice(-30);
+    const immediateBefore = before.slice(-40);
+    // Skip if the IMMEDIATE subject is an opponent recipient
+    // ("target opponent draws", "an opponent draws", etc.).
+    if (CARD_DRAW_OPPONENT_RECIPIENT_RE.test(immediateBefore)) continue;
+    // Skip "they draw" when an "opponent" was named as the most recent
+    // actor within the last 120 chars (Dewdrop Cure Gift reminder text:
+    // "you may promise an opponent ... they draw a card").
     if (
       /\bthey\s*$/i.test(immediateBefore) &&
-      /\bopponent\b/i.test(last120)
+      /\bopponent\b/i.test(before.slice(-120))
     ) {
       continue;
     }
-    // Suppress unused-variable warning — matchedClause is intentional context.
-    void matchedClause;
     return true;
   }
   return false;

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -374,6 +374,13 @@ const TOKEN_PAYOFF_RE =
 // hallmark of removal-with-rider (Path to Exile / Swords to Plowshares).
 const FLICKER_RE =
   /\bexile (?:any number of |another |target |that )(?:[a-z-]+ )*(?:creatures?|permanents?|artifacts?)[^.]*?(?:\.\s+(?!Its controller|It deals|Its owner)[^.]*)?\b(?:return|then return)[^.]*\b(?:to the battlefield|under (?:its|their) owner'?s control)\b/i;
+// Exile-removal with delayed return ("When [this] leaves the battlefield,
+// return the exiled card") is NOT flicker — the return is conditional on
+// the source itself leaving, so it functions as durable removal (Oblivion
+// Ring, Fiend Hunter, Banisher Priest). Suppress Flicker when the oracle
+// text contains a "leaves the battlefield" trigger.
+const FLICKER_LEAVES_EXCLUSION_RE =
+  /\bwhen\b[^.]*\bleaves the battlefield\b/i;
 
 // --- Fog (#56 phase 2) ---
 // Mass damage prevention: "Prevent all combat damage that would be dealt
@@ -849,7 +856,9 @@ export function generateTags(card: EnrichedCard): string[] {
 
   // --- Flicker (#56 phase 2) ---
   // Exile-and-return effects (Cloudshift, Ephemerate, Conjurer's Closet).
-  if (FLICKER_RE.test(text)) {
+  // Skip if the card has a "When [this] leaves the battlefield" return —
+  // that's exile-removal (Oblivion Ring / Fiend Hunter), not flicker.
+  if (FLICKER_RE.test(text) && !FLICKER_LEAVES_EXCLUSION_RE.test(text)) {
     tags.add("Flicker");
   }
 

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -52,6 +52,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   Flicker: { bg: "bg-sky-500/20", text: "text-sky-200" },
   Fog: { bg: "bg-stone-500/20", text: "text-stone-200" },
   "Hatebear / Tax": { bg: "bg-yellow-500/20", text: "text-yellow-200" },
+  "Artifact Hate": { bg: "bg-orange-500/20", text: "text-orange-300" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -379,6 +380,15 @@ const FOG_RE =
 // fit a generic regex (Drannith Magistrate, Grand Abolisher, etc.).
 const HATEBEAR_TAX_RE =
   /\b(?:(?:noncreature\s+|creature\s+)?spells?\s+(?:your opponents control\s+)?cost\s+\{?\d?\}?\s+more|opponents?[^.]+pays?\s+\{?\d?\}?\s+(?:more|additional))/i;
+
+// --- Artifact Hate (#56 phase 2) ---
+// Spells / permanents that destroy or exile artifacts (Vandalblast, Bane of
+// Progress, Shatterstorm, By Force) plus the rarer "damage equal to the
+// number of artifacts" scaling clause.
+const ARTIFACT_HATE_DESTROY_RE =
+  /\b(?:destroy|exile)\s+(?:target\s+|all\s+|x\s+target\s+|x\s+)?artifacts?\b/i;
+const ARTIFACT_HATE_SCALED_DAMAGE_RE =
+  /\bdamage equal to (?:the )?number of artifacts\b/i;
 const HATEBEAR_TAX_NAMES = new Set<string>([
   "Aven Interruptor",
   "Thalia, Guardian of Thraben",
@@ -840,6 +850,16 @@ export function generateTags(card: EnrichedCard): string[] {
   // a name allow-list of canonical staples whose text varies.
   if (HATEBEAR_TAX_RE.test(text) || HATEBEAR_TAX_NAMES.has(card.name)) {
     tags.add("Hatebear / Tax");
+  }
+
+  // --- Artifact Hate (#56 phase 2) ---
+  // Destroy/exile target artifact(s), plus the artifact-count scaled damage
+  // pattern.
+  if (
+    ARTIFACT_HATE_DESTROY_RE.test(text) ||
+    ARTIFACT_HATE_SCALED_DAMAGE_RE.test(text)
+  ) {
+    tags.add("Artifact Hate");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/src/lib/card-tags.ts
+++ b/src/lib/card-tags.ts
@@ -46,6 +46,7 @@ export const TAG_COLORS: Record<string, { bg: string; text: string }> = {
   Converge: { bg: "bg-indigo-500/20", text: "text-indigo-300" },
   // #56 phase 2 functional tags
   "Token Generator": { bg: "bg-lime-500/20", text: "text-lime-200" },
+  "Token Multiplier": { bg: "bg-fuchsia-500/20", text: "text-fuchsia-300" },
 };
 
 const BASIC_LAND_RE = /^Basic Land/i;
@@ -313,6 +314,20 @@ const SELF_DISCARD_KEYWORDS = new Set(["Cycling", "Connive"]);
 // Anointed Procession, Parallel Lives, Doubling Season).
 const TOKEN_GENERATOR_RE =
   /\bcreate\b[^.]*\btokens?\b|\btokens?\b[^.]*\b(?:would be created|are created)\b/i;
+
+// --- Token Multiplier (#56 phase 2) ---
+// Cards that double / multiply token creation. Covers the "twice that many"
+// + "tokens" replacement pattern, plus a name allow-list for staples whose
+// oracle text style varies.
+const TOKEN_MULTIPLIER_RE =
+  /\b(?:twice that many|that many plus|those tokens? plus)[^.]*tokens?\b/i;
+const TOKEN_MULTIPLIER_NAMES = new Set<string>([
+  "Anointed Procession",
+  "Doubling Season",
+  "Parallel Lives",
+  "Mondrak, Glory Dominus",
+  "Adrix and Nev, Twincasters",
+]);
 
 // Discard Payoff — triggers on discard events
 const DISCARD_PAYOFF_TRIGGER_RE = /\bwhenever[^.]*discards?\b/i;
@@ -716,6 +731,16 @@ export function generateTags(card: EnrichedCard): string[] {
   // Any "create ... token(s)" effect: creature tokens, Treasure, Clue, Food.
   if (TOKEN_GENERATOR_RE.test(text)) {
     tags.add("Token Generator");
+  }
+
+  // --- Token Multiplier (#56 phase 2) ---
+  // "twice that many tokens" replacement effects, plus a name allow-list of
+  // canonical token-doubler staples.
+  if (
+    TOKEN_MULTIPLIER_RE.test(text) ||
+    TOKEN_MULTIPLIER_NAMES.has(card.name)
+  ) {
+    tags.add("Token Multiplier");
   }
 
   // --- Secrets of Strixhaven mechanics ---

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2712,3 +2712,87 @@ test.describe("generateTags — Token Generator", () => {
     expect(generateTags(card)).not.toContain("Token Generator");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Token Multiplier (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Token Multiplier", () => {
+  test("Anointed Procession → Token Multiplier", () => {
+    const card = makeCard({
+      name: "Anointed Procession",
+      typeLine: "Enchantment",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.",
+    });
+    expect(generateTags(card)).toContain("Token Multiplier");
+  });
+
+  test("Doubling Season → Token Multiplier", () => {
+    const card = makeCard({
+      name: "Doubling Season",
+      typeLine: "Enchantment",
+      oracleText:
+        "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
+    });
+    expect(generateTags(card)).toContain("Token Multiplier");
+  });
+
+  test("Parallel Lives → Token Multiplier", () => {
+    const card = makeCard({
+      name: "Parallel Lives",
+      typeLine: "Enchantment",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.",
+    });
+    expect(generateTags(card)).toContain("Token Multiplier");
+  });
+
+  test("Mondrak, Glory Dominus → Token Multiplier", () => {
+    const card = makeCard({
+      name: "Mondrak, Glory Dominus",
+      typeLine: "Legendary Creature — Phyrexian Horror",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\nWhenever a nontoken creature you control dies, you may pay 2 life. When you do, return Mondrak from your graveyard to the battlefield. Activate only if Mondrak is on its third stage.",
+    });
+    expect(generateTags(card)).toContain("Token Multiplier");
+  });
+
+  test("Adrix and Nev, Twincasters → Token Multiplier", () => {
+    const card = makeCard({
+      name: "Adrix and Nev, Twincasters",
+      typeLine: "Legendary Creature — Merfolk Wizard",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.",
+    });
+    expect(generateTags(card)).toContain("Token Multiplier");
+  });
+
+  test("Elspeth, Storm Slayer (twice that many tokens) → Token Multiplier", () => {
+    const card = makeCard({
+      name: "Elspeth, Storm Slayer",
+      typeLine: "Legendary Planeswalker — Elspeth",
+      oracleText:
+        "+2: Creatures you control get +1/+1 and gain double strike until end of turn.\n-2: If you control a creature, create twice that many 1/1 white Soldier creature tokens.\n-7: Exile up to two target nonland permanents. Each opponent creates a 2/2 white Knight creature token with vigilance.",
+    });
+    expect(generateTags(card)).toContain("Token Multiplier");
+  });
+
+  test("Furnace of Rath (twice that many damage) → no Token Multiplier", () => {
+    const card = makeCard({
+      name: "Furnace of Rath",
+      typeLine: "Enchantment",
+      oracleText:
+        "If a source would deal damage to a permanent or player, it deals twice that much damage to that permanent or player instead.",
+    });
+    expect(generateTags(card)).not.toContain("Token Multiplier");
+  });
+
+  test("Lightning Bolt → no Token Multiplier", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).not.toContain("Token Multiplier");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2711,6 +2711,71 @@ test.describe("generateTags — Token Generator", () => {
     });
     expect(generateTags(card)).not.toContain("Token Generator");
   });
+
+  test("Token payoff card (would be created) → no Token Generator", () => {
+    // Hypothetical token payoff: triggers when a token is created but
+    // doesn't itself generate any tokens. Should NOT be tagged Token
+    // Generator. (Regression for #56 adversarial review fix.)
+    const card = makeCard({
+      name: "Hypothetical Token Payoff",
+      typeLine: "Enchantment",
+      oracleText:
+        "Whenever a token would be created under your control, you gain 1 life.",
+    });
+    expect(generateTags(card)).not.toContain("Token Generator");
+  });
+
+  test("Token-buff anthem (tokens are creatures) → no Token Generator", () => {
+    // Static effect that buffs existing tokens. Doesn't create tokens, so
+    // it should NOT be tagged Token Generator.
+    const card = makeCard({
+      name: "Hypothetical Token Anthem",
+      typeLine: "Enchantment",
+      oracleText:
+        "Tokens you control are creatures in addition to their other types.",
+    });
+    expect(generateTags(card)).not.toContain("Token Generator");
+  });
+
+  test("Doubling Season → Token Generator (via name allow-list)", () => {
+    const card = makeCard({
+      name: "Doubling Season",
+      typeLine: "Enchantment",
+      oracleText:
+        "If an effect would create one or more tokens under your control, it creates twice that many of those tokens instead.\nIf an effect would put one or more counters on a permanent you control, it puts twice that many of those counters on that permanent instead.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Parallel Lives → Token Generator (via name allow-list)", () => {
+    const card = makeCard({
+      name: "Parallel Lives",
+      typeLine: "Enchantment",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Mondrak, Glory Dominus → Token Generator (via name allow-list)", () => {
+    const card = makeCard({
+      name: "Mondrak, Glory Dominus",
+      typeLine: "Legendary Creature — Phyrexian Horror",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.\nWhenever a nontoken creature you control dies, you may pay 2 life. When you do, return Mondrak from your graveyard to the battlefield.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Adrix and Nev, Twincasters → Token Generator (via name allow-list)", () => {
+    const card = makeCard({
+      name: "Adrix and Nev, Twincasters",
+      typeLine: "Legendary Creature — Merfolk Wizard",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -3245,3 +3245,83 @@ test.describe("generateTags — Hatebear / Tax", () => {
     expect(generateTags(card)).not.toContain("Hatebear / Tax");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Artifact Hate (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Artifact Hate", () => {
+  test("Vandalblast → Artifact Hate", () => {
+    const card = makeCard({
+      name: "Vandalblast",
+      typeLine: "Sorcery",
+      oracleText:
+        "Destroy target artifact you don't control.\nOverload {4}{R}",
+    });
+    expect(generateTags(card)).toContain("Artifact Hate");
+  });
+
+  test("Bane of Progress → Artifact Hate", () => {
+    const card = makeCard({
+      name: "Bane of Progress",
+      typeLine: "Creature — Elemental",
+      oracleText:
+        "When Bane of Progress enters the battlefield, destroy all artifacts and enchantments. Bane of Progress gets +1/+1 for each permanent destroyed this way.",
+    });
+    expect(generateTags(card)).toContain("Artifact Hate");
+  });
+
+  test("By Force → Artifact Hate", () => {
+    const card = makeCard({
+      name: "By Force",
+      typeLine: "Sorcery",
+      oracleText: "Destroy X target artifacts.",
+    });
+    expect(generateTags(card)).toContain("Artifact Hate");
+  });
+
+  test("Smelt → Artifact Hate", () => {
+    const card = makeCard({
+      name: "Smelt",
+      typeLine: "Instant",
+      oracleText: "Destroy target artifact.",
+    });
+    expect(generateTags(card)).toContain("Artifact Hate");
+  });
+
+  test("Shatterstorm → Artifact Hate", () => {
+    const card = makeCard({
+      name: "Shatterstorm",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all artifacts. They can't be regenerated.",
+    });
+    expect(generateTags(card)).toContain("Artifact Hate");
+  });
+
+  test("scaled damage to number of artifacts → Artifact Hate", () => {
+    const card = makeCard({
+      name: "Test Artifact-Scaling Burn",
+      typeLine: "Sorcery",
+      oracleText:
+        "This spell deals damage equal to the number of artifacts you control to any target.",
+    });
+    expect(generateTags(card)).toContain("Artifact Hate");
+  });
+
+  test("Wrath of God → no Artifact Hate", () => {
+    const card = makeCard({
+      name: "Wrath of God",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all creatures. They can't be regenerated.",
+    });
+    expect(generateTags(card)).not.toContain("Artifact Hate");
+  });
+
+  test("Lightning Bolt → no Artifact Hate", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).not.toContain("Artifact Hate");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -3250,6 +3250,19 @@ test.describe("generateTags — Fog", () => {
     });
     expect(generateTags(card)).not.toContain("Fog");
   });
+
+  test("Awe Strike (single-source prevention by target creature) → no Fog", () => {
+    // "Prevent all damage that would be dealt by target creature this turn"
+    // is single-source prevention, not a fog. (Regression for #56
+    // adversarial review fix.)
+    const card = makeCard({
+      name: "Awe Strike",
+      typeLine: "Instant",
+      oracleText:
+        "Prevent all damage that would be dealt by target creature this turn. You gain life equal to that creature's power.",
+    });
+    expect(generateTags(card)).not.toContain("Fog");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -3153,3 +3153,95 @@ test.describe("generateTags — Fog", () => {
     expect(generateTags(card)).not.toContain("Fog");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hatebear / Tax (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Hatebear / Tax", () => {
+  test("Sphere of Resistance (spells cost {1} more) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Sphere of Resistance",
+      typeLine: "Artifact",
+      oracleText: "Spells cost {1} more to cast.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Thorn of Amethyst (noncreature spells cost more) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Thorn of Amethyst",
+      typeLine: "Artifact",
+      oracleText: "Noncreature spells cost {1} more to cast.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Kambal, Consul of Allocation (opponents pay) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Kambal, Consul of Allocation",
+      typeLine: "Legendary Creature — Human Advisor",
+      oracleText:
+        "Whenever an opponent casts a noncreature spell, that player loses 2 life and you gain 2 life.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Aven Interruptor (allow-list) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Aven Interruptor",
+      typeLine: "Creature — Bird Detective",
+      oracleText:
+        "Flash\nFlying\nWhen Aven Interruptor enters the battlefield, plot target nonland card in an opponent's graveyard, hand, or library, then that player shuffles. (You may cast that card on a later turn without paying its mana cost.)",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Thalia, Guardian of Thraben (allow-list) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Thalia, Guardian of Thraben",
+      typeLine: "Legendary Creature — Human Soldier",
+      oracleText:
+        "First strike\nNoncreature spells cost {1} more to cast.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Grand Abolisher (allow-list) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Grand Abolisher",
+      typeLine: "Creature — Human Cleric",
+      oracleText:
+        "During your turn, your opponents can't cast spells or activate abilities of artifacts, creatures, or enchantments.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Esper Sentinel (allow-list) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Esper Sentinel",
+      typeLine: "Artifact Creature — Human Soldier",
+      oracleText:
+        "Whenever an opponent casts their first noncreature spell each turn, unless that player pays {X}, where X is Esper Sentinel's power, draw a card.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Drannith Magistrate (allow-list) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Drannith Magistrate",
+      typeLine: "Creature — Human Wizard",
+      oracleText:
+        "Your opponents can't cast spells from anywhere other than their hands.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
+
+  test("Lightning Bolt → no Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).not.toContain("Hatebear / Tax");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2842,12 +2842,12 @@ test.describe("generateTags — Token Multiplier", () => {
     expect(generateTags(card)).toContain("Token Multiplier");
   });
 
-  test("Furnace of Rath (twice that many damage) → no Token Multiplier", () => {
+  test("Furnace of Rath (deals double that damage) → no Token Multiplier", () => {
     const card = makeCard({
       name: "Furnace of Rath",
       typeLine: "Enchantment",
       oracleText:
-        "If a source would deal damage to a permanent or player, it deals twice that much damage to that permanent or player instead.",
+        "If a source would deal damage to a permanent or player, it deals double that damage to that permanent or player instead.",
     });
     expect(generateTags(card)).not.toContain("Token Multiplier");
   });

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2559,3 +2559,156 @@ test.describe("generateTags — issue #56 false-negative fixes", () => {
     expect(generateTags(card)).toContain("Mass Land Denial");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Token Generator (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Token Generator", () => {
+  test("Anax, Hardened in the Forge → Token Generator", () => {
+    const card = makeCard({
+      name: "Anax, Hardened in the Forge",
+      typeLine: "Legendary Enchantment Creature — God",
+      oracleText:
+        "Indestructible\nAs long as your devotion to red is less than five, Anax isn't a creature.\nWhenever Anax or another nontoken creature you control dies, create a 1/1 red Satyr creature token with haste unless that creature was a Satyr. If the creature's power was 4 or greater, create that many tokens instead.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Cat Collector → Token Generator", () => {
+    const card = makeCard({
+      name: "Cat Collector",
+      typeLine: "Creature — Cat",
+      oracleText:
+        "Whenever Cat Collector attacks, create a 1/1 white Cat creature token.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Decree of Justice → Token Generator", () => {
+    const card = makeCard({
+      name: "Decree of Justice",
+      typeLine: "Sorcery",
+      oracleText:
+        "Create X 4/4 white Angel creature tokens with flying. Then create X 1/1 white Soldier creature tokens.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Defiler of Faith → Token Generator", () => {
+    const card = makeCard({
+      name: "Defiler of Faith",
+      typeLine: "Creature — Phyrexian Cleric",
+      oracleText:
+        "As an additional cost to cast a white spell, you may pay 2 life. If you do, that spell costs {W} less to cast.\nWhenever you cast a white spell, create a 1/1 white Spirit creature token.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Elspeth, Storm Slayer → Token Generator", () => {
+    const card = makeCard({
+      name: "Elspeth, Storm Slayer",
+      typeLine: "Legendary Planeswalker — Elspeth",
+      oracleText:
+        "+2: Creatures you control get +1/+1 and gain double strike until end of turn.\n-2: If you control a creature, create twice that many 1/1 white Soldier creature tokens.\n-7: Exile up to two target nonland permanents. Each opponent creates a 2/2 white Knight creature token with vigilance.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Elspeth, Sun's Champion → Token Generator", () => {
+    const card = makeCard({
+      name: "Elspeth, Sun's Champion",
+      typeLine: "Legendary Planeswalker — Elspeth",
+      oracleText:
+        "+1: Create three 1/1 white Soldier creature tokens.\n-3: Destroy all creatures with power 4 or greater.\n-7: You get an emblem with \"Creatures you control get +2/+2 and have flying.\"",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Entrapment Maneuver → Token Generator", () => {
+    const card = makeCard({
+      name: "Entrapment Maneuver",
+      typeLine: "Instant",
+      oracleText:
+        "Target player sacrifices an attacking creature. You create two 1/1 white Soldier creature tokens.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Knight-Captain of Eos → Token Generator", () => {
+    const card = makeCard({
+      name: "Knight-Captain of Eos",
+      typeLine: "Creature — Human Soldier",
+      oracleText:
+        "When Knight-Captain of Eos enters the battlefield, create two 1/1 white Soldier creature tokens.\n{1}{W}, Sacrifice a Soldier: Prevent all combat damage that would be dealt this turn.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Generous Plunderer (Treasure tokens) → Token Generator", () => {
+    const card = makeCard({
+      name: "Generous Plunderer",
+      typeLine: "Creature — Human Pirate",
+      oracleText:
+        "When Generous Plunderer enters the battlefield, create a Treasure token.\nWhenever Generous Plunderer deals combat damage to a player, that player creates a Treasure token.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Bitterblossom → Token Generator", () => {
+    const card = makeCard({
+      name: "Bitterblossom",
+      typeLine: "Tribal Enchantment — Faerie",
+      oracleText:
+        "At the beginning of your upkeep, you lose 1 life and create a 1/1 black Faerie creature token with flying.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Krenko, Mob Boss → Token Generator", () => {
+    const card = makeCard({
+      name: "Krenko, Mob Boss",
+      typeLine: "Legendary Creature — Goblin Warrior",
+      oracleText:
+        "{T}: Create X 1/1 red Goblin creature tokens, where X is the number of Goblins you control.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Avenger of Zendikar → Token Generator", () => {
+    const card = makeCard({
+      name: "Avenger of Zendikar",
+      typeLine: "Creature — Elemental",
+      oracleText:
+        "When Avenger of Zendikar enters the battlefield, create a 0/1 green Plant creature token for each land you control.\nLandfall — Whenever a land you control enters, put a +1/+1 counter on each Plant creature you control.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Anointed Procession → Token Generator (and Token Multiplier)", () => {
+    const card = makeCard({
+      name: "Anointed Procession",
+      typeLine: "Enchantment",
+      oracleText:
+        "If one or more tokens would be created under your control, twice that many of those tokens are created instead.",
+    });
+    expect(generateTags(card)).toContain("Token Generator");
+  });
+
+  test("Lightning Bolt → no Token Generator", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).not.toContain("Token Generator");
+  });
+
+  test("Counterspell → no Token Generator", () => {
+    const card = makeCard({
+      name: "Counterspell",
+      typeLine: "Instant",
+      oracleText: "Counter target spell.",
+    });
+    expect(generateTags(card)).not.toContain("Token Generator");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2292,3 +2292,270 @@ test.describe("generateTags — Secrets of Strixhaven mechanics", () => {
     expect(tags).not.toContain("Increment");
   });
 });
+
+// ---------------------------------------------------------------------------
+// GitHub issue #56 — Phase 1 false-positive fixes
+// ---------------------------------------------------------------------------
+
+test.describe("generateTags — issue #56 false-positive fixes", () => {
+  test("Invasion of Kaldheim // Pyre of the World Tree → NOT Board Wipe", () => {
+    // Front face says "exile all cards from your hand" — matches BOARD_WIPE_RE
+    // /\b(?:destroy|exile)\s+all\b/i, but is hand-exile, not a permanent wipe.
+    // Name-based denylist excludes the DFC.
+    const card = makeCard({
+      name: "Invasion of Kaldheim // Pyre of the World Tree",
+      typeLine: "Battle — Siege // Enchantment",
+      oracleText:
+        "When this Siege enters, exile all cards from your hand, then draw that many cards. Until the end of your next turn, you may play cards exiled this way.\n\nDiscard a land card: Pyre of the World Tree deals 2 damage to any target.\nWhenever you discard a land card, exile the top card of your library. You may play that card this turn.",
+      layout: "transform",
+    });
+    expect(generateTags(card)).not.toContain("Board Wipe");
+  });
+
+  test("Abraded Bluffs (deals 1 damage to target opponent) → NOT Removal", () => {
+    // Land that pings an OPPONENT, not a creature/permanent. The previous
+    // REMOVAL_DAMAGE_RE matched any "deals N damage to ... target" — too loose.
+    const card = makeCard({
+      name: "Abraded Bluffs",
+      typeLine: "Land — Desert",
+      oracleText:
+        "Abraded Bluffs enters tapped.\nWhen Abraded Bluffs enters, it deals 1 damage to target opponent.\n{T}: Add {R} or {W}.",
+      producedMana: ["R", "W"],
+    });
+    expect(generateTags(card)).not.toContain("Removal");
+  });
+
+  test("Dewdrop Cure (Gift: opponent draws a card) → NOT Card Draw", () => {
+    // The "draw a card" clause refers to an OPPONENT (Gift mechanic). Not your draw.
+    const card = makeCard({
+      name: "Dewdrop Cure",
+      typeLine: "Sorcery",
+      oracleText:
+        "Gift a card (You may promise an opponent a gift as you cast this spell. If you do, they draw a card before its other effects.)\nReturn up to two target creature cards each with mana value 2 or less from your graveyard to the battlefield. If the gift was promised, instead return up to three target creature cards each with mana value 2 or less from your graveyard to the battlefield.",
+    });
+    expect(generateTags(card)).not.toContain("Card Draw");
+  });
+
+  // ---- Regression: existing tests that MUST still pass after the tightening ----
+
+  test("Lightning Bolt (any target) → still Removal", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  test("Chain Lightning (target creature, player, or planeswalker) → still Removal", () => {
+    const card = makeCard({
+      name: "Chain Lightning",
+      typeLine: "Sorcery",
+      oracleText:
+        "Chain Lightning deals 3 damage to any target. Then that player or that permanent's controller may pay {R}{R}. If the player does, they may copy this spell and may choose a new target for the copy.",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  test("Lightning Helix (any target) → still Removal", () => {
+    const card = makeCard({
+      name: "Lightning Helix",
+      typeLine: "Instant",
+      oracleText: "Lightning Helix deals 3 damage to any target and you gain 3 life.",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  test("Wrath of God → still Board Wipe (denylist regression)", () => {
+    const card = makeCard({
+      name: "Wrath of God",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all creatures. They can't be regenerated.",
+    });
+    expect(generateTags(card)).toContain("Board Wipe");
+  });
+
+  test("Damnation → still Board Wipe", () => {
+    const card = makeCard({
+      name: "Damnation",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all creatures. They can't be regenerated.",
+    });
+    expect(generateTags(card)).toContain("Board Wipe");
+  });
+
+  test("Cyclonic Rift overload → still Board Wipe", () => {
+    const card = makeCard({
+      name: "Cyclonic Rift",
+      typeLine: "Instant",
+      oracleText:
+        "Return target nonland permanent you don't control to its owner's hand.\nOverload {6}{U} (You may cast this spell for its overload cost. If you do, change \"target\" in its text to \"each.\")\nReturn all nonland permanents your opponents control to their owners' hands.",
+    });
+    expect(generateTags(card)).toContain("Board Wipe");
+  });
+
+  test("Sign in Blood (target player draws) → still Card Draw", () => {
+    const card = makeCard({
+      name: "Sign in Blood",
+      typeLine: "Sorcery",
+      oracleText: "Target player draws two cards and loses 2 life.",
+    });
+    expect(generateTags(card)).toContain("Card Draw");
+  });
+
+  test("Brainstorm → still Card Draw", () => {
+    const card = makeCard({
+      name: "Brainstorm",
+      typeLine: "Instant",
+      oracleText:
+        "Draw three cards, then put two cards from your hand on top of your library in any order.",
+    });
+    expect(generateTags(card)).toContain("Card Draw");
+  });
+
+  test("Concentrate → still Card Draw", () => {
+    const card = makeCard({
+      name: "Concentrate",
+      typeLine: "Sorcery",
+      oracleText: "Draw three cards.",
+    });
+    expect(generateTags(card)).toContain("Card Draw");
+  });
+
+  test("Phyrexian Arena (per-turn draw) → still Card Draw", () => {
+    const card = makeCard({
+      name: "Phyrexian Arena",
+      typeLine: "Enchantment",
+      oracleText:
+        "At the beginning of your upkeep, you draw a card and you lose 1 life.",
+    });
+    expect(generateTags(card)).toContain("Card Draw");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHub issue #56 — Phase 1 false-negative fixes (existing tags)
+// ---------------------------------------------------------------------------
+
+test.describe("generateTags — issue #56 false-negative fixes", () => {
+  test("Banefire (X damage) → Removal", () => {
+    const card = makeCard({
+      name: "Banefire",
+      typeLine: "Sorcery",
+      manaCost: "{X}{R}",
+      oracleText:
+        "Banefire deals X damage to any target. If X is 5 or more, this spell can't be countered and the damage can't be prevented.",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  test("Leyline Tyrant (deals that much damage) → Removal", () => {
+    const card = makeCard({
+      name: "Leyline Tyrant",
+      typeLine: "Creature — Dragon",
+      oracleText:
+        "Flying\nYou don't lose unspent red mana as steps and phases end.\nWhen Leyline Tyrant dies, you may pay any amount of {R}. When you do, it deals that much damage to any target.",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  test("Bonecrusher Giant // Stomp (combined oracle text, deals 2 to any target) → Removal", () => {
+    const card = makeCard({
+      name: "Bonecrusher Giant // Stomp",
+      typeLine: "Creature — Giant // Instant — Adventure",
+      oracleText:
+        "Whenever Bonecrusher Giant becomes the target of a spell, Bonecrusher Giant deals 2 damage to that spell's controller.\n\nDamage can't be prevented this turn. Stomp deals 2 damage to any target.",
+      layout: "adventure",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  test("Comet Storm (X damage divided) → Removal", () => {
+    const card = makeCard({
+      name: "Comet Storm",
+      typeLine: "Instant",
+      oracleText:
+        "Multikicker {2}\nComet Storm deals X damage divided as you choose among any number of target creatures and/or players.",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  test("Braid of Fire (cumulative upkeep — Add {R}) → Ramp", () => {
+    const card = makeCard({
+      name: "Braid of Fire",
+      typeLine: "Enchantment",
+      oracleText:
+        "Cumulative upkeep—Add {R}. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)",
+    });
+    expect(generateTags(card)).toContain("Ramp");
+  });
+
+  test("Mana Geyser (Add {R} for each tapped land) → Ramp", () => {
+    const card = makeCard({
+      name: "Mana Geyser",
+      typeLine: "Sorcery",
+      oracleText: "Add {R} for each tapped land your opponents control.",
+    });
+    expect(generateTags(card)).toContain("Ramp");
+  });
+
+  test("Karn's Sylex (Destroy each nonland permanent ... mana value) → Board Wipe", () => {
+    const card = makeCard({
+      name: "Karn's Sylex",
+      typeLine: "Legendary Artifact",
+      oracleText:
+        "Players can't pay life to cast spells or to activate abilities that aren't mana abilities.\n{X}, {T}, Exile Karn's Sylex: Destroy each nonland permanent with mana value X or less. Activate only as a sorcery.",
+    });
+    expect(generateTags(card)).toContain("Board Wipe");
+  });
+
+  test("Winter Moon (untap restriction) → Mass Land Denial", () => {
+    const card = makeCard({
+      name: "Winter Moon",
+      typeLine: "Enchantment",
+      oracleText:
+        "Players can't untap more than one nonbasic land during their untap steps.",
+    });
+    expect(generateTags(card)).toContain("Mass Land Denial");
+  });
+
+  test("Generous Plunderer (creates Treasure tokens) → Ramp", () => {
+    const card = makeCard({
+      name: "Generous Plunderer",
+      typeLine: "Creature — Human Rogue",
+      oracleText:
+        "Menace\nAt the beginning of your upkeep, you may create a Treasure token. When you do, target opponent creates a tapped Treasure token.\nWhenever Generous Plunderer attacks, it deals damage to defending player equal to the number of artifacts they control.",
+    });
+    expect(generateTags(card)).toContain("Ramp");
+  });
+
+  test("Entrapment Maneuver (target player sacrifices a creature) → Removal", () => {
+    const card = makeCard({
+      name: "Entrapment Maneuver",
+      typeLine: "Instant",
+      oracleText:
+        "Target player sacrifices an attacking creature. You create X 1/1 white Soldier creature tokens, where X is that creature's toughness.",
+    });
+    expect(generateTags(card)).toContain("Removal");
+  });
+
+  // ---- Regression: existing tags that MUST still pass after additions ----
+
+  test("Armageddon → still Mass Land Denial (after MLD_DONT_UNTAP_RE addition)", () => {
+    const card = makeCard({
+      name: "Armageddon",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all lands.",
+    });
+    expect(generateTags(card)).toContain("Mass Land Denial");
+  });
+
+  test("Ravages of War → still Mass Land Denial", () => {
+    const card = makeCard({
+      name: "Ravages of War",
+      typeLine: "Sorcery",
+      oracleText: "Destroy all lands.",
+    });
+    expect(generateTags(card)).toContain("Mass Land Denial");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2956,3 +2956,108 @@ test.describe("generateTags — Token Payoff", () => {
     expect(generateTags(card)).not.toContain("Token Payoff");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Flicker (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Flicker", () => {
+  test("Cloudshift → Flicker", () => {
+    const card = makeCard({
+      name: "Cloudshift",
+      typeLine: "Instant",
+      oracleText:
+        "Exile target creature you control, then return that card to the battlefield under your control.",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Ephemerate → Flicker", () => {
+    const card = makeCard({
+      name: "Ephemerate",
+      typeLine: "Instant",
+      oracleText:
+        "Exile target creature you control, then return that card to the battlefield under its owner's control.\nRebound",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Eerie Interlude → Flicker", () => {
+    const card = makeCard({
+      name: "Eerie Interlude",
+      typeLine: "Instant",
+      oracleText:
+        "Exile any number of target creatures you control. Return those cards to the battlefield under their owner's control at the beginning of the next end step.",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Conjurer's Closet → Flicker", () => {
+    const card = makeCard({
+      name: "Conjurer's Closet",
+      typeLine: "Artifact",
+      oracleText:
+        "At the beginning of your end step, you may exile target creature you control, then return that card to the battlefield under its owner's control.",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Soulherder → Flicker", () => {
+    const card = makeCard({
+      name: "Soulherder",
+      typeLine: "Creature — Spirit",
+      oracleText:
+        "Whenever a creature is exiled from the battlefield, put a +1/+1 counter on Soulherder.\nAt the beginning of your end step, you may exile another target creature you control, then return that card to the battlefield under its owner's control.",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Restoration Angel → Flicker", () => {
+    const card = makeCard({
+      name: "Restoration Angel",
+      typeLine: "Creature — Angel",
+      oracleText:
+        "Flash\nFlying\nWhen Restoration Angel enters the battlefield, you may exile target non-Angel creature you control, then return that card to the battlefield under its owner's control.",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Eldrazi Displacer → Flicker", () => {
+    const card = makeCard({
+      name: "Eldrazi Displacer",
+      typeLine: "Creature — Eldrazi",
+      oracleText:
+        "Devoid\n{2}{C}: Exile another target creature, then return it to the battlefield tapped under its owner's control.",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Getaway Glamer → Flicker", () => {
+    const card = makeCard({
+      name: "Getaway Glamer",
+      typeLine: "Instant",
+      oracleText:
+        "Exile target creature or artifact you control, then return that card to the battlefield under its owner's control.",
+    });
+    expect(generateTags(card)).toContain("Flicker");
+  });
+
+  test("Path to Exile → no Flicker", () => {
+    const card = makeCard({
+      name: "Path to Exile",
+      typeLine: "Instant",
+      oracleText:
+        "Exile target creature. Its controller may search their library for a basic land card, put that card onto the battlefield tapped, then shuffle.",
+    });
+    expect(generateTags(card)).not.toContain("Flicker");
+  });
+
+  test("Swords to Plowshares → no Flicker", () => {
+    const card = makeCard({
+      name: "Swords to Plowshares",
+      typeLine: "Instant",
+      oracleText:
+        "Exile target creature. Its controller gains life equal to its power.",
+    });
+    expect(generateTags(card)).not.toContain("Flicker");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -3342,6 +3342,29 @@ test.describe("generateTags — Hatebear / Tax", () => {
     });
     expect(generateTags(card)).not.toContain("Hatebear / Tax");
   });
+
+  test("Symmetric anthem-debuff (creature spells cost more) → no Hatebear / Tax", () => {
+    // A symmetric cost increase that hits both players' creature spells is
+    // not a hatebear — it's an anthem-debuff. (Regression for #56
+    // adversarial review fix.) Sphere of Resistance / Thorn of Amethyst
+    // also have symmetric oracle text but ARE hatebears in practice; they
+    // remain tagged via the HATEBEAR_TAX_NAMES allow-list.
+    const card = makeCard({
+      name: "Hypothetical Symmetric Tax",
+      typeLine: "Enchantment",
+      oracleText: "Creature spells cost {1} more to cast.",
+    });
+    expect(generateTags(card)).not.toContain("Hatebear / Tax");
+  });
+
+  test("Asymmetric tax (spells your opponents cast cost more) → Hatebear / Tax", () => {
+    const card = makeCard({
+      name: "Hypothetical Asymmetric Tax",
+      typeLine: "Enchantment",
+      oracleText: "Spells your opponents cast cost {1} more to cast.",
+    });
+    expect(generateTags(card)).toContain("Hatebear / Tax");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -3125,6 +3125,39 @@ test.describe("generateTags — Flicker", () => {
     });
     expect(generateTags(card)).not.toContain("Flicker");
   });
+
+  test("Oblivion Ring (exile-removal with leaves trigger) → no Flicker", () => {
+    // Oblivion Ring is REMOVAL: it exiles on ETB and only returns when the
+    // Ring itself leaves the battlefield. This is not flicker. (Regression
+    // for #56 adversarial review fix.)
+    const card = makeCard({
+      name: "Oblivion Ring",
+      typeLine: "Enchantment",
+      oracleText:
+        "When Oblivion Ring enters the battlefield, exile another target nonland permanent. When Oblivion Ring leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
+    });
+    expect(generateTags(card)).not.toContain("Flicker");
+  });
+
+  test("Banisher Priest (exile-removal with leaves trigger) → no Flicker", () => {
+    const card = makeCard({
+      name: "Banisher Priest",
+      typeLine: "Creature — Human Cleric",
+      oracleText:
+        "When Banisher Priest enters the battlefield, exile target creature an opponent controls until Banisher Priest leaves the battlefield.",
+    });
+    expect(generateTags(card)).not.toContain("Flicker");
+  });
+
+  test("Fiend Hunter (exile-removal with leaves trigger) → no Flicker", () => {
+    const card = makeCard({
+      name: "Fiend Hunter",
+      typeLine: "Creature — Human Cleric",
+      oracleText:
+        "When Fiend Hunter enters the battlefield, you may exile another target creature. When Fiend Hunter leaves the battlefield, return the exiled card to the battlefield under its owner's control.",
+    });
+    expect(generateTags(card)).not.toContain("Flicker");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2796,3 +2796,79 @@ test.describe("generateTags — Token Multiplier", () => {
     expect(generateTags(card)).not.toContain("Token Multiplier");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Mana Reduction (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Mana Reduction", () => {
+  test("Defiler of Faith → Mana Reduction", () => {
+    const card = makeCard({
+      name: "Defiler of Faith",
+      typeLine: "Creature — Phyrexian Cleric",
+      oracleText:
+        "As an additional cost to cast a white spell, you may pay 2 life. If you do, that spell costs {W} less to cast.\nWhenever you cast a white spell, create a 1/1 white Spirit creature token.",
+    });
+    expect(generateTags(card)).toContain("Mana Reduction");
+  });
+
+  test("Defiler of Instinct → Mana Reduction", () => {
+    const card = makeCard({
+      name: "Defiler of Instinct",
+      typeLine: "Creature — Phyrexian Minotaur",
+      oracleText:
+        "As an additional cost to cast a red spell, you may pay 2 life. If you do, that spell costs {R} less to cast.\nWhenever you cast a red spell, Defiler of Instinct deals 1 damage to any target.",
+    });
+    expect(generateTags(card)).toContain("Mana Reduction");
+  });
+
+  test("Defiler of Vigor → Mana Reduction", () => {
+    const card = makeCard({
+      name: "Defiler of Vigor",
+      typeLine: "Creature — Phyrexian Hellion",
+      oracleText:
+        "As an additional cost to cast a green spell, you may pay 2 life. If you do, that spell costs {G} less to cast.\nWhenever you cast a green spell, put a +1/+1 counter on each creature you control with a +1/+1 counter on it.",
+    });
+    expect(generateTags(card)).toContain("Mana Reduction");
+  });
+
+  test("Defiler of Flesh (Grandeur) → Mana Reduction", () => {
+    const card = makeCard({
+      name: "Defiler of Flesh",
+      typeLine: "Creature — Phyrexian Horror",
+      oracleText:
+        "As an additional cost to cast a black spell, you may pay 2 life. If you do, that spell costs {B} less to cast.\nWhenever you cast a black spell, target creature you control gets +1/+1 and gains menace until end of turn.",
+    });
+    expect(generateTags(card)).toContain("Mana Reduction");
+  });
+
+  test("Defiler of Dreams → Mana Reduction", () => {
+    const card = makeCard({
+      name: "Defiler of Dreams",
+      typeLine: "Creature — Phyrexian Sphinx",
+      oracleText:
+        "As an additional cost to cast a blue spell, you may pay 2 life. If you do, that spell costs {U} less to cast.\nWhenever you cast a blue spell, draw a card.",
+    });
+    expect(generateTags(card)).toContain("Mana Reduction");
+  });
+
+  test("Goblin Electromancer (cost reduction) → no Mana Reduction", () => {
+    const card = makeCard({
+      name: "Goblin Electromancer",
+      typeLine: "Creature — Goblin Wizard",
+      oracleText:
+        "Instant and sorcery spells you cast cost {1} less to cast.",
+    });
+    const tags = generateTags(card);
+    expect(tags).not.toContain("Mana Reduction");
+    expect(tags).toContain("Cost Reduction");
+  });
+
+  test("Lightning Bolt → no Mana Reduction", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).not.toContain("Mana Reduction");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -2872,3 +2872,87 @@ test.describe("generateTags — Mana Reduction", () => {
     expect(generateTags(card)).not.toContain("Mana Reduction");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Token Payoff (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Token Payoff", () => {
+  test("Impact Tremors → Token Payoff", () => {
+    const card = makeCard({
+      name: "Impact Tremors",
+      typeLine: "Enchantment",
+      oracleText:
+        "Whenever a creature enters the battlefield under your control, Impact Tremors deals 1 damage to each opponent.",
+    });
+    expect(generateTags(card)).toContain("Token Payoff");
+  });
+
+  test("Purphoros, God of the Forge → Token Payoff", () => {
+    const card = makeCard({
+      name: "Purphoros, God of the Forge",
+      typeLine: "Legendary Enchantment Creature — God",
+      oracleText:
+        "Indestructible\nAs long as your devotion to red is less than five, Purphoros isn't a creature.\nWhenever another creature enters the battlefield under your control, Purphoros deals 2 damage to each opponent.\n{2}{R}: Creatures you control get +1/+0 until end of turn.",
+    });
+    expect(generateTags(card)).toContain("Token Payoff");
+  });
+
+  test("Terror of the Peaks → Token Payoff", () => {
+    const card = makeCard({
+      name: "Terror of the Peaks",
+      typeLine: "Creature — Dragon",
+      oracleText:
+        "Flying\nWhenever another creature enters the battlefield under your control, Terror of the Peaks deals damage equal to that creature's power to any target.",
+    });
+    expect(generateTags(card)).toContain("Token Payoff");
+  });
+
+  test("Warstorm Surge → Token Payoff", () => {
+    const card = makeCard({
+      name: "Warstorm Surge",
+      typeLine: "Enchantment",
+      oracleText:
+        "Whenever a creature enters the battlefield under your control, it deals damage equal to its power to any target.",
+    });
+    expect(generateTags(card)).toContain("Token Payoff");
+  });
+
+  test("Witty Roastmaster → Token Payoff", () => {
+    const card = makeCard({
+      name: "Witty Roastmaster",
+      typeLine: "Creature — Human Warrior",
+      oracleText:
+        "Whenever Witty Roastmaster or another creature enters the battlefield under your control, that creature deals 1 damage to any opponent or planeswalker an opponent controls.",
+    });
+    expect(generateTags(card)).toContain("Token Payoff");
+  });
+
+  test("Pandemonium → Token Payoff", () => {
+    const card = makeCard({
+      name: "Pandemonium",
+      typeLine: "Enchantment",
+      oracleText:
+        "Whenever a creature enters the battlefield, that creature's controller may have it deal damage equal to its power to any target.",
+    });
+    expect(generateTags(card)).toContain("Token Payoff");
+  });
+
+  test("Brainstorm → no Token Payoff", () => {
+    const card = makeCard({
+      name: "Brainstorm",
+      typeLine: "Instant",
+      oracleText:
+        "Draw three cards, then put two cards from your hand on top of your library in any order.",
+    });
+    expect(generateTags(card)).not.toContain("Token Payoff");
+  });
+
+  test("Lightning Bolt → no Token Payoff", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).not.toContain("Token Payoff");
+  });
+});

--- a/tests/unit/card-tags.spec.ts
+++ b/tests/unit/card-tags.spec.ts
@@ -3061,3 +3061,95 @@ test.describe("generateTags — Flicker", () => {
     expect(generateTags(card)).not.toContain("Flicker");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Fog (#56 phase 2)
+// ---------------------------------------------------------------------------
+test.describe("generateTags — Fog", () => {
+  test("Fog → Fog", () => {
+    const card = makeCard({
+      name: "Fog",
+      typeLine: "Instant",
+      oracleText: "Prevent all combat damage that would be dealt this turn.",
+    });
+    expect(generateTags(card)).toContain("Fog");
+  });
+
+  test("Holy Day → Fog", () => {
+    const card = makeCard({
+      name: "Holy Day",
+      typeLine: "Instant",
+      oracleText: "Prevent all combat damage that would be dealt this turn.",
+    });
+    expect(generateTags(card)).toContain("Fog");
+  });
+
+  test("Angelsong → Fog", () => {
+    const card = makeCard({
+      name: "Angelsong",
+      typeLine: "Instant",
+      oracleText:
+        "Prevent all combat damage that would be dealt this turn.\nCycling {2}",
+    });
+    expect(generateTags(card)).toContain("Fog");
+  });
+
+  test("Constant Mists → Fog", () => {
+    const card = makeCard({
+      name: "Constant Mists",
+      typeLine: "Instant",
+      oracleText:
+        "Buyback—Sacrifice a land.\nPrevent all combat damage that would be dealt this turn.",
+    });
+    expect(generateTags(card)).toContain("Fog");
+  });
+
+  test("Tangle → Fog", () => {
+    const card = makeCard({
+      name: "Tangle",
+      typeLine: "Instant",
+      oracleText:
+        "Prevent all combat damage that would be dealt this turn. At the beginning of the next turn's untap step, creatures that attacked or blocked this turn don't untap during their controller's untap step.",
+    });
+    expect(generateTags(card)).toContain("Fog");
+  });
+
+  test("Spore Frog → Fog", () => {
+    const card = makeCard({
+      name: "Spore Frog",
+      typeLine: "Creature — Frog",
+      oracleText:
+        "Sacrifice Spore Frog: Prevent all combat damage that would be dealt this turn.",
+    });
+    expect(generateTags(card)).toContain("Fog");
+  });
+
+  test("Knight-Captain of Eos (sac trigger) → Fog", () => {
+    const card = makeCard({
+      name: "Knight-Captain of Eos",
+      typeLine: "Creature — Human Soldier",
+      oracleText:
+        "When Knight-Captain of Eos enters the battlefield, create two 1/1 white Soldier creature tokens.\n{1}{W}, Sacrifice a Soldier: Prevent all combat damage that would be dealt this turn.",
+    });
+    expect(generateTags(card)).toContain("Fog");
+  });
+
+  test("Healing Salve (single-source prevention) → no Fog", () => {
+    const card = makeCard({
+      name: "Healing Salve",
+      typeLine: "Instant",
+      oracleText:
+        "Choose one —\n• Target player gains 3 life.\n• Prevent the next 3 damage that would be dealt to any target this turn.",
+    });
+    expect(generateTags(card)).not.toContain("Fog");
+  });
+
+  test("Lightning Bolt → no Fog", () => {
+    const card = makeCard({
+      name: "Lightning Bolt",
+      typeLine: "Instant",
+      oracleText: "Lightning Bolt deals 3 damage to any target.",
+    });
+    expect(generateTags(card)).not.toContain("Fog");
+  });
+});


### PR DESCRIPTION
## Summary

Addresses [#56](https://github.com/MichaelMillsOfficial/deck-evaluator/issues/56)'s list of 25 cards needing tag corrections. Two phases plus an adversarial-review pass:

### Phase 1 — regex fixes for existing tags (commits `ff433d5`, `c37e952`)

**False-positive fixes:**
- `Invasion of Kaldheim // Pyre of the Worldtree` no longer tagged Board Wipe (added `BOARD_WIPE_NAME_DENYLIST`)
- `Abraded Bluffs` no longer tagged Removal — `REMOVAL_DAMAGE_RE` tightened to require the target be `creature/planeswalker/permanent/battle/attacking/blocking` or "any target"; `target opponent`/`target player` explicitly rejected. Lightning Bolt / Chain Lightning / Lightning Helix still match.
- `Dewdrop Cure` no longer tagged Card Draw — added `hasNonOpponentCardDraw` helper that filters opponent-recipient draws via immediate-subject window. Sign in Blood / Brainstorm / Concentrate / Phyrexian Arena / Rhystic Study still match.

**False-negative fixes:**
- `Banefire`, `Leyline Tyrant`, `Bonecrusher Giant // Stomp`, `Comet Storm` → Removal (X / "that much" damage allowed)
- `Braid of Fire` → Ramp (`RAMP_UPKEEP_ADD_RE`)
- `Mana Geyser`, `Pyretic Ritual`, `Seething Song` → Ramp (`RAMP_RITUAL_FOR_EACH_RE`)
- `Generous Plunderer`, `Smothering Tithe` → Ramp (`RAMP_TREASURE_RE`)
- `Karn's Sylex` → Board Wipe (`BOARD_WIPE_CONDITIONAL_RE`)
- `Winter Moon`, Stasis-style → Mass Land Denial (`MLD_DONT_UNTAP_RE`)
- `Entrapment Maneuver` → Removal (`REMOVAL_FORCE_SAC_RE`)

### Phase 2 — 8 new tags (commits `8358d33` … `8246caa`)

Each new tag includes a `TAG_COLORS` entry, a Scryfall query in `TAG_TO_SCRYFALL_QUERY` (the previously orphaned `Token Generator` is now wired up), and 6–13 positive + 1–2 negative tests.

| Tag | Motivating cards | Sample staples |
|---|---|---|
| **Token Generator** | Anax, Cat Collector, Decree of Justice, Defiler of Faith, Elspeth (both), Entrapment Maneuver, Knight-Captain of Eos, Generous Plunderer | Bitterblossom, Avenger of Zendikar, Krenko Mob Boss |
| **Token Multiplier** | Elspeth, Storm Slayer | Anointed Procession, Doubling Season, Parallel Lives, Mondrak, Adrix and Nev |
| **Mana Reduction** | Defiler of Faith, Defiler of Instinct | All five Defilers (DMU) |
| **Token Payoff** | Impact Tremors | Purphoros, Terror of the Peaks, Warstorm Surge, Witty Roastmaster, Pandemonium |
| **Flicker** | Getaway Glamer | Cloudshift, Ephemerate, Eerie Interlude, Conjurer's Closet, Soulherder, Restoration Angel, Eldrazi Displacer |
| **Fog** | Angelsong, Knight-Captain of Eos | Holy Day, Fog, Constant Mists, Tangle, Spore Frog |
| **Hatebear / Tax** | Aven Interruptor | Thalia, Grand Abolisher, Esper Sentinel, Kambal, Drannith Magistrate, Sphere of Resistance, Thorn of Amethyst |
| **Artifact Hate** | Generous Plunderer | Vandalblast, Bane of Progress, By Force, Smelt, Shatterstorm |

### Adversarial review fixes (commits `564fb51`, `bd1dbe4`, `d8c7385`, `aa649b0`, `19ff8e7`)

The review identified 4 verified false-positive defects in the new regex constants. Each is now fixed with a regression test pinning the contract:

1. **Token Generator** no longer matches passive "would be created" / "are created" — those alternations were dropped and the doubler staples now go through `TOKEN_GENERATOR_NAMES` allow-list. Synthetic *"When a token would be created, gain 1 life"* (a payoff, not a generator) now correctly does NOT match.
2. **Flicker** no longer matches exile-removal cards with delayed return triggers (Oblivion Ring, Banisher Priest, Fiend Hunter). Added `FLICKER_LEAVES_EXCLUSION_RE` that suppresses Flicker when oracle text contains `When … leaves the battlefield`.
3. **Hatebear / Tax** regex no longer matches symmetric anthem-debuffs ("Creature spells cost {1} more"). Tightened to require an asymmetric subject (`spells your opponents control / cast`, `opponents' spells`, `spells of opponents`). Sphere of Resistance and Thorn of Amethyst remain tagged via the name allow-list since their effect text is symmetric.
4. **Fog** regex no longer matches single-source prevention ("Prevent all damage that would be dealt by target creature this turn"). The `by … this turn` branch now requires a class of source (`all creatures/sources`, `creatures you (don't) control / attacking / blocking`).

Plus the **Furnace of Rath** test fixture text was updated to the real oracle text ("deals double that damage instead").

## Test plan

- [x] `npm run test:unit` — **2584 passed, 0 failed** (1167 new lines in `card-tags.spec.ts`, 318 tests in that file alone)
- [x] All Phase 1 regression cases (Lightning Bolt, Chain Lightning, Wrath of God, Damnation, Cyclonic Rift, Sign in Blood, Brainstorm, Concentrate, Phyrexian Arena, Rhystic Study, Armageddon, Ravages of War) keep their existing tags
- [x] All `toEqual([…])` snapshot tests survive without conversion (Sol Ring's `["Ramp"]` etc.)
- [x] Adversarial review verified: 4 false-positive regex defects fixed and pinned with negative tests

## Notes for reviewers

- **Aven Interruptor** is tagged Hatebear / Tax via the name allow-list because its actual disruption is via the Plot mechanic rather than a cost-increase clause; semantic categorization is debatable. If you want a separate "Disruption" tag for Plot-style cards, that's worth a follow-up.
- **Token Multiplier** name allow-list is intentionally redundant with the regex (defense-in-depth) — the staples already match the regex via "twice that many tokens".
- **`MANA_REDUCTION_RATHER_THAN_RE`** doesn't match hybrid/Phyrexian alternative-cost text. Acceptable for the Defiler cycle; can be extended later if needed.
- **Hatebear / Tax** regex tightening means generic "noncreature spells cost {N} more" cards are now captured ONLY via the name allow-list. To broaden coverage, expand `HATEBEAR_TAX_NAMES` rather than relax the regex.
- WebFetch to Scryfall returned 403 in the agent's environment, so the fixture oracle text for a few cards was reconstructed from MTG knowledge. The Furnace of Rath fixture was corrected as part of this PR; if reviewers spot any other fixture/reality drift, those are easy follow-ups.

Closes #56

https://claude.ai/code/session_01VTGwUyrCRQMs5TvnXuoHBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTGwUyrCRQMs5TvnXuoHBQ)_