### PR TITLE
fix: resolve all open code scanning alerts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   unit:
     name: Unit Tests

--- a/src/lib/archidekt.ts
+++ b/src/lib/archidekt.ts
@@ -27,6 +27,9 @@ const SIDEBOARD_CATEGORIES = new Set([
 export async function fetchArchidektDeck(
   deckId: string
 ): Promise<ArchidektApiResponse> {
+  if (!/^\d+$/.test(deckId)) {
+    throw new Error(`Invalid deck ID: ${deckId}`);
+  }
   const res = await fetch(`https://archidekt.com/api/decks/${deckId}/`, {
     headers: { Accept: "application/json" },
     cache: "no-store",


### PR DESCRIPTION
## Summary

Fixes all 3 open CodeQL / GitHub code scanning alerts.

### Alert #3 — SSRF (error): `src/lib/archidekt.ts`

**Root cause:** CodeQL's taint analysis traced user input (the Archidekt URL from query params) through `extractArchidektDeckId()` into the `fetch()` call inside `fetchArchidektDeck()`, flagging it as server-side request forgery.

**Why it's a false positive:** The regex `ARCHIDEKT_URL_PATTERN` constrains the extracted `deckId` to digits only (`\d+`), and the final fetch URL is always `https://archidekt.com/api/decks/{deckId}/` — the host is hardcoded and cannot be influenced by user input.

**Fix:** Added an explicit `!/^\d+$/.test(deckId)` guard at the top of `fetchArchidektDeck()`. This makes the numeric-only invariant self-documenting, provides a real defensive check, and breaks the taint flow that CodeQL was tracking.

### Alerts #1 & #2 — Missing workflow permissions (warning): `.github/workflows/test.yml`

**Root cause:** Neither the workflow nor its two jobs (`unit`, `e2e`) declared a `permissions:` block. GitHub Actions defaults to broad `GITHUB_TOKEN` permissions when none are specified.

**Fix:** Added `permissions: contents: read` at the workflow level. Both jobs only check out code and run tests — read access to the repository contents is the minimum required, and nothing else should be granted.

## Test plan

- [ ] `npm run build` succeeds (TypeScript compiles cleanly)
- [ ] `npm run test:unit` passes
- [ ] Code scanning re-scan shows 0 open alerts after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)