### PR TITLE
feat(crucible): add pile-triage deck builder with popover commander picker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,7 @@ Inventory of primitives that must be reused (current as of this writing — run
 |---|---|
 | Panel / surface / bordered container | `<Card>` from `src/components/ui/Card.tsx` — never raw `rounded-xl border bg-slate-800/50` |
 | Modal / drawer / focus-trapped overlay | `<Sheet>` from `src/components/ui/Sheet.tsx` — never a hand-rolled `<dialog>` |
+| Anchored, non-modal dropdown / filterable list popover | `<Popover>` from `src/components/ui/Popover.tsx` — never a hand-rolled absolutely-positioned dropdown |
 | Mono uppercase label / kicker | `<Eyebrow>` from `src/components/ui/Eyebrow.tsx` |
 | Pill / chip / category label | `<Tag>` from `src/components/ui/Tag.tsx` (or `<CardTag>` for card-tag-specific styling) |
 | Button (primary / secondary / ghost) | `<Button>` from `src/components/ui/Button.tsx` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ src/
 │   │       ├── compare/page.tsx
 │   │       └── share/page.tsx
 │   ├── shared/page.tsx            # Decode share URL → setPayload → push /reading
+│   ├── crucible/
+│   │   ├── layout.tsx             # Mounts CrucibleSessionProvider
+│   │   └── page.tsx               # The Crucible: pile import → triage workbench
 │   ├── compare/page.tsx           # Standalone two-deck comparison
 │   ├── preview/page.tsx           # Design-system component preview
 │   └── api/
@@ -78,6 +81,7 @@ src/
 │   │   ├── ReadingHero.tsx        # Hero block (eyebrow + title + tagline + tiles)
 │   │   └── SectionHeader.tsx      # Per-route eyebrow + serif h1 + italic tagline
 │   ├── ritual/CosmicLoader.tsx    # Pulsing orb + incantation phrases
+│   ├── crucible/                  # Workbench, lens switcher, triage rows, tracker rail, insight panels
 │   ├── shell/                     # Top nav + cosmos background
 │   ├── DeckSidebar.tsx            # Route-aware nav (usePathname → activeTab)
 │   ├── DeckMobileTopBar.tsx
@@ -89,6 +93,7 @@ src/
 │   └── ...                        # Analysis components (Synergy, Goldfish, etc.)
 ├── contexts/
 │   ├── DeckSessionContext.tsx     # sessionStorage-backed deck + enrichment state
+│   ├── CrucibleSessionContext.tsx # /crucible pile triage state (own sessionStorage key)
 │   └── CandidatesContext.tsx      # /reading/add candidate state (shell-scoped)
 └── lib/
     ├── types.ts                   # DeckData, DeckCard, EnrichedCard
@@ -98,6 +103,7 @@ src/
     ├── view-tabs.ts               # ViewTab union, TAB_ROUTES, tabFromPathname
     ├── archidekt.ts · moxfield.ts · scryfall.ts
     ├── decklist-parser.ts · mana.ts · oracle.ts · card-tags.ts
+    ├── crucible-session.ts · crucible-grouping.ts · cut-suggestions.ts
     └── ...                        # Synergy, combos, simulation, export
 ```
 
@@ -118,6 +124,16 @@ src/
    `useDeckSession()` and renders its analysis component inside a
    `<SectionHeader>` + `tabpanel` wrapper. Soft `<Link>` navigation
    keeps the shell mounted across switches.
+
+**Alternate entry - The Crucible** (`/crucible`): a deck-building workbench
+that accepts an arbitrary pile of cards (no deck structure), enriches it in
+chunks behind the `CosmicLoader` treatment, and guides keep/cut/undecided
+triage across lenses down to a legal 100-card EDH deck. State lives in
+`CrucibleSessionContext` (its own sessionStorage key, coexisting with the
+reading session). "Seal the Deck" builds a normal `DeckData` (kept cards as
+mainboard, cuts as sideboard so `/reading/add` still sees them), calls
+`setPayload`, and hands off to the untouched `/ritual` → `/reading` journey.
+Design details: `docs/plans/crucible-deck-builder.md`.
 
 ### API endpoints
 
@@ -254,7 +270,11 @@ tests/unit/                         # Pure function tests (no browser, no dev se
 ├── color-distribution.spec.ts      # Color distribution & mana base metrics
 ├── known-combos.spec.ts            # Known combo registry & detection
 ├── synergy-axes.spec.ts            # Synergy axis detectors
-└── synergy-engine.spec.ts          # Synergy engine scoring
+├── synergy-engine.spec.ts          # Synergy engine scoring
+├── crucible-session.spec.ts        # Pile session model, statuses, final-deck builder
+├── crucible-grouping.spec.ts       # Lens grouping functions
+├── cut-suggestions.spec.ts         # Ranked cut recommender
+└── ...
 ```
 
 ### Writing Tests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web application for importing and analyzing Magic: The Gathering decklists. Bu
 
 Import a deck (paste, Moxfield export, or Archidekt URL) and the app walks you through a four-stage **journey** — *import → ritual → reading → sub-route*. The reading lands on a verdict hero (bracket, power level, top theme), then fans out across ten sub-routes for cards, composition, synergy, interactions, opening hands, goldfish simulation, suggestions, candidate finder, deck-vs-deck compare, and share/export. Cards are automatically enriched via Scryfall (mana costs as official MTG symbols, oracle text with inline symbols, heuristic tags), and combos are detected via Commander Spellbook.
 
-Don't have a finished deck yet? **The Crucible** (`/crucible`) is a deck-building workbench: pour in any pile of cards, organize it through lenses (category, synergy axis, type line, mana value, color identity, game changers), triage each card as keep/cut/undecided with an explicit commander pick, and seal a legal 100-card Commander deck that flows straight into the reading journey (cuts are kept as sideboard candidates).
+Don't have a finished deck yet? **The Crucible** (`/crucible`) is a deck-building workbench: pour in any pile of cards, organize it through lenses (category, synergy axis, type line, mana value, color identity, game changers), triage each card as keep/cut/undecided with an explicit commander pick, search up and add more cards mid-triage, and seal a legal 100-card Commander deck that flows straight into the reading journey (cuts are kept as sideboard candidates).
 
 See [Promises to You](./PROMISES.md) for how this tool handles your data and what drives the analysis.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A web application for importing and analyzing Magic: The Gathering decklists. Bu
 
 Import a deck (paste, Moxfield export, or Archidekt URL) and the app walks you through a four-stage **journey** — *import → ritual → reading → sub-route*. The reading lands on a verdict hero (bracket, power level, top theme), then fans out across ten sub-routes for cards, composition, synergy, interactions, opening hands, goldfish simulation, suggestions, candidate finder, deck-vs-deck compare, and share/export. Cards are automatically enriched via Scryfall (mana costs as official MTG symbols, oracle text with inline symbols, heuristic tags), and combos are detected via Commander Spellbook.
 
+Don't have a finished deck yet? **The Crucible** (`/crucible`) is a deck-building workbench: pour in any pile of cards, organize it through lenses (category, synergy axis, type line, mana value, color identity, game changers), triage each card as keep/cut/undecided with an explicit commander pick, and seal a legal 100-card Commander deck that flows straight into the reading journey (cuts are kept as sideboard candidates).
+
 See [Promises to You](./PROMISES.md) for how this tool handles your data and what drives the analysis.
 
 ## Getting Started
@@ -66,10 +68,11 @@ docker compose logs -f         # Tail logs
 | `/reading/compare` | Deck-vs-deck redirect to `/compare` |
 | `/reading/share` | Share URL · PNG · Discord · Markdown · JSON |
 | `/shared` | Decode share URL → forward to `/reading` |
+| `/crucible` | The Crucible: pile triage workbench → seal a legal EDH deck |
 | `/compare` | Standalone two-deck comparison |
 | `/preview` | Design-system component preview |
 
-State flows through `DeckSessionContext` (sessionStorage-backed) so navigation between sub-routes does not refetch the deck or re-enrich cards. `CandidatesContext` is mounted at the `/reading/(shell)` layout so candidate state on `/reading/add` survives tab switches.
+State flows through `DeckSessionContext` (sessionStorage-backed) so navigation between sub-routes does not refetch the deck or re-enrich cards. `CandidatesContext` is mounted at the `/reading/(shell)` layout so candidate state on `/reading/add` survives tab switches. The Crucible keeps its own `CrucibleSessionContext` under a separate sessionStorage key, so a pile in progress coexists with a reading session.
 
 ## Project Structure
 
@@ -86,11 +89,13 @@ src/
 │   │       ├── layout.tsx
 │   │       └── <slug>/page.tsx     # 10 sub-routes
 │   ├── shared/page.tsx             # Decode share URL → /reading
+│   ├── crucible/                   # The Crucible pile triage workbench
 │   ├── compare/                    # Standalone two-deck compare
 │   ├── preview/                    # Design-system component preview
 │   └── api/                        # /deck, /deck-parse, /deck-enrich, /deck-combos, ...
 ├── components/
 │   ├── reading/                    # Shell, hero, overview, section header
+│   ├── crucible/                   # Workbench, lenses, triage rows, tracker rail
 │   ├── ritual/CosmicLoader.tsx
 │   ├── shell/                      # Top nav, cosmos background
 │   ├── DeckSidebar.tsx             # Route-aware nav
@@ -99,6 +104,7 @@ src/
 │   └── ManaCost.tsx · ManaSymbol.tsx · OracleText.tsx · CardTags.tsx
 ├── contexts/
 │   ├── DeckSessionContext.tsx      # sessionStorage-backed deck + enrichment
+│   ├── CrucibleSessionContext.tsx  # /crucible pile triage state
 │   └── CandidatesContext.tsx       # /reading/add candidate state
 └── lib/
     ├── types.ts                    # DeckData, DeckCard, EnrichedCard

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ docker compose logs -f         # Tail logs
 | `npm run build` | Production build |
 | `npm run start` | Run production server |
 | `npm run lint` | Run ESLint |
-| `npm test` | Run Playwright E2E tests (headless) |
-| `npm run test:headed` | Run tests with visible browser |
-| `npm run test:ui` | Open Playwright interactive UI |
+| `npm test` | Run all tests (e2e + unit, headless) |
+| `npm run test:e2e` | Run only browser/API e2e tests |
+| `npm run test:unit` | Run only pure function unit tests (fast, no dev server) |
+| `npm run test:headed` | Run e2e tests with visible browser |
+| `npm run test:ui` | Open Playwright interactive e2e UI |
 
 ## Routes
 
@@ -117,50 +119,20 @@ src/
 
 ## Testing
 
-This project uses [Playwright](https://playwright.dev/) for end-to-end testing. Tests live in the `e2e/` directory and run against the Next.js dev server (started automatically via `webServer` in `playwright.config.ts`).
+This project uses [Playwright](https://playwright.dev/) for two test suites: browser/API e2e tests in `e2e/` (run against the Next.js dev server, started automatically via `webServer` in `playwright.config.ts`) and pure function unit tests in `tests/unit/` (no browser, no dev server, run under `playwright.unit.config.ts`).
 
 ### Running Tests
 
 ```bash
-npm test                                          # Run all tests headless
-npm run test:headed                               # Run with a visible browser
-npm run test:ui                                   # Open Playwright interactive UI
-npx playwright test e2e/deck-import.spec.ts       # Run a single test file
+npm test                                          # Run all tests (e2e + unit) headless
+npm run test:e2e                                  # Run only browser/API e2e tests
+npm run test:unit                                 # Run only pure function unit tests (fast)
+npm run test:headed                               # Run e2e tests with a visible browser
+npm run test:ui                                   # Open Playwright interactive e2e UI
+npx playwright test --config playwright.config.ts e2e/deck-import.spec.ts  # Single e2e file
 ```
 
-### Test Structure
-
-```
-e2e/
-├── fixtures.ts                 # DeckPage page-object, sample decklists, custom test export
-├── deck-import.spec.ts         # Manual decklist import user flows
-├── tab-navigation.spec.ts      # Tab switching, Load Example, form state persistence
-├── deck-display.spec.ts        # Rendered deck sections, card counts, source label
-├── api-deck-parse.spec.ts      # POST /api/deck-parse API contract tests
-├── api-deck-enrich.spec.ts     # POST /api/deck-enrich API contract tests
-├── deck-enrichment.spec.ts     # Enriched card UI: symbols, chevrons, expand/collapse
-├── card-tags.spec.ts           # Heuristic card tag rendering
-├── mana-parsers.spec.ts        # Unit tests for mana cost parsing
-└── oracle-parser.spec.ts       # Unit tests for oracle text tokenizer
-```
-
-### Writing Tests
-
-- Import `test` and `expect` from `./fixtures` (not from `@playwright/test` directly) to get the `deckPage` fixture automatically.
-- Use `deckPage` methods (`goto()`, `fillDecklist()`, `submitImport()`, `waitForDeckDisplay()`) to express tests as user intent.
-- Use `deckPage.deckDisplay` to scope assertions to the rendered deck panel.
-- Add new page-object methods to `DeckPage` in `fixtures.ts` when new UI elements are introduced.
-- API tests can use Playwright's `request` fixture directly with `@playwright/test` imports.
-- Focus on functional behavior, not styling or visual assertions.
-
-### TDD Workflow
-
-All new features follow test-driven development:
-
-1. **Write failing tests first** -- add tests in `e2e/` that describe the expected behavior. Run `npm test` to confirm they fail.
-2. **Implement the feature** -- write the minimum code to make the tests pass.
-3. **Refactor** -- clean up while keeping tests green.
-4. **All tests must pass before committing** -- run `npm test` and verify 0 failures.
+For the full test structure, conventions for writing tests, and the TDD workflow, see the Testing section of [CLAUDE.md](./CLAUDE.md).
 
 ## Tech Stack
 

--- a/design-system/tokens.css
+++ b/design-system/tokens.css
@@ -215,6 +215,9 @@
   --sheet-border:      var(--border-accent);
   --sheet-shadow:      0 -20px 60px rgba(0,0,0,0.6);
 
+  /* Popover (anchored, non-modal dropdown) */
+  --popover-shadow:    0 18px 50px rgba(0, 0, 0, 0.55);
+
   /* Tags / chips */
   --tag-radius:        var(--radius-pill);
   --tag-padding-y:     var(--space-1);

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -171,7 +171,8 @@ The workbench header hosts a `CardSearchInput` so cards can be searched up and a
 | `src/components/crucible/CrucibleWorkbench.tsx` | Create | Three-pane workbench shell |
 | `src/components/crucible/LensSwitcher.tsx` | Create | Lens/filter sidebar |
 | `src/components/crucible/CrucibleCardRow.tsx` | Create | Triage row with preview + disclosure |
-| `src/components/crucible/CommanderPicker.tsx` | Create | Legal-commander picker + search fallback |
+| `src/components/crucible/CommanderPicker.tsx` | Create | Legal-commander picker; fixed-height trigger opens a filterable `Popover` listing every candidate |
+| `src/components/ui/Popover.tsx` | Create | Anchored, non-modal filterable dropdown (Escape + outside-click dismissal, focus restore) |
 | `src/components/crucible/CutPile.tsx` | Create | Cut list with restore |
 | `src/components/crucible/CrucibleCharts.tsx` | Create | Curve + pip coverage panel |
 | `src/components/crucible/CrucibleCombos.tsx` | Create | Combo states panel |

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -100,56 +100,56 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 
 ### Phase 3: Route and import
 
-- [ ] 3.1 Create `e2e/crucible-import.spec.ts` (failing first)
+- [x] 3.1 Create `e2e/crucible-import.spec.ts` (failing first)
   - Test case: `/crucible` renders the pile import form with the sacred eyebrow pattern
   - Test case: pasting a pile and submitting shows the CosmicLoader treatment, then the workbench with the full pool as undecided
   - Test case: a pile whose trailing card would be commander-inferred still lands fully in the pool
   - Test case: reloading mid-triage restores statuses from sessionStorage
-- [ ] 3.2 Create `src/app/crucible/page.tsx` + `src/components/crucible/CrucibleImport.tsx`
+- [x] 3.2 Create `src/app/crucible/page.tsx` + `src/components/crucible/CrucibleImport.tsx`
   - Reuse `Textarea`, `Button`, `Card`, `SectionHeader` patterns; parse via `POST /api/deck-parse` then `flattenPileParse`
   - Reuse `CosmicLoader` during enrichment with chunk progress in the incantation line
-- [ ] 3.3 Add a Crucible entry to the top nav in `src/components/shell/`
+- [x] 3.3 Add a Crucible entry to the top nav in `src/components/shell/`
 
 ### Phase 4: Workbench
 
-- [ ] 4.1 Create `e2e/crucible-triage.spec.ts` (failing first)
+- [x] 4.1 Create `e2e/crucible-triage.spec.ts` (failing first)
   - Test case: keep/cut/undecided toggles update the row state and the kept counter
   - Test case: cut rows stay visible dimmed; Cut Pile lens lists them; restore flips them back
   - Test case: lens switching regroups without losing statuses
   - Test case: category groups collapse/expand; at-target groups start collapsed; "Undecided only" filter hides decided rows
   - Test case: commander picker lists legal commanders from the pool; picking one flags off-identity cards
   - Test case: hovering a card name reveals its image preview (aria-safe)
-- [ ] 4.2 Create `src/components/crucible/CrucibleWorkbench.tsx`, `LensSwitcher.tsx`, `CrucibleCardRow.tsx`, `CommanderPicker.tsx`, `CutPile.tsx`
+- [x] 4.2 Create `src/components/crucible/CrucibleWorkbench.tsx`, `LensSwitcher.tsx`, `CrucibleCardRow.tsx`, `CommanderPicker.tsx`, `CutPile.tsx`
   - `CrucibleCardRow` wraps the disclosure/a11y patterns of `EnrichedCardRow` and adds the triage buttons and image preview (from `EnrichedCard.imageUris`; `Sheet` on touch)
   - Collapsible groups with sticky headers; virtualize rows past ~200 cards
   - All styling via semantic tokens; reduced-motion gates on any transition
 
 ### Phase 5: Insight panels
 
-- [ ] 5.1 Create `e2e/crucible-insight.spec.ts` (failing first)
+- [x] 5.1 Create `e2e/crucible-insight.spec.ts` (failing first)
   - Test case: Charts lens renders curve and pip coverage for the kept subset and toggles to pool
   - Test case: Combos lens shows intact/possible/broken states that react to triage flips
   - Test case: cutting a combo piece surfaces the broken warning; restore clears it
   - Test case: Suggested Cuts lists ranked reasons; accepting marks the card cut; dismissing hides the suggestion
   - Test case: Game Changers lens lists flagged cards with kept count vs bracket allowance
-- [ ] 5.2 Create `src/components/crucible/CrucibleCharts.tsx`, `CrucibleCombos.tsx`, `SuggestedCuts.tsx`
+- [x] 5.2 Create `src/components/crucible/CrucibleCharts.tsx`, `CrucibleCombos.tsx`, `SuggestedCuts.tsx`
   - Charts reuse `CurveConstellation` / `ColorPie` / `computeManaCurve` / `computeColorDistribution` / `computeManaBaseMetrics`
 
 ### Phase 6: Tracker and gate
 
-- [ ] 6.1 Create `e2e/crucible-legality.spec.ts` (failing first)
+- [x] 6.1 Create `e2e/crucible-legality.spec.ts` (failing first)
   - Test case: rail shows kept count, category health bars, combo status, legality checklist
   - Test case: "Seal the Deck" stays disabled until `validateCommanderDeck` passes over commanders + kept
   - Test case: below 768px the rail renders inside the `Sheet` drawer
-- [ ] 6.2 Create `src/components/crucible/TrackerRail.tsx`
+- [x] 6.2 Create `src/components/crucible/TrackerRail.tsx`
   - Reuse `StatTile`, `Tag`, `Sheet`; legality via `validateCommanderDeck` + `/api/commander-rules`
 
 ### Phase 7: Handoff
 
-- [ ] 7.1 Create `e2e/crucible-handoff.spec.ts` (failing first)
+- [x] 7.1 Create `e2e/crucible-handoff.spec.ts` (failing first)
   - Test case: sealing builds the DeckData (kept mainboard, cuts sideboard), sets the reading payload, and lands on `/reading` via `/ritual` (use `window.__SKIP_RITUAL_FLOOR__`)
   - Test case: the reading session reflects the sealed deck; `/reading/add` sees cuts as sideboard
-- [ ] 7.2 Wire `finalize()` in `CrucibleWorkbench` to `buildFinalDeck` + `setPayload` + router push; no reading-side changes
+- [x] 7.2 Wire `finalize()` in `CrucibleWorkbench` to `buildFinalDeck` + `setPayload` + router push; no reading-side changes
 
 ## Files to Create/Modify
 

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -1,0 +1,192 @@
+# The Crucible - Deck-Building Workbench
+
+## Context
+
+Every existing route assumes a finished deck: the user imports a complete decklist on `/`, the ritual loader plays while enrichment runs, and `/reading` renders analysis of that fixed 100. The closest thing to candidate management, `/reading/add` backed by `PendingChangesContext`, is hard-wired to strict 1:1 add/cut swaps against a valid base deck. There is no way to start from an arbitrary pile of cards (a collection dump, a box of staples, 200+ candidates from a brainstorm) and work it down into a deck.
+
+The Crucible is a new top-level route (`/crucible`) that accepts any number of cards, organizes them through multiple lenses built on the existing tag, synergy, composition, combo, and legality engines, and guides the user through triage (keep / cut / undecided per card) until they have a legal 100-card EDH deck. On finalize it builds a normal `DeckData` (kept cards as mainboard, cuts as sideboard), calls `setPayload` on the deck session context, and routes to `/ritual` so the existing reading journey takes over unchanged.
+
+Scope decisions, locked during plan review:
+
+- **In:** pile import (paste), chunked enrichment with the CosmicLoader ritual treatment, explicit commander picker, lenses (By Category, By Synergy Axis, By Type Line, By Mana Value, By Color Identity, Flat List, Game Changers), Insight panels (Charts, Combos in Pile, Suggested Cuts, Cut Pile), tracker rail (kept count, category health, combo status, legality checklist), collapsible/sticky category groups with row virtualization, hover/tap card image previews, "Seal the Deck" handoff.
+- **Out (fast-follows, not v1):** share-a-pile URL, price/budget lens, Scryfall-backed "fill this gap" suggestions inside the Crucible, non-EDH formats.
+
+## Design Decisions
+
+### Naming and placement
+**The Crucible** at top-level `/crucible`. `/reading`'s layout redirects to `/` when no session exists, so a pile cannot start there; a top-level route avoids carving exceptions into the redirect gate and the deck-centric sidebar. Handoff to the existing journey happens only at finalize, via `setPayload`.
+
+### State model: a new context, not a retrofit
+`PendingChangesContext` models 1:1 add/cut pairs against a valid base deck and enriches one card at a time; it is not a pool manager. The Crucible gets its own `CrucibleSessionContext` mirroring the `DeckSessionContext` patterns (hydration lifecycle `pending -> hydrated / absent`, sessionStorage persistence with try/catch, background enrichment kicked off on payload set).
+
+Core state:
+
+```ts
+export type CrucibleCardStatus = "keep" | "cut" | "undecided";
+
+export interface CrucibleSessionPayload {
+  crucibleId: string;
+  pool: DeckCard[];                                  // every imported card, quantity-aware
+  statuses: Record<string, CrucibleCardStatus>;      // keyed by card name; default "undecided"
+  commanders: string[];                              // 0-2, chosen in the workbench
+  parseWarnings: string[];
+  createdAt: number;
+}
+```
+
+Runtime-only state in the context (not persisted): `cardMap: Record<string, EnrichedCard> | null`, `notFound: string[]`, `combos` (from `/api/deck-combos`), plus memoized derived data (tag cache via `buildTagCache`, per-lens groupings, kept-subset scorecard, legality result, cut suggestions). Persistence key: `astral.crucible-session.v1`, separate from the reading session so both coexist in one tab.
+
+### Cuts are status flips, never deletions
+A cut row stays in place, dimmed, in whatever lens is active, and also collects in the Cut Pile lens where one click restores it. Finalize stores cuts as the sideboard so `/reading` and `/reading/add` still see them as candidates.
+
+### Pile parsing
+Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred commanders back into the pool: its "trailing 1-2 cards are the commander" heuristic misfires on plain piles. Commander choice is explicit in the workbench via a picker that lists legal commanders detected in the pool (`isLegalCommander`) with a `CardSearchInput` fallback.
+
+### Enrichment
+`POST /api/deck-enrich` rejects more than 250 unique names per request. The context chunks the pool into batches of at most 250 names, issues them sequentially, and merges `cards`/`notFound`. While enrichment runs, the Crucible plays the same `CosmicLoader` ritual treatment as a normal reading, with chunk progress feeding the incantation line.
+
+### Synergy on a pile
+`analyzeDeckSynergy` takes a `DeckData`; the Crucible feeds it a synthetic one (chosen commanders + pool as mainboard). Before a commander is chosen, per-card axis scores still work (each axis `detect(card)` is commander-independent); anchor boosts and off-identity flagging activate after the pick via `resolveCommanderIdentity` + per-card `colorIdentity`.
+
+### Lens grouping rules
+- **By Category:** tag-driven groups from `computeCompositionScorecard` against `TEMPLATE_COMMAND_ZONE` over the kept subset; groups show candidates/kept/target with a health bar. Groups at target auto-collapse; headers stick on scroll; rows virtualize past ~200 cards.
+- **By Synergy Axis:** axes sorted by pool-wide strength; only axes with strength >= 0.2 get a group; each card appears once under its strongest axis with a "+N axes" badge for its other homes; an "Unaligned" group gathers cards with no axis >= 0.2 (prime cut candidates).
+- **Game Changers:** cards flagged `isGameChanger` (list served by `/api/commander-rules`), with kept count shown against the deck's bracket allowance.
+- **Charts:** mana curve and color pip coverage over the kept subset via existing `computeManaCurve` / `computeColorDistribution` / `computeManaBaseMetrics` and the `CurveConstellation` / `ColorPie` components, with a kept-vs-pool toggle.
+- **Combos in Pile:** `/api/deck-combos` runs once over the full pool; each combo derives a live state from triage statuses: intact (all pieces kept), possible (pieces undecided/in pool), broken (a piece cut, with restore affordance). Cutting a combo piece warns inline in any lens.
+- **Suggested Cuts:** ranked list with reason chips (low synergy score, off-identity, category overfull, curve glut), following the weak-card scoring approach of `card-suggestions.ts` (`WEAK_CARD_THRESHOLD`) and `analyzeCandidateCard`. Suggestions only mark status; nothing is cut without a click.
+
+### Legality gate
+`GET /api/commander-rules` supplies the banned list and game-changer names; `validateCommanderDeck` over (commanders + kept) is the enable condition for "Seal the Deck". The tracker rail shows the checklist: commander chosen, exactly 100, singleton, no banned cards, no off-identity kept cards.
+
+## Implementation Tasks
+
+### Phase 1: Core lib (TDD)
+
+- [ ] 1.1 Create `tests/unit/crucible-session.spec.ts`
+  - Test case: `createCrucibleSession(pool, warnings)` returns payload with all statuses defaulting to "undecided" and a generated id
+  - Test case: `setCardStatus(payload, name, status)` returns a new payload (immutability) with the status flipped
+  - Test case: `keptCards(payload)` / `cutCards(payload)` / `undecidedCards(payload)` partition the pool correctly, quantity-aware
+  - Test case: `keptCount` counts quantities, not unique names
+  - Test case: `buildFinalDeck(payload, name)` produces `DeckData` with commanders, kept mainboard (commanders excluded), cuts as sideboard, source "text"
+  - Test case: serialize/deserialize round-trip drops nothing and tolerates corrupt JSON (returns null)
+  - Test case: `flattenPileParse(parsed)` folds parser-inferred commanders back into the pool
+- [ ] 1.2 Create `src/lib/crucible-session.ts` implementing the above
+  - Follow the codec/guard patterns in `src/lib/deck-session.ts` (SESSION_KEY constant, try/catch storage access)
+- [ ] 1.3 Create `tests/unit/crucible-grouping.spec.ts`
+  - Test case: `groupByCategory` uses tag cache; untagged cards land in an "Uncategorized" group
+  - Test case: `groupBySynergyAxis` assigns each card to its strongest axis only; axes below 0.2 pool strength excluded; unaligned bucket collects the rest; `otherAxes` lists secondary homes
+  - Test case: `groupByTypeLine` / `groupByManaValue` (buckets 0-1, 2, 3, 4, 5, 6, 7+) / `groupByColorIdentity` bucket correctly, including multicolor and colorless
+  - Test case: `gameChangers` filter uses `isGameChanger`
+  - Test case: groups are stable-sorted (by kept-relevance desc, then name) so UI order does not jitter on status flips
+- [ ] 1.4 Create `src/lib/crucible-grouping.ts` implementing the above
+  - Reuse `buildTagCache`/`getTagsCached` from `src/lib/card-tags.ts` and `SYNERGY_AXES` from `src/lib/synergy-axes.ts`
+- [ ] 1.5 Create `tests/unit/cut-suggestions.spec.ts`
+  - Test case: off-identity cards rank as cut suggestions once commanders are set
+  - Test case: cards below the weak-synergy threshold rank with reason "low synergy"
+  - Test case: overfull categories (kept > target max) suggest their lowest-scoring members with reason "category overfull"
+  - Test case: kept commanders and cards already cut are never suggested
+  - Test case: dismissed suggestions are excluded
+- [ ] 1.6 Create `src/lib/cut-suggestions.ts` implementing `suggestCuts(payload, cardMap, synergy, scorecard, dismissed): CutSuggestion[]`
+  - Follow the scoring approach in `src/lib/card-suggestions.ts` (`WEAK_CARD_THRESHOLD`) and reuse `analyzeCandidateCard` from `src/lib/candidate-analysis.ts` where applicable
+
+### Phase 2: Context
+
+- [ ] 2.1 Create `src/contexts/CrucibleSessionContext.tsx`
+  - Hydration lifecycle `pending -> hydrated / absent` mirroring `DeckSessionContext`
+  - `setPile(pool, warnings)` persists and kicks off chunked enrichment (batches of <= 250 unique names against `POST /api/deck-enrich`, merged results, progress state for the loader) and a single `POST /api/deck-combos` over the full pool
+  - `setStatus(name, status)`, `setCommanders(names)`, `restore(name)`, `finalize()` helpers
+  - Memoized derived state: tag cache, per-lens groupings, kept-subset scorecard (`computeCompositionScorecard` with `TEMPLATE_COMMAND_ZONE`), legality (`validateCommanderDeck` fed by `/api/commander-rules`), cut suggestions
+
+### Phase 3: Route and import
+
+- [ ] 3.1 Create `e2e/crucible-import.spec.ts` (failing first)
+  - Test case: `/crucible` renders the pile import form with the sacred eyebrow pattern
+  - Test case: pasting a pile and submitting shows the CosmicLoader treatment, then the workbench with the full pool as undecided
+  - Test case: a pile whose trailing card would be commander-inferred still lands fully in the pool
+  - Test case: reloading mid-triage restores statuses from sessionStorage
+- [ ] 3.2 Create `src/app/crucible/page.tsx` + `src/components/crucible/CrucibleImport.tsx`
+  - Reuse `Textarea`, `Button`, `Card`, `SectionHeader` patterns; parse via `POST /api/deck-parse` then `flattenPileParse`
+  - Reuse `CosmicLoader` during enrichment with chunk progress in the incantation line
+- [ ] 3.3 Add a Crucible entry to the top nav in `src/components/shell/`
+
+### Phase 4: Workbench
+
+- [ ] 4.1 Create `e2e/crucible-triage.spec.ts` (failing first)
+  - Test case: keep/cut/undecided toggles update the row state and the kept counter
+  - Test case: cut rows stay visible dimmed; Cut Pile lens lists them; restore flips them back
+  - Test case: lens switching regroups without losing statuses
+  - Test case: category groups collapse/expand; at-target groups start collapsed; "Undecided only" filter hides decided rows
+  - Test case: commander picker lists legal commanders from the pool; picking one flags off-identity cards
+  - Test case: hovering a card name reveals its image preview (aria-safe)
+- [ ] 4.2 Create `src/components/crucible/CrucibleWorkbench.tsx`, `LensSwitcher.tsx`, `CrucibleCardRow.tsx`, `CommanderPicker.tsx`, `CutPile.tsx`
+  - `CrucibleCardRow` wraps the disclosure/a11y patterns of `EnrichedCardRow` and adds the triage buttons and image preview (from `EnrichedCard.imageUris`; `Sheet` on touch)
+  - Collapsible groups with sticky headers; virtualize rows past ~200 cards
+  - All styling via semantic tokens; reduced-motion gates on any transition
+
+### Phase 5: Insight panels
+
+- [ ] 5.1 Create `e2e/crucible-insight.spec.ts` (failing first)
+  - Test case: Charts lens renders curve and pip coverage for the kept subset and toggles to pool
+  - Test case: Combos lens shows intact/possible/broken states that react to triage flips
+  - Test case: cutting a combo piece surfaces the broken warning; restore clears it
+  - Test case: Suggested Cuts lists ranked reasons; accepting marks the card cut; dismissing hides the suggestion
+  - Test case: Game Changers lens lists flagged cards with kept count vs bracket allowance
+- [ ] 5.2 Create `src/components/crucible/CrucibleCharts.tsx`, `CrucibleCombos.tsx`, `SuggestedCuts.tsx`
+  - Charts reuse `CurveConstellation` / `ColorPie` / `computeManaCurve` / `computeColorDistribution` / `computeManaBaseMetrics`
+
+### Phase 6: Tracker and gate
+
+- [ ] 6.1 Create `e2e/crucible-legality.spec.ts` (failing first)
+  - Test case: rail shows kept count, category health bars, combo status, legality checklist
+  - Test case: "Seal the Deck" stays disabled until `validateCommanderDeck` passes over commanders + kept
+  - Test case: below 768px the rail renders inside the `Sheet` drawer
+- [ ] 6.2 Create `src/components/crucible/TrackerRail.tsx`
+  - Reuse `StatTile`, `Tag`, `Sheet`; legality via `validateCommanderDeck` + `/api/commander-rules`
+
+### Phase 7: Handoff
+
+- [ ] 7.1 Create `e2e/crucible-handoff.spec.ts` (failing first)
+  - Test case: sealing builds the DeckData (kept mainboard, cuts sideboard), sets the reading payload, and lands on `/reading` via `/ritual` (use `window.__SKIP_RITUAL_FLOOR__`)
+  - Test case: the reading session reflects the sealed deck; `/reading/add` sees cuts as sideboard
+- [ ] 7.2 Wire `finalize()` in `CrucibleWorkbench` to `buildFinalDeck` + `setPayload` + router push; no reading-side changes
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `docs/plans/crucible-deck-builder.md` | Create | This plan |
+| `src/lib/crucible-session.ts` | Create | Pile session model, statuses, codec, final-deck builder |
+| `src/lib/crucible-grouping.ts` | Create | Lens grouping functions |
+| `src/lib/cut-suggestions.ts` | Create | Ranked cut recommender |
+| `src/contexts/CrucibleSessionContext.tsx` | Create | Hydration, chunked enrichment, combos fetch, derived state |
+| `src/app/crucible/page.tsx` | Create | Route: import form -> loader -> workbench |
+| `src/components/crucible/CrucibleImport.tsx` | Create | Pile paste form |
+| `src/components/crucible/CrucibleWorkbench.tsx` | Create | Three-pane workbench shell |
+| `src/components/crucible/LensSwitcher.tsx` | Create | Lens/filter sidebar |
+| `src/components/crucible/CrucibleCardRow.tsx` | Create | Triage row with preview + disclosure |
+| `src/components/crucible/CommanderPicker.tsx` | Create | Legal-commander picker + search fallback |
+| `src/components/crucible/CutPile.tsx` | Create | Cut list with restore |
+| `src/components/crucible/CrucibleCharts.tsx` | Create | Curve + pip coverage panel |
+| `src/components/crucible/CrucibleCombos.tsx` | Create | Combo states panel |
+| `src/components/crucible/SuggestedCuts.tsx` | Create | Ranked cut suggestions panel |
+| `src/components/crucible/TrackerRail.tsx` | Create | Count, health, legality, seal button |
+| `src/components/shell/` (top nav) | Modify | Add Crucible nav entry |
+| `tests/unit/crucible-session.spec.ts` | Create | Phase 1 unit tests |
+| `tests/unit/crucible-grouping.spec.ts` | Create | Phase 1 unit tests |
+| `tests/unit/cut-suggestions.spec.ts` | Create | Phase 1 unit tests |
+| `e2e/crucible-import.spec.ts` | Create | Phase 3 e2e |
+| `e2e/crucible-triage.spec.ts` | Create | Phase 4 e2e |
+| `e2e/crucible-insight.spec.ts` | Create | Phase 5 e2e |
+| `e2e/crucible-legality.spec.ts` | Create | Phase 6 e2e |
+| `e2e/crucible-handoff.spec.ts` | Create | Phase 7 e2e |
+
+No changes to: `src/app/reading/**`, `src/contexts/DeckSessionContext.tsx`, `src/contexts/PendingChangesContext.tsx`, `src/lib/deck-session.ts`, `src/lib/view-tabs.ts`, existing API routes, `design-system/tokens.css`.
+
+## Verification
+
+1. `npm run test:unit` - all unit tests pass
+2. `npm run test:e2e` - all e2e tests pass
+3. `npm run build` - production build succeeds
+4. `npm run lint` - clean
+5. Manual: paste a 150+ card pile on `/crucible`, watch the ritual loader, pick a commander, triage across every lens (including Charts, Combos, Suggested Cuts, Cut Pile, Game Changers), confirm the rail's legality checklist gates "Seal the Deck", seal, and verify the full reading journey renders the sealed deck with cuts as sideboard

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -167,7 +167,7 @@ The workbench header hosts a `CardSearchInput` so cards can be searched up and a
 | `src/lib/cut-suggestions.ts` | Create | Ranked cut recommender |
 | `src/contexts/CrucibleSessionContext.tsx` | Create | Hydration, chunked enrichment, combos fetch, derived state |
 | `src/app/crucible/page.tsx` | Create | Route: import form -> loader -> workbench |
-| `src/components/crucible/CrucibleImport.tsx` | Create | Pile paste form |
+| `src/components/crucible/CrucibleImport.tsx` | Create | Pile paste form + `CardSearchInput` to build the pile by search |
 | `src/components/crucible/CrucibleWorkbench.tsx` | Create | Three-pane workbench shell |
 | `src/components/crucible/LensSwitcher.tsx` | Create | Lens/filter sidebar |
 | `src/components/crucible/CrucibleCardRow.tsx` | Create | Triage row with preview + disclosure |

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -8,8 +8,8 @@ The Crucible is a new top-level route (`/crucible`) that accepts any number of c
 
 Scope decisions, locked during plan review:
 
-- **In:** pile import (paste), chunked enrichment with the CosmicLoader ritual treatment, explicit commander picker, lenses (By Category, By Synergy Axis, By Type Line, By Mana Value, By Color Identity, Flat List, Game Changers), Insight panels (Charts, Combos in Pile, Suggested Cuts, Cut Pile), tracker rail (kept count, category health, combo status, legality checklist), collapsible/sticky category groups with row virtualization, hover/tap card image previews, "Seal the Deck" handoff.
-- **Out (fast-follows, not v1):** share-a-pile URL, price/budget lens, Scryfall-backed "fill this gap" suggestions inside the Crucible, non-EDH formats.
+- **In:** pile import (paste), chunked enrichment with the CosmicLoader ritual treatment, explicit commander picker, lenses (By Category, By Synergy Axis, By Type Line, By Mana Value, By Color Identity, Flat List, Game Changers), Insight panels (Charts, Combos in Pile, Suggested Cuts, Cut Pile), tracker rail (kept count, category health, combo status, legality checklist), collapsible/sticky category groups with capped rendering ("Show all N" expansion), hover/tap card image previews, "Seal the Deck" handoff.
+- **Out (fast-follows, not v1):** share-a-pile URL, price/budget lens, Scryfall-backed "fill this gap" suggestions inside the Crucible, non-EDH formats, a deck-name input at seal (v1 uses the default name "Forged in the Crucible"), external card search in the commander picker (v1 only lists legal commanders found in the pool), true row virtualization (v1 caps rendered rows per group and offers "Show all N").
 
 ## Design Decisions
 
@@ -40,7 +40,7 @@ Runtime-only state in the context (not persisted): `cardMap: Record<string, Enri
 A cut row stays in place, dimmed, in whatever lens is active, and also collects in the Cut Pile lens where one click restores it. Finalize stores cuts as the sideboard so `/reading` and `/reading/add` still see them as candidates.
 
 ### Pile parsing
-Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred commanders back into the pool: its "trailing 1-2 cards are the commander" heuristic misfires on plain piles. Commander choice is explicit in the workbench via a picker that lists legal commanders detected in the pool (`isLegalCommander`) with a `CardSearchInput` fallback.
+Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred commanders back into the pool: its "trailing 1-2 cards are the commander" heuristic misfires on plain piles. Commander choice is explicit in the workbench via a picker that lists legal commanders detected in the pool (`isLegalCommander`); an external `CardSearchInput` fallback is a fast-follow (see Out list above).
 
 ### Enrichment
 `POST /api/deck-enrich` rejects more than 250 unique names per request. The context chunks the pool into batches of at most 250 names, issues them sequentially, and merges `cards`/`notFound`. While enrichment runs, the Crucible plays the same `CosmicLoader` ritual treatment as a normal reading, with chunk progress feeding the incantation line.
@@ -49,11 +49,11 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 `analyzeDeckSynergy` takes a `DeckData`; the Crucible feeds it a synthetic one (chosen commanders + pool as mainboard). Before a commander is chosen, per-card axis scores still work (each axis `detect(card)` is commander-independent); anchor boosts and off-identity flagging activate after the pick via `resolveCommanderIdentity` + per-card `colorIdentity`.
 
 ### Lens grouping rules
-- **By Category:** tag-driven groups from `computeCompositionScorecard` against `TEMPLATE_COMMAND_ZONE` over the kept subset; groups show candidates/kept/target with a health bar. Groups at target auto-collapse; headers stick on scroll; rows virtualize past ~200 cards.
+- **By Category:** tag-driven groups from `computeCompositionScorecard` against `TEMPLATE_COMMAND_ZONE` over the kept subset; groups show candidates/kept/target with a health bar. Groups at target auto-collapse; headers stick on scroll; groups cap rendered rows (60) with a "Show all N" expansion.
 - **By Synergy Axis:** axes sorted by pool-wide strength; only axes with strength >= 0.2 get a group; each card appears once under its strongest axis with a "+N axes" badge for its other homes; an "Unaligned" group gathers cards with no axis >= 0.2 (prime cut candidates).
 - **Game Changers:** cards flagged `isGameChanger` (list served by `/api/commander-rules`), with kept count shown against the deck's bracket allowance.
 - **Charts:** mana curve and color pip coverage over the kept subset via existing `computeManaCurve` / `computeColorDistribution` / `computeManaBaseMetrics` and the `CurveConstellation` / `ColorPie` components, with a kept-vs-pool toggle.
-- **Combos in Pile:** `/api/deck-combos` runs once over the full pool; each combo derives a live state from triage statuses: intact (all pieces kept), possible (pieces undecided/in pool), broken (a piece cut, with restore affordance). Cutting a combo piece warns inline in any lens.
+- **Combos in Pile:** `/api/deck-combos` runs once over the full pool when its unique-name count is under the API cap; for larger piles the lookup runs over the keep+undecided subset once cuts bring it under the cap (debounced, results merged so broken combos keep rendering). Each combo derives a live state from triage statuses: intact (all pieces kept), possible (pieces undecided/in pool), broken (a piece cut, with restore affordance). Cutting a combo piece warns inline in any lens.
 - **Suggested Cuts:** ranked list with reason chips (low synergy score, off-identity, category overfull, curve glut), following the weak-card scoring approach of `card-suggestions.ts` (`WEAK_CARD_THRESHOLD`) and `analyzeCandidateCard`. Suggestions only mark status; nothing is cut without a click.
 
 ### Legality gate
@@ -94,7 +94,7 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 
 - [x] 2.1 Create `src/contexts/CrucibleSessionContext.tsx`
   - Hydration lifecycle `pending -> hydrated / absent` mirroring `DeckSessionContext`
-  - `setPile(pool, warnings)` persists and kicks off chunked enrichment (batches of <= 250 unique names against `POST /api/deck-enrich`, merged results, progress state for the loader) and a single `POST /api/deck-combos` over the full pool
+  - `setPile(pool, warnings)` persists and kicks off chunked enrichment (batches of <= 250 unique names against `POST /api/deck-enrich`, merged results, progress state for the loader) and `POST /api/deck-combos` (full pool when under the API cap; large piles refetch over the keep+undecided subset once it fits)
   - `setStatus(name, status)`, `setCommanders(names)`, `restore(name)`, `finalize()` helpers
   - Memoized derived state: tag cache, per-lens groupings, kept-subset scorecard (`computeCompositionScorecard` with `TEMPLATE_COMMAND_ZONE`), legality (`validateCommanderDeck` fed by `/api/commander-rules`), cut suggestions
 
@@ -121,7 +121,7 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
   - Test case: hovering a card name reveals its image preview (aria-safe)
 - [x] 4.2 Create `src/components/crucible/CrucibleWorkbench.tsx`, `LensSwitcher.tsx`, `CrucibleCardRow.tsx`, `CommanderPicker.tsx`, `CutPile.tsx`
   - `CrucibleCardRow` wraps the disclosure/a11y patterns of `EnrichedCardRow` and adds the triage buttons and image preview (from `EnrichedCard.imageUris`; `Sheet` on touch)
-  - Collapsible groups with sticky headers; virtualize rows past ~200 cards
+  - Collapsible groups with sticky headers; cap rendered rows per group with a "Show all N" expansion
   - All styling via semantic tokens; reduced-motion gates on any transition
 
 ### Phase 5: Insight panels
@@ -172,6 +172,8 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 | `src/components/crucible/SuggestedCuts.tsx` | Create | Ranked cut suggestions panel |
 | `src/components/crucible/TrackerRail.tsx` | Create | Count, health, legality, seal button |
 | `src/components/shell/` (top nav) | Modify | Add Crucible nav entry |
+| `src/contexts/DeckSessionContext.tsx` | Modify | Chunk enrichment requests so sealed decks over the 250-name API cap (kept + cuts) enrich in batches |
+| `src/lib/commander-validation.ts` | Modify | Add `canPairCommanders` two-commander pairing legality |
 | `tests/unit/crucible-session.spec.ts` | Create | Phase 1 unit tests |
 | `tests/unit/crucible-grouping.spec.ts` | Create | Phase 1 unit tests |
 | `tests/unit/cut-suggestions.spec.ts` | Create | Phase 1 unit tests |
@@ -181,7 +183,7 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 | `e2e/crucible-legality.spec.ts` | Create | Phase 6 e2e |
 | `e2e/crucible-handoff.spec.ts` | Create | Phase 7 e2e |
 
-No changes to: `src/app/reading/**`, `src/contexts/DeckSessionContext.tsx`, `src/contexts/PendingChangesContext.tsx`, `src/lib/deck-session.ts`, `src/lib/view-tabs.ts`, existing API routes, `design-system/tokens.css`.
+No changes to: `src/app/reading/**`, `src/contexts/PendingChangesContext.tsx`, `src/lib/deck-session.ts`, `src/lib/view-tabs.ts`, existing API routes, `design-system/tokens.css`. (`src/contexts/DeckSessionContext.tsx` gained request chunking during review so a sealed deck larger than the enrich API's 250-name cap still enriches; the reading journey's behavior is otherwise untouched.)
 
 ## Verification
 

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -92,7 +92,7 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 
 ### Phase 2: Context
 
-- [ ] 2.1 Create `src/contexts/CrucibleSessionContext.tsx`
+- [x] 2.1 Create `src/contexts/CrucibleSessionContext.tsx`
   - Hydration lifecycle `pending -> hydrated / absent` mirroring `DeckSessionContext`
   - `setPile(pool, warnings)` persists and kicks off chunked enrichment (batches of <= 250 unique names against `POST /api/deck-enrich`, merged results, progress state for the loader) and a single `POST /api/deck-combos` over the full pool
   - `setStatus(name, status)`, `setCommanders(names)`, `restore(name)`, `finalize()` helpers

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -63,7 +63,7 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 
 ### Phase 1: Core lib (TDD)
 
-- [ ] 1.1 Create `tests/unit/crucible-session.spec.ts`
+- [x] 1.1 Create `tests/unit/crucible-session.spec.ts`
   - Test case: `createCrucibleSession(pool, warnings)` returns payload with all statuses defaulting to "undecided" and a generated id
   - Test case: `setCardStatus(payload, name, status)` returns a new payload (immutability) with the status flipped
   - Test case: `keptCards(payload)` / `cutCards(payload)` / `undecidedCards(payload)` partition the pool correctly, quantity-aware
@@ -71,23 +71,23 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
   - Test case: `buildFinalDeck(payload, name)` produces `DeckData` with commanders, kept mainboard (commanders excluded), cuts as sideboard, source "text"
   - Test case: serialize/deserialize round-trip drops nothing and tolerates corrupt JSON (returns null)
   - Test case: `flattenPileParse(parsed)` folds parser-inferred commanders back into the pool
-- [ ] 1.2 Create `src/lib/crucible-session.ts` implementing the above
+- [x] 1.2 Create `src/lib/crucible-session.ts` implementing the above
   - Follow the codec/guard patterns in `src/lib/deck-session.ts` (SESSION_KEY constant, try/catch storage access)
-- [ ] 1.3 Create `tests/unit/crucible-grouping.spec.ts`
+- [x] 1.3 Create `tests/unit/crucible-grouping.spec.ts`
   - Test case: `groupByCategory` uses tag cache; untagged cards land in an "Uncategorized" group
   - Test case: `groupBySynergyAxis` assigns each card to its strongest axis only; axes below 0.2 pool strength excluded; unaligned bucket collects the rest; `otherAxes` lists secondary homes
   - Test case: `groupByTypeLine` / `groupByManaValue` (buckets 0-1, 2, 3, 4, 5, 6, 7+) / `groupByColorIdentity` bucket correctly, including multicolor and colorless
   - Test case: `gameChangers` filter uses `isGameChanger`
   - Test case: groups are stable-sorted (by kept-relevance desc, then name) so UI order does not jitter on status flips
-- [ ] 1.4 Create `src/lib/crucible-grouping.ts` implementing the above
+- [x] 1.4 Create `src/lib/crucible-grouping.ts` implementing the above
   - Reuse `buildTagCache`/`getTagsCached` from `src/lib/card-tags.ts` and `SYNERGY_AXES` from `src/lib/synergy-axes.ts`
-- [ ] 1.5 Create `tests/unit/cut-suggestions.spec.ts`
+- [x] 1.5 Create `tests/unit/cut-suggestions.spec.ts`
   - Test case: off-identity cards rank as cut suggestions once commanders are set
   - Test case: cards below the weak-synergy threshold rank with reason "low synergy"
   - Test case: overfull categories (kept > target max) suggest their lowest-scoring members with reason "category overfull"
   - Test case: kept commanders and cards already cut are never suggested
   - Test case: dismissed suggestions are excluded
-- [ ] 1.6 Create `src/lib/cut-suggestions.ts` implementing `suggestCuts(payload, cardMap, synergy, scorecard, dismissed): CutSuggestion[]`
+- [x] 1.6 Create `src/lib/cut-suggestions.ts` implementing `suggestCuts(payload, cardMap, synergy, scorecard, dismissed): CutSuggestion[]`
   - Follow the scoring approach in `src/lib/card-suggestions.ts` (`WEAK_CARD_THRESHOLD`) and reuse `analyzeCandidateCard` from `src/lib/candidate-analysis.ts` where applicable
 
 ### Phase 2: Context

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -8,7 +8,7 @@ The Crucible is a new top-level route (`/crucible`) that accepts any number of c
 
 Scope decisions, locked during plan review:
 
-- **In:** pile import (paste), chunked enrichment with the CosmicLoader ritual treatment, explicit commander picker, lenses (By Category, By Synergy Axis, By Type Line, By Mana Value, By Color Identity, Flat List, Game Changers), Insight panels (Charts, Combos in Pile, Suggested Cuts, Cut Pile), tracker rail (kept count, category health, combo status, legality checklist), collapsible/sticky category groups with capped rendering ("Show all N" expansion), hover/tap card image previews, "Seal the Deck" handoff.
+- **In:** pile import (paste), chunked enrichment with the CosmicLoader ritual treatment, explicit commander picker, lenses (By Category, By Synergy Axis, By Type Line, By Mana Value, By Color Identity, Flat List, Game Changers), Insight panels (Charts, Combos in Pile, Suggested Cuts, Cut Pile), tracker rail (kept count, category health, combo status, legality checklist), collapsible/sticky category groups with capped rendering ("Show all N" expansion), hover/tap card image previews, mid-triage card search (added at user direction after the initial review; see "Adding cards mid-triage" below), "Seal the Deck" handoff.
 - **Out (fast-follows, not v1):** share-a-pile URL, price/budget lens, Scryfall-backed "fill this gap" suggestions inside the Crucible, non-EDH formats, a deck-name input at seal (v1 uses the default name "Forged in the Crucible"), external card search in the commander picker (v1 only lists legal commanders found in the pool), true row virtualization (v1 caps rendered rows per group and offers "Show all N").
 
 ## Design Decisions
@@ -24,15 +24,18 @@ Core state:
 ```ts
 export type CrucibleCardStatus = "keep" | "cut" | "undecided";
 
-export interface CrucibleSessionPayload {
+export interface CruciblePayload {
   crucibleId: string;
   pool: DeckCard[];                                  // every imported card, quantity-aware
   statuses: Record<string, CrucibleCardStatus>;      // keyed by card name; default "undecided"
+  keptQuantities: Record<string, number>;            // partial keeps for stacked cards
   commanders: string[];                              // 0-2, chosen in the workbench
   parseWarnings: string[];
   createdAt: number;
 }
 ```
+
+The authoritative shape lives in `src/lib/crucible-session.ts` (`CruciblePayload`).
 
 Runtime-only state in the context (not persisted): `cardMap: Record<string, EnrichedCard> | null`, `notFound: string[]`, `combos` (from `/api/deck-combos`), plus memoized derived data (tag cache via `buildTagCache`, per-lens groupings, kept-subset scorecard, legality result, cut suggestions). Persistence key: `astral.crucible-session.v1`, separate from the reading session so both coexist in one tab.
 
@@ -41,6 +44,9 @@ A cut row stays in place, dimmed, in whatever lens is active, and also collects 
 
 ### Pile parsing
 Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred commanders back into the pool: its "trailing 1-2 cards are the commander" heuristic misfires on plain piles. Commander choice is explicit in the workbench via a picker that lists legal commanders detected in the pool (`isLegalCommander`); an external `CardSearchInput` fallback is a fast-follow (see Out list above).
+
+### Adding cards mid-triage
+The workbench header hosts a `CardSearchInput` so cards can be searched up and added to the pile during triage (`addCard` on the context, `addCardToPool` in `src/lib/crucible-session.ts`). A found card lands as undecided; an existing name gets a quantity bump that preserves its status and partial keeps. The new card enriches incrementally via a single-name `/api/deck-enrich` merge, and combo detection refreshes where the pile size allows (a pure quantity bump skips the redundant refetch). The search deliberately excludes nothing so basics can be stacked; singleton legality flags illegal duplicates.
 
 ### Enrichment
 `POST /api/deck-enrich` rejects more than 250 unique names per request. The context chunks the pool into batches of at most 250 names, issues them sequentially, and merges `cards`/`notFound`. While enrichment runs, the Crucible plays the same `CosmicLoader` ritual treatment as a normal reading, with chunk progress feeding the incantation line.
@@ -95,7 +101,7 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 - [x] 2.1 Create `src/contexts/CrucibleSessionContext.tsx`
   - Hydration lifecycle `pending -> hydrated / absent` mirroring `DeckSessionContext`
   - `setPile(pool, warnings)` persists and kicks off chunked enrichment (batches of <= 250 unique names against `POST /api/deck-enrich`, merged results, progress state for the loader) and `POST /api/deck-combos` (full pool when under the API cap; large piles refetch over the keep+undecided subset once it fits)
-  - `setStatus(name, status)`, `setCommanders(names)`, `restore(name)`, `finalize()` helpers
+  - `setStatus(name, status)`, `setKeptQuantity(name, count)`, `setCommanders(names)`, `restore(name)`, `addCard(name)`, `finalize()` helpers
   - Memoized derived state: tag cache, per-lens groupings, kept-subset scorecard (`computeCompositionScorecard` with `TEMPLATE_COMMAND_ZONE`), legality (`validateCommanderDeck` fed by `/api/commander-rules`), cut suggestions
 
 ### Phase 3: Route and import
@@ -174,6 +180,8 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 | `src/components/shell/` (top nav) | Modify | Add Crucible nav entry |
 | `src/contexts/DeckSessionContext.tsx` | Modify | Chunk enrichment requests so sealed decks over the 250-name API cap (kept + cuts) enrich in batches |
 | `src/lib/commander-validation.ts` | Modify | Add `canPairCommanders` two-commander pairing legality |
+| `src/lib/enrich-chunking.ts` | Create | Shared `ENRICH_CHUNK_SIZE` + `chunk` helper used by both contexts and the enrich route |
+| `src/app/api/deck-enrich/route.ts` | Modify | Derive `MAX_UNIQUE_NAMES` from `ENRICH_CHUNK_SIZE` (no behavior change) |
 | `tests/unit/crucible-session.spec.ts` | Create | Phase 1 unit tests |
 | `tests/unit/crucible-grouping.spec.ts` | Create | Phase 1 unit tests |
 | `tests/unit/cut-suggestions.spec.ts` | Create | Phase 1 unit tests |
@@ -182,8 +190,9 @@ Reuse `parseDecklist` (`src/lib/decklist-parser.ts`) but flatten its inferred co
 | `e2e/crucible-insight.spec.ts` | Create | Phase 5 e2e |
 | `e2e/crucible-legality.spec.ts` | Create | Phase 6 e2e |
 | `e2e/crucible-handoff.spec.ts` | Create | Phase 7 e2e |
+| `e2e/crucible-add.spec.ts` | Create | Mid-triage search-and-add e2e |
 
-No changes to: `src/app/reading/**`, `src/contexts/PendingChangesContext.tsx`, `src/lib/deck-session.ts`, `src/lib/view-tabs.ts`, existing API routes, `design-system/tokens.css`. (`src/contexts/DeckSessionContext.tsx` gained request chunking during review so a sealed deck larger than the enrich API's 250-name cap still enriches; the reading journey's behavior is otherwise untouched.)
+No changes to: `src/app/reading/**`, `src/contexts/PendingChangesContext.tsx`, `src/lib/deck-session.ts`, `src/lib/view-tabs.ts`, `design-system/tokens.css`. (`src/contexts/DeckSessionContext.tsx` gained request chunking during review so a sealed deck larger than the enrich API's 250-name cap still enriches, and `/api/deck-enrich` now derives its cap constant from the shared `src/lib/enrich-chunking.ts`; the reading journey's behavior and the API contract are otherwise untouched.)
 
 ## Verification
 

--- a/e2e/api-card-autocomplete.spec.ts
+++ b/e2e/api-card-autocomplete.spec.ts
@@ -1,14 +1,20 @@
 import { test, expect } from "@playwright/test";
 
 /**
- * Probe Scryfall reachability so we can skip network-dependent tests
- * when the API is unreachable (sandboxed CI, offline dev).
+ * Probe Scryfall reachability so we can skip network-dependent tests when
+ * the API is unreachable (sandboxed CI, offline dev). The probe must hit
+ * Scryfall DIRECTLY, not our own route: probing through /api/card-autocomplete
+ * made a broken route indistinguishable from an offline network, so a real
+ * regression (the missing User-Agent header) skipped instead of failing.
  */
 let scryfallReachable = true;
 
 test.beforeAll(async ({ request }) => {
   try {
-    const res = await request.get("/api/card-autocomplete?q=Sol+Ring");
+    const res = await request.get(
+      "https://api.scryfall.com/cards/autocomplete?q=sol",
+      { headers: { "User-Agent": "DeckEvaluator/1.0", Accept: "application/json" } }
+    );
     if (!res.ok()) {
       scryfallReachable = false;
     }

--- a/e2e/crucible-add.spec.ts
+++ b/e2e/crucible-add.spec.ts
@@ -1,33 +1,11 @@
-import type { Page } from "@playwright/test";
 import {
   test,
   expect,
   SAMPLE_PILE,
   mockCommanderRules,
+  mockAutocomplete,
+  searchAndAdd,
 } from "./crucible-helpers";
-
-/** Mock the autocomplete with a tiny catalog; the real route hits Scryfall. */
-async function mockAutocomplete(page: Page) {
-  const catalog = ["Birds of Paradise", "Sol Ring", "Tymna the Weaver"];
-  await page.route("**/api/card-autocomplete**", (route) => {
-    const url = new URL(route.request().url());
-    const q = (url.searchParams.get("q") ?? "").toLowerCase();
-    return route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        suggestions: catalog.filter((name) => name.toLowerCase().includes(q)),
-      }),
-    });
-  });
-}
-
-async function addCard(page: Page, query: string, name: string) {
-  await page.locator("#card-search-input").fill(query);
-  const option = page.getByRole("option", { name });
-  await option.waitFor({ timeout: 5_000 });
-  await option.click();
-}
 
 test.describe("Crucible add cards mid-triage", () => {
   test.beforeEach(async ({ page }) => {
@@ -39,7 +17,7 @@ test.describe("Crucible add cards mid-triage", () => {
     await crucible.importPile(SAMPLE_PILE);
     await expect(crucible.poolCount).toContainText("16");
 
-    await addCard(page, "Birds", "Birds of Paradise");
+    await searchAndAdd(page, "Birds", "Birds of Paradise");
 
     await expect(crucible.poolCount).toContainText("17");
     await expect(crucible.row("Birds of Paradise").first()).toBeVisible();
@@ -54,7 +32,7 @@ test.describe("Crucible add cards mid-triage", () => {
     await crucible.importPile(SAMPLE_PILE);
     await crucible.keepButton("Sol Ring").click();
 
-    await addCard(page, "Sol R", "Sol Ring");
+    await searchAndAdd(page, "Sol R", "Sol Ring");
 
     await expect(crucible.poolCount).toContainText("17");
     await expect(crucible.row("Sol Ring").first()).toContainText("2");
@@ -64,7 +42,7 @@ test.describe("Crucible add cards mid-triage", () => {
   test("an added legendary becomes a commander candidate and additions survive reload", async ({ page, crucible }) => {
     await crucible.importPile(SAMPLE_PILE);
 
-    await addCard(page, "Tymna", "Tymna the Weaver");
+    await searchAndAdd(page, "Tymna", "Tymna the Weaver");
     await expect(
       page.getByRole("button", { name: "Choose Tymna the Weaver" })
     ).toBeVisible();

--- a/e2e/crucible-add.spec.ts
+++ b/e2e/crucible-add.spec.ts
@@ -59,9 +59,11 @@ test.describe("Crucible add cards mid-triage", () => {
     await crucible.importPile(SAMPLE_PILE);
 
     await searchAndAdd(page, "Tymna", "Tymna the Weaver");
+    await crucible.openCommanderPopover();
     await expect(
       page.getByRole("button", { name: "Choose Tymna the Weaver" })
     ).toBeVisible();
+    await page.keyboard.press("Escape");
 
     await page.reload();
     await crucible.workbench.waitFor({ timeout: 15_000 });

--- a/e2e/crucible-add.spec.ts
+++ b/e2e/crucible-add.spec.ts
@@ -39,6 +39,22 @@ test.describe("Crucible add cards mid-triage", () => {
     await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "true");
   });
 
+  test("a failing card search surfaces an error instead of silently showing nothing", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await page.route("**/api/card-autocomplete**", (route) =>
+      route.fulfill({
+        status: 502,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Scryfall autocomplete request failed" }),
+      })
+    );
+
+    await page.locator("#card-search-input").fill("Birds");
+    await expect(page.getByTestId("card-search-error")).toBeVisible();
+    await expect(page.getByTestId("card-search-error")).toContainText(/search/i);
+  });
+
   test("an added legendary becomes a commander candidate and additions survive reload", async ({ page, crucible }) => {
     await crucible.importPile(SAMPLE_PILE);
 

--- a/e2e/crucible-add.spec.ts
+++ b/e2e/crucible-add.spec.ts
@@ -1,0 +1,77 @@
+import type { Page } from "@playwright/test";
+import {
+  test,
+  expect,
+  SAMPLE_PILE,
+  mockCommanderRules,
+} from "./crucible-helpers";
+
+/** Mock the autocomplete with a tiny catalog; the real route hits Scryfall. */
+async function mockAutocomplete(page: Page) {
+  const catalog = ["Birds of Paradise", "Sol Ring", "Tymna the Weaver"];
+  await page.route("**/api/card-autocomplete**", (route) => {
+    const url = new URL(route.request().url());
+    const q = (url.searchParams.get("q") ?? "").toLowerCase();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        suggestions: catalog.filter((name) => name.toLowerCase().includes(q)),
+      }),
+    });
+  });
+}
+
+async function addCard(page: Page, query: string, name: string) {
+  await page.locator("#card-search-input").fill(query);
+  const option = page.getByRole("option", { name });
+  await option.waitFor({ timeout: 5_000 });
+  await option.click();
+}
+
+test.describe("Crucible add cards mid-triage", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+    await mockAutocomplete(page);
+  });
+
+  test("searching adds a new card to the pool as undecided", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+    await expect(crucible.poolCount).toContainText("16");
+
+    await addCard(page, "Birds", "Birds of Paradise");
+
+    await expect(crucible.poolCount).toContainText("17");
+    await expect(crucible.row("Birds of Paradise").first()).toBeVisible();
+    await expect(crucible.keepButton("Birds of Paradise")).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+    await expect(crucible.keptCount).toContainText("0");
+  });
+
+  test("adding a card already in the pile bumps its quantity and keeps its status", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+    await crucible.keepButton("Sol Ring").click();
+
+    await addCard(page, "Sol R", "Sol Ring");
+
+    await expect(crucible.poolCount).toContainText("17");
+    await expect(crucible.row("Sol Ring").first()).toContainText("2");
+    await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("an added legendary becomes a commander candidate and additions survive reload", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await addCard(page, "Tymna", "Tymna the Weaver");
+    await expect(
+      page.getByRole("button", { name: "Choose Tymna the Weaver" })
+    ).toBeVisible();
+
+    await page.reload();
+    await crucible.workbench.waitFor({ timeout: 15_000 });
+    await expect(crucible.row("Tymna the Weaver").first()).toBeVisible();
+    await expect(crucible.poolCount).toContainText("17");
+  });
+});

--- a/e2e/crucible-handoff.spec.ts
+++ b/e2e/crucible-handoff.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, mockCommanderRules } from "./crucible-helpers";
+
+/** 101 cards including Sol Ring so one cut leaves a legal 100 with a
+ * sideboard entry to verify on the reading side. */
+const HUNDRED_ONE_PILE = `1 Atraxa, Praetors' Voice
+1 Sol Ring
+59 Forest
+40 Island`;
+
+test.describe("Crucible handoff", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+  });
+
+  test("sealing hands the deck to the ritual and reading journey with cuts as sideboard", async ({ page, crucible }) => {
+    await crucible.importPile(HUNDRED_ONE_PILE);
+
+    await crucible.chooseCommander("Atraxa, Praetors' Voice");
+    await crucible.keepButton("Forest").click();
+    await crucible.keepButton("Island").click();
+    await crucible.cutButton("Sol Ring").click();
+
+    await expect(crucible.keptCount).toContainText("100");
+    await expect(crucible.sealButton).toBeEnabled();
+    await crucible.sealButton.click();
+
+    // __SKIP_RITUAL_FLOOR__ is set by the fixture, so the ritual forwards
+    // immediately once the reading session's enrichment resolves.
+    await page.waitForURL(/\/reading/, { timeout: 15_000 });
+    await expect(page.getByTestId("reading-section-grid")).toBeVisible({ timeout: 15_000 });
+
+    // The cut Sol Ring survives as sideboard on the reading side.
+    await page
+      .getByTestId("reading-section-grid")
+      .getByRole("link", { name: /cards/i })
+      .first()
+      .click();
+    await page.waitForURL(/\/reading\/cards/, { timeout: 5_000 });
+    const display = page.getByTestId("deck-display");
+    await expect(display).toContainText("Sideboard");
+    await expect(display).toContainText("Sol Ring");
+    await expect(display).toContainText("Atraxa, Praetors' Voice");
+  });
+});

--- a/e2e/crucible-helpers.ts
+++ b/e2e/crucible-helpers.ts
@@ -49,6 +49,33 @@ export const TRAILING_COMMANDER_PILE = `1 Sol Ring
 1 Ezuri, Stalker of Spheres`;
 
 /**
+ * Mock the card-autocomplete route with a tiny catalog; the real route hits
+ * Scryfall. Used by both the import-screen and workbench search tests.
+ */
+export async function mockAutocomplete(page: Page) {
+  const catalog = ["Birds of Paradise", "Sol Ring", "Tymna the Weaver"];
+  await page.route("**/api/card-autocomplete**", (route) => {
+    const url = new URL(route.request().url());
+    const q = (url.searchParams.get("q") ?? "").toLowerCase();
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        suggestions: catalog.filter((name) => name.toLowerCase().includes(q)),
+      }),
+    });
+  });
+}
+
+/** Type into the card search and pick a suggestion. */
+export async function searchAndAdd(page: Page, query: string, name: string) {
+  await page.locator("#card-search-input").fill(query);
+  const option = page.getByRole("option", { name });
+  await option.waitFor({ timeout: 5_000 });
+  await option.click();
+}
+
+/**
  * Mock GET /api/commander-rules so crucible tests never hit Scryfall.
  * Shape mirrors the real route: banned names + game-changer cards.
  */

--- a/e2e/crucible-helpers.ts
+++ b/e2e/crucible-helpers.ts
@@ -169,7 +169,28 @@ export class CruciblePage {
       .click();
   }
 
+  /** The collapsed control that opens the candidate popover — either the
+   * initial "Choose from N candidates" button or the "Add a partner" button
+   * once a first commander is locked in. */
+  get commanderTrigger() {
+    return this.commanderPicker.getByRole("button", {
+      name: /^(Choose from \d+ candidates?|Add a partner)$/,
+    });
+  }
+
+  get commanderPopover() {
+    return this.page.getByTestId("crucible-commander-popover");
+  }
+
+  /** Open the commander/partner candidate popover if it isn't already open. */
+  async openCommanderPopover() {
+    if (!(await this.commanderPopover.isVisible())) {
+      await this.commanderTrigger.click();
+    }
+  }
+
   async chooseCommander(name: string) {
+    await this.openCommanderPopover();
     await this.page
       .getByRole("button", { name: `Choose ${name}`, exact: true })
       .click();

--- a/e2e/crucible-helpers.ts
+++ b/e2e/crucible-helpers.ts
@@ -1,0 +1,153 @@
+import type { Page } from "@playwright/test";
+import { test as deckTest, expect } from "./fixtures";
+
+// ---------------------------------------------------------------------------
+// Sample piles — all names exist in the enriched-cards fixture bank so the
+// default /api/deck-enrich mock returns realistic data.
+// ---------------------------------------------------------------------------
+
+/** 13 unique names, 16 total cards. Atraxa + Ezuri are legal commanders;
+ * Lightning Bolt is off Atraxa's WUBG identity. */
+export const SAMPLE_PILE = `1 Atraxa, Praetors' Voice
+1 Ezuri, Stalker of Spheres
+1 Sol Ring
+1 Command Tower
+1 Arcane Signet
+1 Swords to Plowshares
+1 Counterspell
+1 Cultivate
+1 Llanowar Elves
+1 Lightning Bolt
+1 Path to Exile
+3 Forest
+2 Island`;
+
+/** Exactly 100 cards with 3 unique names, so a test can reach a legal
+ * hundred with two keep clicks plus the commander pick. */
+export const HUNDRED_PILE = `1 Atraxa, Praetors' Voice
+59 Forest
+40 Island`;
+
+/** A pile whose trailing blank-line group would trigger the parser's
+ * commander-inference heuristic if the Crucible didn't flatten it. */
+export const TRAILING_COMMANDER_PILE = `1 Sol Ring
+1 Command Tower
+1 Cultivate
+
+1 Ezuri, Stalker of Spheres`;
+
+/**
+ * Mock GET /api/commander-rules so crucible tests never hit Scryfall.
+ * Shape mirrors the real route: banned names + game-changer cards.
+ */
+export async function mockCommanderRules(page: Page) {
+  await page.route("**/api/commander-rules", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        banned: ["Black Lotus"],
+        gameChangers: [
+          { name: "Atraxa, Praetors' Voice", oracleText: "" },
+        ],
+      }),
+    })
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page object
+// ---------------------------------------------------------------------------
+
+export class CruciblePage {
+  constructor(public readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto("/crucible");
+  }
+
+  get pileTextarea() {
+    return this.page.getByLabel("Card pile");
+  }
+
+  get submitButton() {
+    return this.page.getByRole("button", { name: "Begin Refinement" });
+  }
+
+  get workbench() {
+    return this.page.getByTestId("crucible-workbench");
+  }
+
+  get poolCount() {
+    return this.page.getByTestId("crucible-pool-count");
+  }
+
+  get commanderPicker() {
+    return this.page.getByTestId("crucible-commander-picker");
+  }
+
+  get tracker() {
+    return this.page.getByTestId("crucible-tracker");
+  }
+
+  get keptCount() {
+    return this.page.getByTestId("crucible-kept-count");
+  }
+
+  get sealButton() {
+    return this.page.getByRole("button", { name: /seal the deck/i });
+  }
+
+  /** Import a pile end-to-end and wait for the workbench. */
+  async importPile(text: string) {
+    await this.goto();
+    await this.pileTextarea.fill(text);
+    await this.submitButton.click();
+    await this.workbench.waitFor({ timeout: 15_000 });
+  }
+
+  row(name: string) {
+    return this.page.getByTestId(`crucible-row-${name}`);
+  }
+
+  keepButton(name: string) {
+    return this.page.getByRole("button", { name: `Keep ${name}`, exact: true });
+  }
+
+  cutButton(name: string) {
+    return this.page.getByRole("button", { name: `Cut ${name}`, exact: true });
+  }
+
+  restoreButton(name: string) {
+    return this.page.getByRole("button", { name: `Restore ${name}`, exact: true });
+  }
+
+  /** Select a lens or insight view in the sidebar. */
+  async selectLens(label: string) {
+    await this.page
+      .getByTestId("crucible-lens-switcher")
+      .getByRole("button", { name: label })
+      .click();
+  }
+
+  async chooseCommander(name: string) {
+    await this.page
+      .getByRole("button", { name: `Choose ${name}`, exact: true })
+      .click();
+  }
+}
+
+/**
+ * Crucible test fixture. Depends on `deckPage` so the base fixture's route
+ * mocks (/api/deck-enrich fixture bank, empty /api/deck-combos) and the
+ * ritual-floor skip are active — Playwright fixtures are lazy, so a test
+ * that only destructures `page` would otherwise hit the live APIs.
+ */
+export const test = deckTest.extend<{ crucible: CruciblePage }>({
+  crucible: async ({ page, deckPage }, provide) => {
+    void deckPage;
+    await provide(new CruciblePage(page));
+  },
+});
+
+export { expect };

--- a/e2e/crucible-helpers.ts
+++ b/e2e/crucible-helpers.ts
@@ -34,6 +34,12 @@ export const PARTNER_PILE = `${SAMPLE_PILE}
 1 Thrasios, Triton Hero
 1 Tymna the Weaver`;
 
+/** A Choose-a-Background commander, its Background, and 98 basics — pairable
+ * in the picker and sealable as a legal hundred. */
+export const BACKGROUND_PILE = `1 Wilson, Refined Grizzly
+1 Raised by Giants
+98 Forest`;
+
 /** A pile whose trailing blank-line group would trigger the parser's
  * commander-inference heuristic if the Crucible didn't flatten it. */
 export const TRAILING_COMMANDER_PILE = `1 Sol Ring

--- a/e2e/crucible-helpers.ts
+++ b/e2e/crucible-helpers.ts
@@ -28,6 +28,12 @@ export const HUNDRED_PILE = `1 Atraxa, Praetors' Voice
 59 Forest
 40 Island`;
 
+/** SAMPLE_PILE plus the Thrasios/Tymna Partner pair, for two-commander
+ * selection tests. Atraxa and Ezuri stay in as non-partner legendaries. */
+export const PARTNER_PILE = `${SAMPLE_PILE}
+1 Thrasios, Triton Hero
+1 Tymna the Weaver`;
+
 /** A pile whose trailing blank-line group would trigger the parser's
  * commander-inference heuristic if the Crucible didn't flatten it. */
 export const TRAILING_COMMANDER_PILE = `1 Sol Ring

--- a/e2e/crucible-import.spec.ts
+++ b/e2e/crucible-import.spec.ts
@@ -74,6 +74,7 @@ test.describe("Crucible pile import", () => {
     await crucible.importPile(TRAILING_COMMANDER_PILE);
 
     await expect(crucible.row("Ezuri, Stalker of Spheres")).toBeVisible();
-    await expect(crucible.commanderPicker).toContainText(/choose a commander/i);
+    // Ezuri is offered as a candidate, not silently promoted to commander.
+    await expect(crucible.commanderTrigger).toContainText(/choose from 1 candidate/i);
   });
 });

--- a/e2e/crucible-import.spec.ts
+++ b/e2e/crucible-import.spec.ts
@@ -1,0 +1,52 @@
+import {
+  test,
+  expect,
+  SAMPLE_PILE,
+  TRAILING_COMMANDER_PILE,
+  mockCommanderRules,
+} from "./crucible-helpers";
+
+test.describe("Crucible pile import", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+  });
+
+  test("renders the import form with the eyebrow pattern and nav entry", async ({ page, crucible }) => {
+    await crucible.goto();
+
+    await expect(page.getByTestId("section-header-crucible")).toBeVisible();
+    await expect(crucible.pileTextarea).toBeVisible();
+    await expect(crucible.submitButton).toBeVisible();
+    await expect(
+      page.getByRole("navigation", { name: /main navigation/i }).getByRole("link", { name: "The Crucible" })
+    ).toBeVisible();
+  });
+
+  test("pasting a pile shows the cosmic loader, then the workbench with every card undecided", async ({ page, crucible }) => {
+    // Delay enrichment so the loader is observable, then fall through to the
+    // fixture-bank mock registered by the deckPage fixture.
+    await page.route("**/api/deck-enrich", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 600));
+      await route.fallback();
+    });
+
+    await crucible.goto();
+    await crucible.pileTextarea.fill(SAMPLE_PILE);
+    await crucible.submitButton.click();
+
+    await expect(page.getByTestId("cosmic-loader")).toBeVisible();
+    await crucible.workbench.waitFor({ timeout: 15_000 });
+
+    await expect(crucible.poolCount).toContainText("16");
+    await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "false");
+    await expect(crucible.cutButton("Sol Ring")).toHaveAttribute("aria-pressed", "false");
+    await expect(crucible.keptCount).toContainText("0");
+  });
+
+  test("a trailing blank-line group stays in the pool instead of becoming the commander", async ({ crucible }) => {
+    await crucible.importPile(TRAILING_COMMANDER_PILE);
+
+    await expect(crucible.row("Ezuri, Stalker of Spheres")).toBeVisible();
+    await expect(crucible.commanderPicker).toContainText(/choose a commander/i);
+  });
+});

--- a/e2e/crucible-import.spec.ts
+++ b/e2e/crucible-import.spec.ts
@@ -4,6 +4,8 @@ import {
   SAMPLE_PILE,
   TRAILING_COMMANDER_PILE,
   mockCommanderRules,
+  mockAutocomplete,
+  searchAndAdd,
 } from "./crucible-helpers";
 
 test.describe("Crucible pile import", () => {
@@ -41,6 +43,31 @@ test.describe("Crucible pile import", () => {
     await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "false");
     await expect(crucible.cutButton("Sol Ring")).toHaveAttribute("aria-pressed", "false");
     await expect(crucible.keptCount).toContainText("0");
+  });
+
+  test("the import form builds the pile via card search, bumping repeats", async ({ page, crucible }) => {
+    await mockAutocomplete(page);
+    await crucible.goto();
+
+    await searchAndAdd(page, "Sol R", "Sol Ring");
+    await expect(crucible.pileTextarea).toHaveValue("1 Sol Ring");
+
+    await searchAndAdd(page, "Birds", "Birds of Paradise");
+    await expect(crucible.pileTextarea).toHaveValue(
+      "1 Sol Ring\n1 Birds of Paradise"
+    );
+
+    // Selecting the same card again bumps the line instead of duplicating it.
+    await searchAndAdd(page, "Sol R", "Sol Ring");
+    await expect(crucible.pileTextarea).toHaveValue(
+      "2 Sol Ring\n1 Birds of Paradise"
+    );
+
+    // The searched-up pile imports like any pasted list.
+    await crucible.submitButton.click();
+    await crucible.workbench.waitFor({ timeout: 15_000 });
+    await expect(crucible.poolCount).toContainText("3");
+    await expect(crucible.row("Birds of Paradise").first()).toBeVisible();
   });
 
   test("a trailing blank-line group stays in the pool instead of becoming the commander", async ({ crucible }) => {

--- a/e2e/crucible-insight.spec.ts
+++ b/e2e/crucible-insight.spec.ts
@@ -1,0 +1,102 @@
+import {
+  test,
+  expect,
+  SAMPLE_PILE,
+  mockCommanderRules,
+} from "./crucible-helpers";
+
+const FAKE_COMBO = {
+  id: "test-combo-1",
+  cards: ["Sol Ring", "Counterspell"],
+  description: "A purely hypothetical engine for testing.",
+  produces: ["Infinite testing"],
+  missingCards: [],
+  templateRequirements: [],
+  manaNeeded: "",
+  bracketTag: "",
+  identity: "wu",
+  type: "exact",
+};
+
+test.describe("Crucible insight panels", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+  });
+
+  test("Charts renders curve and pip coverage for the kept subset with a pool toggle", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+    await crucible.keepButton("Sol Ring").click();
+
+    await crucible.selectLens("Charts");
+    const charts = page.getByTestId("crucible-charts");
+    await expect(charts).toBeVisible();
+    await expect(charts).toContainText(/mana curve/i);
+    await expect(charts).toContainText(/pip coverage/i);
+
+    const poolToggle = charts.getByRole("button", { name: /pool/i });
+    await expect(poolToggle).toHaveAttribute("aria-pressed", "false");
+    await poolToggle.click();
+    await expect(poolToggle).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("Combos derive intact, possible, and broken states from triage", async ({ page, crucible }) => {
+    await page.route("**/api/deck-combos", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ exactCombos: [FAKE_COMBO], nearCombos: [] }),
+      })
+    );
+
+    await crucible.importPile(SAMPLE_PILE);
+    await crucible.selectLens("Combos in Pile");
+
+    const combos = page.getByTestId("crucible-combos");
+    await expect(combos).toContainText("Sol Ring");
+    await expect(combos).toContainText(/possible/i);
+
+    await crucible.selectLens("By Category");
+    await crucible.keepButton("Sol Ring").click();
+    await crucible.keepButton("Counterspell").click();
+    await crucible.selectLens("Combos in Pile");
+    await expect(combos).toContainText(/intact/i);
+
+    await crucible.selectLens("By Category");
+    await crucible.cutButton("Counterspell").click();
+    await crucible.selectLens("Combos in Pile");
+    await expect(combos).toContainText(/broken/i);
+    await combos.getByRole("button", { name: "Restore Counterspell" }).click();
+    await expect(combos).not.toContainText(/broken/i);
+  });
+
+  test("Suggested Cuts ranks off-identity cards with reasons; accepting cuts, dismissing hides", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+    await crucible.chooseCommander("Atraxa, Praetors' Voice");
+
+    await crucible.selectLens("Suggested Cuts");
+    const suggestions = page.getByTestId("crucible-suggested-cuts");
+    await expect(suggestions).toContainText("Lightning Bolt");
+    await expect(suggestions).toContainText(/off-identity/i);
+
+    await suggestions.getByRole("button", { name: "Cut Lightning Bolt" }).click();
+    await expect(suggestions).not.toContainText("Lightning Bolt");
+
+    // Dismissing removes without cutting.
+    const dismissable = suggestions.getByRole("button", { name: /^Dismiss / }).first();
+    if (await dismissable.isVisible()) {
+      const label = await dismissable.getAttribute("aria-label");
+      const name = label?.replace(/^Dismiss /, "") ?? "";
+      await dismissable.click();
+      await expect(suggestions).not.toContainText(name);
+    }
+  });
+
+  test("Game Changers lens lists flagged cards with the kept count", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.selectLens("Game Changers");
+    const panel = page.getByTestId("crucible-groups");
+    await expect(crucible.row("Atraxa, Praetors' Voice")).toBeVisible();
+    await expect(panel).not.toContainText("Counterspell");
+  });
+});

--- a/e2e/crucible-insight.spec.ts
+++ b/e2e/crucible-insight.spec.ts
@@ -69,6 +69,33 @@ test.describe("Crucible insight panels", () => {
     await expect(combos).not.toContainText(/broken/i);
   });
 
+  test("Keep all flips every undecided combo piece to keep in one click", async ({ page, crucible }) => {
+    await page.route("**/api/deck-combos", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          exactCombos: [
+            {
+              ...FAKE_COMBO,
+              cards: ["Sol Ring", "Counterspell", "Arcane Signet"],
+            },
+          ],
+          nearCombos: [],
+        }),
+      })
+    );
+
+    await crucible.importPile(SAMPLE_PILE);
+    await crucible.selectLens("Combos in Pile");
+
+    const combos = page.getByTestId("crucible-combos");
+    await combos.getByRole("button", { name: "Keep all 3" }).click();
+
+    await expect(combos).toContainText(/intact/i);
+    await expect(crucible.keptCount).toContainText("3");
+  });
+
   test("Suggested Cuts ranks off-identity cards with reasons; accepting cuts, dismissing hides", async ({ page, crucible }) => {
     await crucible.importPile(SAMPLE_PILE);
     await crucible.chooseCommander("Atraxa, Praetors' Voice");

--- a/e2e/crucible-legality.spec.ts
+++ b/e2e/crucible-legality.spec.ts
@@ -1,0 +1,53 @@
+import {
+  test,
+  expect,
+  SAMPLE_PILE,
+  HUNDRED_PILE,
+  mockCommanderRules,
+} from "./crucible-helpers";
+
+test.describe("Crucible tracker and legality gate", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+  });
+
+  test("rail shows kept count, category health, and the legality checklist", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await expect(crucible.tracker).toBeVisible();
+    await expect(crucible.keptCount).toContainText("0");
+    await expect(crucible.tracker).toContainText(/legality/i);
+    await expect(crucible.sealButton).toBeDisabled();
+
+    await crucible.keepButton("Sol Ring").click();
+    await expect(crucible.keptCount).toContainText("1");
+    await expect(page.getByTestId("crucible-category-health")).toBeVisible();
+  });
+
+  test("Seal the Deck enables only when the kept hundred is legal", async ({ crucible }) => {
+    await crucible.importPile(HUNDRED_PILE);
+
+    await crucible.chooseCommander("Atraxa, Praetors' Voice");
+    await crucible.keepButton("Forest").click();
+    await expect(crucible.sealButton).toBeDisabled();
+
+    await crucible.keepButton("Island").click();
+    await expect(crucible.keptCount).toContainText("100");
+    await expect(crucible.sealButton).toBeEnabled();
+
+    // Cutting below 100 disables it again.
+    await crucible.cutButton("Island").click();
+    await expect(crucible.sealButton).toBeDisabled();
+  });
+
+  test("below 768px the tracker moves into a bottom sheet", async ({ page, crucible }) => {
+    await page.setViewportSize({ width: 500, height: 900 });
+    await crucible.importPile(SAMPLE_PILE);
+
+    await expect(crucible.tracker).toBeHidden();
+    await page.getByRole("button", { name: /open tracker/i }).click();
+    const sheet = page.getByRole("dialog");
+    await expect(sheet).toBeVisible();
+    await expect(sheet.getByTestId("crucible-kept-count")).toContainText("0");
+  });
+});

--- a/e2e/crucible-triage.spec.ts
+++ b/e2e/crucible-triage.spec.ts
@@ -2,6 +2,7 @@ import {
   test,
   expect,
   SAMPLE_PILE,
+  HUNDRED_PILE,
   mockCommanderRules,
 } from "./crucible-helpers";
 
@@ -79,6 +80,50 @@ test.describe("Crucible triage", () => {
     await expect(crucible.commanderPicker).toContainText("Atraxa, Praetors' Voice");
     // Lightning Bolt (R) is outside Atraxa's WUBG identity.
     await expect(crucible.row("Lightning Bolt").first()).toContainText(/off-identity/i);
+  });
+
+  test("stacked rows keep a partial count via the kept-copies input", async ({ page, crucible }) => {
+    await crucible.importPile(HUNDRED_PILE);
+
+    await page.getByLabel("Kept copies of Forest").fill("30");
+    await expect(crucible.keptCount).toContainText("30");
+    await expect(crucible.keepButton("Forest")).toHaveAttribute("aria-pressed", "true");
+
+    // The all-or-nothing buttons still work as shortcuts: toggling keep off
+    // and on again snaps back to the full stack.
+    await crucible.keepButton("Forest").click();
+    await expect(crucible.keptCount).toContainText("0");
+    await crucible.keepButton("Forest").click();
+    await expect(crucible.keptCount).toContainText("59");
+  });
+
+  test("a chosen commander is locked to keep", async ({ crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.chooseCommander("Atraxa, Praetors' Voice");
+    await expect(crucible.keepButton("Atraxa, Praetors' Voice").first()).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    await expect(crucible.cutButton("Atraxa, Praetors' Voice").first()).toBeDisabled();
+    await expect(crucible.keptCount).toContainText("1");
+  });
+
+  test("a second commander can be added and removed", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.chooseCommander("Atraxa, Praetors' Voice");
+    await crucible.chooseCommander("Ezuri, Stalker of Spheres");
+    await expect(crucible.commanderPicker).toContainText("Atraxa, Praetors' Voice");
+    await expect(crucible.commanderPicker).toContainText("Ezuri, Stalker of Spheres");
+
+    await page
+      .getByRole("button", { name: "Remove Ezuri, Stalker of Spheres" })
+      .click();
+    await expect(
+      page.getByRole("button", { name: "Remove Ezuri, Stalker of Spheres" })
+    ).toHaveCount(0);
+    await expect(crucible.commanderPicker).toContainText("Atraxa, Praetors' Voice");
   });
 
   test("reloading mid-triage restores statuses from sessionStorage", async ({ page, crucible }) => {

--- a/e2e/crucible-triage.spec.ts
+++ b/e2e/crucible-triage.spec.ts
@@ -4,6 +4,7 @@ import {
   SAMPLE_PILE,
   HUNDRED_PILE,
   PARTNER_PILE,
+  BACKGROUND_PILE,
   mockCommanderRules,
 } from "./crucible-helpers";
 
@@ -146,6 +147,28 @@ test.describe("Crucible triage", () => {
     await expect(
       page.getByRole("button", { name: "Choose Ezuri, Stalker of Spheres" })
     ).toHaveCount(0);
+  });
+
+  test("a Background pairs with its Choose-a-Background commander and seals legal", async ({ page, crucible }) => {
+    await crucible.importPile(BACKGROUND_PILE);
+
+    // A Background is never offered as a solo commander.
+    await expect(
+      page.getByRole("button", { name: "Choose Wilson, Refined Grizzly" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Choose Raised by Giants" })
+    ).toHaveCount(0);
+
+    await crucible.chooseCommander("Wilson, Refined Grizzly");
+    await expect(crucible.commanderPicker).toContainText("Add a partner");
+    await crucible.chooseCommander("Raised by Giants");
+    await expect(crucible.commanderPicker).toContainText("Wilson, Refined Grizzly");
+    await expect(crucible.commanderPicker).toContainText("Raised by Giants");
+
+    await crucible.keepButton("Forest").click();
+    await expect(crucible.keptCount).toContainText("100");
+    await expect(crucible.sealButton).toBeEnabled();
   });
 
   test("reloading mid-triage restores statuses from sessionStorage", async ({ page, crucible }) => {

--- a/e2e/crucible-triage.spec.ts
+++ b/e2e/crucible-triage.spec.ts
@@ -1,0 +1,104 @@
+import {
+  test,
+  expect,
+  SAMPLE_PILE,
+  mockCommanderRules,
+} from "./crucible-helpers";
+
+test.describe("Crucible triage", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+  });
+
+  test("keep and cut toggles update row state and the kept counter", async ({ crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.keepButton("Sol Ring").click();
+    await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "true");
+    await expect(crucible.keptCount).toContainText("1");
+
+    await crucible.cutButton("Counterspell").click();
+    await expect(crucible.cutButton("Counterspell")).toHaveAttribute("aria-pressed", "true");
+    await expect(crucible.keptCount).toContainText("1");
+
+    // Toggling keep off returns the card to undecided.
+    await crucible.keepButton("Sol Ring").click();
+    await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "false");
+    await expect(crucible.keptCount).toContainText("0");
+  });
+
+  test("cut rows stay visible dimmed, collect in the Cut Pile, and restore", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.cutButton("Counterspell").click();
+    await expect(crucible.row("Counterspell").first()).toHaveAttribute("data-status", "cut");
+
+    await crucible.selectLens("Cut Pile");
+    await expect(crucible.row("Counterspell")).toBeVisible();
+    await crucible.restoreButton("Counterspell").click();
+    await expect(page.getByTestId("crucible-cut-pile")).not.toContainText("Counterspell");
+  });
+
+  test("lens switching regroups without losing statuses", async ({ crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.keepButton("Sol Ring").click();
+    await crucible.selectLens("By Type Line");
+    await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("category groups collapse and the undecided filter hides decided rows", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    // Collapse the Lands group.
+    const landsToggle = page.getByRole("button", { name: /lands group/i });
+    await expect(landsToggle).toHaveAttribute("aria-expanded", "true");
+    await landsToggle.click();
+    await expect(landsToggle).toHaveAttribute("aria-expanded", "false");
+    await expect(crucible.row("Forest")).toHaveCount(0);
+
+    // Undecided-only filter hides kept rows.
+    await crucible.keepButton("Sol Ring").click();
+    await page.getByRole("button", { name: /undecided only/i }).click();
+    await expect(crucible.row("Sol Ring")).toHaveCount(0);
+    await page.getByRole("button", { name: /undecided only/i }).click();
+    await expect(crucible.row("Sol Ring").first()).toBeVisible();
+  });
+
+  test("commander picker lists legal commanders and flags off-identity cards", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await expect(
+      page.getByRole("button", { name: "Choose Atraxa, Praetors' Voice" })
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Choose Ezuri, Stalker of Spheres" })
+    ).toBeVisible();
+
+    await crucible.chooseCommander("Atraxa, Praetors' Voice");
+    await expect(crucible.commanderPicker).toContainText("Atraxa, Praetors' Voice");
+    // Lightning Bolt (R) is outside Atraxa's WUBG identity.
+    await expect(crucible.row("Lightning Bolt").first()).toContainText(/off-identity/i);
+  });
+
+  test("reloading mid-triage restores statuses from sessionStorage", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.keepButton("Sol Ring").click();
+    await crucible.cutButton("Counterspell").click();
+
+    await page.reload();
+    await crucible.workbench.waitFor({ timeout: 15_000 });
+    await expect(crucible.keepButton("Sol Ring")).toHaveAttribute("aria-pressed", "true");
+    await expect(crucible.cutButton("Counterspell")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  test("hovering a card name reveals its preview", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.row("Sol Ring").first().getByTestId("crucible-card-name").hover();
+    const preview = page.getByTestId("crucible-card-preview");
+    await expect(preview).toBeVisible();
+    await expect(preview).toContainText("Artifact");
+  });
+});

--- a/e2e/crucible-triage.spec.ts
+++ b/e2e/crucible-triage.spec.ts
@@ -68,9 +68,17 @@ test.describe("Crucible triage", () => {
     await expect(crucible.row("Sol Ring").first()).toBeVisible();
   });
 
-  test("commander picker lists legal commanders and flags off-identity cards", async ({ page, crucible }) => {
+  test("commander candidates live in a popover, not inline in the header", async ({ page, crucible }) => {
     await crucible.importPile(SAMPLE_PILE);
 
+    // Candidates are collapsed behind a fixed-height trigger — nothing
+    // renders inline in the header until the popover opens.
+    await expect(
+      page.getByRole("button", { name: "Choose Atraxa, Praetors' Voice" })
+    ).toHaveCount(0);
+    await expect(crucible.commanderTrigger).toContainText(/choose from 2 candidates/i);
+
+    await crucible.openCommanderPopover();
     await expect(
       page.getByRole("button", { name: "Choose Atraxa, Praetors' Voice" })
     ).toBeVisible();
@@ -79,9 +87,32 @@ test.describe("Crucible triage", () => {
     ).toBeVisible();
 
     await crucible.chooseCommander("Atraxa, Praetors' Voice");
+    await expect(crucible.commanderPopover).toHaveCount(0);
     await expect(crucible.commanderPicker).toContainText("Atraxa, Praetors' Voice");
     // Lightning Bolt (R) is outside Atraxa's WUBG identity.
     await expect(crucible.row("Lightning Bolt").first()).toContainText(/off-identity/i);
+  });
+
+  test("the commander popover filters candidates and closes on Escape", async ({ page, crucible }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await crucible.openCommanderPopover();
+    await page.getByLabel("Filter commander candidates").fill("ezuri");
+    await expect(
+      page.getByRole("button", { name: "Choose Atraxa, Praetors' Voice" })
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Choose Ezuri, Stalker of Spheres" })
+    ).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(crucible.commanderPopover).toHaveCount(0);
+
+    // Reopening starts from a clean, unfiltered list.
+    await crucible.openCommanderPopover();
+    await expect(
+      page.getByRole("button", { name: "Choose Atraxa, Praetors' Voice" })
+    ).toBeVisible();
   });
 
   test("stacked rows keep a partial count via the kept-copies input", async ({ page, crucible }) => {
@@ -116,6 +147,7 @@ test.describe("Crucible triage", () => {
 
     await crucible.chooseCommander("Thrasios, Triton Hero");
     await expect(crucible.commanderPicker).toContainText("Add a partner");
+    await crucible.openCommanderPopover();
     await expect(
       page.getByRole("button", { name: "Choose Tymna the Weaver" })
     ).toBeVisible();
@@ -153,6 +185,7 @@ test.describe("Crucible triage", () => {
     await crucible.importPile(BACKGROUND_PILE);
 
     // A Background is never offered as a solo commander.
+    await crucible.openCommanderPopover();
     await expect(
       page.getByRole("button", { name: "Choose Wilson, Refined Grizzly" })
     ).toBeVisible();

--- a/e2e/crucible-triage.spec.ts
+++ b/e2e/crucible-triage.spec.ts
@@ -3,6 +3,7 @@ import {
   expect,
   SAMPLE_PILE,
   HUNDRED_PILE,
+  PARTNER_PILE,
   mockCommanderRules,
 } from "./crucible-helpers";
 
@@ -109,21 +110,42 @@ test.describe("Crucible triage", () => {
     await expect(crucible.keptCount).toContainText("1");
   });
 
-  test("a second commander can be added and removed", async ({ page, crucible }) => {
+  test("a legal Partner pair can be selected and removed; non-partners are not offered", async ({ page, crucible }) => {
+    await crucible.importPile(PARTNER_PILE);
+
+    await crucible.chooseCommander("Thrasios, Triton Hero");
+    await expect(crucible.commanderPicker).toContainText("Add a partner");
+    await expect(
+      page.getByRole("button", { name: "Choose Tymna the Weaver" })
+    ).toBeVisible();
+    // Atraxa and Ezuri are legal solo commanders but have no Partner ability,
+    // so they must not be offered as a second commander.
+    await expect(
+      page.getByRole("button", { name: "Choose Atraxa, Praetors' Voice" })
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Choose Ezuri, Stalker of Spheres" })
+    ).toHaveCount(0);
+
+    await crucible.chooseCommander("Tymna the Weaver");
+    await expect(crucible.commanderPicker).toContainText("Thrasios, Triton Hero");
+    await expect(crucible.commanderPicker).toContainText("Tymna the Weaver");
+
+    await page.getByRole("button", { name: "Remove Tymna the Weaver" }).click();
+    await expect(
+      page.getByRole("button", { name: "Remove Tymna the Weaver" })
+    ).toHaveCount(0);
+    await expect(crucible.commanderPicker).toContainText("Thrasios, Triton Hero");
+  });
+
+  test("a non-partner second commander cannot be chosen from the picker", async ({ page, crucible }) => {
     await crucible.importPile(SAMPLE_PILE);
 
     await crucible.chooseCommander("Atraxa, Praetors' Voice");
-    await crucible.chooseCommander("Ezuri, Stalker of Spheres");
-    await expect(crucible.commanderPicker).toContainText("Atraxa, Praetors' Voice");
-    await expect(crucible.commanderPicker).toContainText("Ezuri, Stalker of Spheres");
-
-    await page
-      .getByRole("button", { name: "Remove Ezuri, Stalker of Spheres" })
-      .click();
+    await expect(crucible.commanderPicker).not.toContainText("Add a partner");
     await expect(
-      page.getByRole("button", { name: "Remove Ezuri, Stalker of Spheres" })
+      page.getByRole("button", { name: "Choose Ezuri, Stalker of Spheres" })
     ).toHaveCount(0);
-    await expect(crucible.commanderPicker).toContainText("Atraxa, Praetors' Voice");
   });
 
   test("reloading mid-triage restores statuses from sessionStorage", async ({ page, crucible }) => {

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -58,7 +58,16 @@ export class DeckPage {
 
   /** Click a specific import tab by label text */
   async selectTab(tab: "Manual Import" | "Moxfield" | "Archidekt") {
-    await this.page.getByRole("tab", { name: tab }).click();
+    // Under full-suite load the first click can land before React hydration
+    // attaches the handler, silently doing nothing. Re-click until the tab
+    // actually reports selected instead of trusting a single click.
+    const tabButton = this.page.getByRole("tab", { name: tab });
+    await expect(async () => {
+      await tabButton.click();
+      await expect(tabButton).toHaveAttribute("aria-selected", "true", {
+        timeout: 1_000,
+      });
+    }).toPass({ timeout: 15_000 });
   }
 
   // ---------------------------------------------------------------------------

--- a/e2e/fixtures/enriched-cards.ts
+++ b/e2e/fixtures/enriched-cards.ts
@@ -357,6 +357,40 @@ const FIXTURES: PartialEnrichedCard[] = [
     rarity: "mythic",
     manaPips: { G: 1, U: 1 },
   },
+  {
+    name: "Thrasios, Triton Hero",
+    manaCost: "{G}{U}",
+    cmc: 2,
+    colorIdentity: ["G", "U"],
+    colors: ["G", "U"],
+    typeLine: "Legendary Creature — Merfolk Wizard",
+    supertypes: ["Legendary"],
+    subtypes: ["Merfolk", "Wizard"],
+    oracleText:
+      "{4}: Scry 1, then reveal the top card of your library. If it's a land card, put it onto the battlefield tapped. Otherwise, draw a card.\nPartner (You can have two commanders if both have partner.)",
+    keywords: ["Partner"],
+    power: "1",
+    toughness: "3",
+    rarity: "mythic",
+    manaPips: { G: 1, U: 1 },
+  },
+  {
+    name: "Tymna the Weaver",
+    manaCost: "{1}{W}{B}",
+    cmc: 3,
+    colorIdentity: ["W", "B"],
+    colors: ["W", "B"],
+    typeLine: "Legendary Creature — Human Cleric",
+    supertypes: ["Legendary"],
+    subtypes: ["Human", "Cleric"],
+    oracleText:
+      "Lifelink\nAt the beginning of your postcombat main phase, you may pay X life, where X is the number of opponents that were dealt combat damage this turn. If you do, draw X cards.\nPartner (You can have two commanders if both have partner.)",
+    keywords: ["Lifelink", "Partner"],
+    power: "2",
+    toughness: "2",
+    rarity: "mythic",
+    manaPips: { W: 1, B: 1 },
+  },
 
   // ─── Basic + dual lands ─────────────────────────────────────────────────
   {

--- a/e2e/fixtures/enriched-cards.ts
+++ b/e2e/fixtures/enriched-cards.ts
@@ -391,6 +391,38 @@ const FIXTURES: PartialEnrichedCard[] = [
     rarity: "mythic",
     manaPips: { W: 1, B: 1 },
   },
+  {
+    name: "Wilson, Refined Grizzly",
+    manaCost: "{1}{G}",
+    cmc: 2,
+    colorIdentity: ["G"],
+    colors: ["G"],
+    typeLine: "Legendary Creature — Bear",
+    supertypes: ["Legendary"],
+    subtypes: ["Bear"],
+    oracleText:
+      "Vigilance, reach, ward {2}\nChoose a Background (You can have a Background as a second commander.)",
+    keywords: ["Vigilance", "Reach", "Ward"],
+    power: "4",
+    toughness: "4",
+    rarity: "uncommon",
+    manaPips: { G: 1 },
+  },
+  {
+    name: "Raised by Giants",
+    manaCost: "{2}{G}",
+    cmc: 3,
+    colorIdentity: ["G"],
+    colors: ["G"],
+    typeLine: "Legendary Enchantment — Background",
+    supertypes: ["Legendary"],
+    subtypes: ["Background"],
+    oracleText:
+      "Commander creatures you own have base power and toughness 10/10 and have trample.",
+    keywords: ["Trample"],
+    rarity: "rare",
+    manaPips: { G: 1 },
+  },
 
   // ─── Basic + dual lands ─────────────────────────────────────────────────
   {

--- a/scripts/vercel-ignore-build.sh
+++ b/scripts/vercel-ignore-build.sh
@@ -38,20 +38,34 @@ APP_PATHS=(
 # Use Vercel-provided previous SHA, fall back to merge base with master
 PREVIOUS_SHA="${VERCEL_GIT_PREVIOUS_SHA:-}"
 if [ -z "$PREVIOUS_SHA" ]; then
-  # On first push of a branch, compare against the merge base with master
-  # so we see ALL changes in the branch, not just the last commit
+  # Vercel's checkout is shallow, so origin/master usually isn't present yet.
+  # Deepen the clone before asking for a merge-base, so this doesn't silently
+  # degrade to comparing only the last commit (which drops earlier commits'
+  # changes whenever several commits land in one push, e.g. from the
+  # no-mistakes gate).
+  echo "  VERCEL_GIT_PREVIOUS_SHA not set, deriving merge-base with master"
+  git fetch --unshallow origin 2>/dev/null || true
+  # Explicit refspec: a single-branch clone (what Vercel uses) only writes
+  # FETCH_HEAD on a plain "git fetch origin master", not the origin/master
+  # remote-tracking ref that merge-base needs below.
+  git fetch origin +master:refs/remotes/origin/master 2>/dev/null || true
   MERGE_BASE=$(git merge-base origin/master HEAD 2>/dev/null || true)
   if [ -n "$MERGE_BASE" ]; then
-    echo "  VERCEL_GIT_PREVIOUS_SHA not set, using merge-base with master ($MERGE_BASE)"
+    echo "  Using merge-base with master ($MERGE_BASE)"
     PREVIOUS_SHA="$MERGE_BASE"
   else
-    echo "  VERCEL_GIT_PREVIOUS_SHA not set, using HEAD^"
-    PREVIOUS_SHA="HEAD^"
+    echo "  Could not determine merge-base with master - proceeding with build (fail open)"
+    exit 1
   fi
 fi
 
-# Get list of changed files
-CHANGED_FILES=$(git diff --name-only "$PREVIOUS_SHA" HEAD 2>/dev/null || true)
+# Get list of changed files. A failed diff is treated as "unknown" rather
+# than "nothing changed" - fail open so we never silently skip a build.
+if ! CHANGED_FILES=$(git diff --name-only "$PREVIOUS_SHA" HEAD 2>&1); then
+  echo "  git diff against $PREVIOUS_SHA failed - proceeding with build (fail open)"
+  echo "$CHANGED_FILES"
+  exit 1
+fi
 
 if [ -z "$CHANGED_FILES" ]; then
   echo "  No changed files detected — skipping build"

--- a/src/app/api/card-autocomplete/route.ts
+++ b/src/app/api/card-autocomplete/route.ts
@@ -1,3 +1,5 @@
+import { SCRYFALL_REQUEST_HEADERS } from "@/lib/scryfall";
+
 const SCRYFALL_AUTOCOMPLETE = "https://api.scryfall.com/cards/autocomplete";
 
 export async function GET(request: Request): Promise<Response> {
@@ -15,7 +17,7 @@ export async function GET(request: Request): Promise<Response> {
     const res = await fetch(
       `${SCRYFALL_AUTOCOMPLETE}?q=${encodeURIComponent(q)}`,
       {
-        headers: { Accept: "application/json" },
+        headers: SCRYFALL_REQUEST_HEADERS,
         signal: AbortSignal.timeout(10_000),
       }
     );

--- a/src/app/api/deck-enrich/route.ts
+++ b/src/app/api/deck-enrich/route.ts
@@ -4,8 +4,9 @@ import {
   normalizeToEnrichedCard,
 } from "@/lib/scryfall";
 import type { EnrichedCard } from "@/lib/types";
+import { ENRICH_CHUNK_SIZE } from "@/lib/enrich-chunking";
 
-const MAX_UNIQUE_NAMES = 250;
+const MAX_UNIQUE_NAMES = ENRICH_CHUNK_SIZE;
 const MAX_NAME_LENGTH = 200;
 const MAX_IDENTIFIERS = 250;
 

--- a/src/app/crucible/layout.tsx
+++ b/src/app/crucible/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { CrucibleSessionProvider } from "@/contexts/CrucibleSessionContext";
+
+export const metadata: Metadata = {
+  title: "The Crucible · MTG Deck Evaluator",
+  description:
+    "Pour in any pile of cards and refine it down to a legal 100-card Commander deck.",
+};
+
+export default function CrucibleLayout({ children }: { children: ReactNode }) {
+  return <CrucibleSessionProvider>{children}</CrucibleSessionProvider>;
+}

--- a/src/app/crucible/page.tsx
+++ b/src/app/crucible/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import CosmicLoader from "@/components/ritual/CosmicLoader";
+import CrucibleImport from "@/components/crucible/CrucibleImport";
+import CrucibleWorkbench from "@/components/crucible/CrucibleWorkbench";
+import { Button, Card } from "@/components/ui";
+
+export default function CruciblePage() {
+  const {
+    hydration,
+    payload,
+    cardMap,
+    enrichError,
+    enrichProgress,
+    retryEnrichment,
+    clearCrucible,
+  } = useCrucibleSession();
+
+  if (hydration === "pending") return null;
+
+  if (!payload) {
+    return <CrucibleImport />;
+  }
+
+  if (enrichError) {
+    return (
+      <main style={{ maxWidth: 560, margin: "0 auto", padding: "var(--space-16)" }}>
+        <Card
+          variant="outline"
+          eyebrow="THE CRUCIBLE"
+          title="The pile resisted the reading"
+        >
+          <p style={{ color: "var(--ink-secondary)", marginBottom: "var(--space-8)" }}>
+            {enrichError}
+          </p>
+          <div style={{ display: "flex", gap: "var(--space-6)" }}>
+            <Button variant="primary" onClick={retryEnrichment}>
+              Try again
+            </Button>
+            <Button variant="ghost" onClick={clearCrucible}>
+              Start over
+            </Button>
+          </div>
+        </Card>
+      </main>
+    );
+  }
+
+  if (cardMap === null) {
+    const { done, total } = enrichProgress;
+    const tagline =
+      total > 1
+        ? `The pile is being weighed — part ${Math.min(done + 1, total)} of ${total}.`
+        : "The pile is being weighed.";
+    return <CosmicLoader tagline={tagline} />;
+  }
+
+  return <CrucibleWorkbench />;
+}

--- a/src/components/CardSearchInput.tsx
+++ b/src/components/CardSearchInput.tsx
@@ -78,6 +78,7 @@ export default function CardSearchInput({
     if (val.length < 2) {
       setSuggestions([]);
       setIsOpen(false);
+      setSearchError(false);
       return;
     }
 

--- a/src/components/CardSearchInput.tsx
+++ b/src/components/CardSearchInput.tsx
@@ -20,6 +20,7 @@ export default function CardSearchInput({
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
   const [loading, setLoading] = useState(false);
+  const [searchError, setSearchError] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
   const listboxRef = useRef<HTMLUListElement>(null);
@@ -41,6 +42,7 @@ export default function CardSearchInput({
     abortRef.current = controller;
 
     setLoading(true);
+    setSearchError(false);
     try {
       const res = await fetch(
         `/api/card-autocomplete?q=${encodeURIComponent(q)}`,
@@ -48,6 +50,7 @@ export default function CardSearchInput({
       );
       if (!res.ok) {
         setSuggestions([]);
+        setSearchError(true);
         return;
       }
       const json = (await res.json()) as { suggestions: string[] };
@@ -60,6 +63,7 @@ export default function CardSearchInput({
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       setSuggestions([]);
+      setSearchError(true);
     } finally {
       setLoading(false);
     }
@@ -183,6 +187,16 @@ export default function CardSearchInput({
           <div className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
             <div className="h-4 w-4 animate-spin rounded-full border-2 border-slate-500 border-t-purple-400" />
           </div>
+        )}
+
+        {searchError && (
+          <p
+            role="alert"
+            data-testid="card-search-error"
+            className="mt-1 text-xs text-rose-300"
+          >
+            Card search is unavailable right now — try again in a moment.
+          </p>
         )}
 
         {isOpen && suggestions.length > 0 && (

--- a/src/components/crucible/CommanderPicker.tsx
+++ b/src/components/crucible/CommanderPicker.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
 import { isLegalCommander, canPairCommanders } from "@/lib/commander-validation";
-import { Button, Tag } from "@/components/ui";
+import { Button, Input, Popover, Tag } from "@/components/ui";
+import ManaSymbol from "@/components/ManaSymbol";
 import styles from "./crucible.module.css";
-
-const MAX_CANDIDATES_SHOWN = 8;
 
 export default function CommanderPicker() {
   const { payload, cardMap, setCommanders } = useCrucibleSession();
+  const [open, setOpen] = useState(false);
+  const [filter, setFilter] = useState("");
+  const anchorRef = useRef<HTMLDivElement>(null);
 
   const candidates = useMemo(() => {
     if (!payload || !cardMap) return [];
@@ -38,34 +40,70 @@ export default function CommanderPicker() {
   if (!payload) return null;
 
   const commanders = payload.commanders;
+  const options = commanders.length === 0 ? candidates : partnerCandidates;
+  const query = filter.trim().toLowerCase();
+  const filtered = query
+    ? options.filter((name) => name.toLowerCase().includes(query))
+    : options;
 
-  const candidateButtons = (names: string[], label: string) => (
-    <span className={styles.commanderCandidates}>
-      {names.slice(0, MAX_CANDIDATES_SHOWN).map((name) => (
+  const close = () => {
+    setOpen(false);
+    setFilter("");
+  };
+
+  const choose = (name: string) => {
+    setCommanders([...commanders, name]);
+    close();
+  };
+
+  const trigger =
+    commanders.length === 0 ? (
+      candidates.length === 0 ? (
+        <Tag variant="watch">No legal commanders in the pile</Tag>
+      ) : (
         <Button
-          key={name}
           variant="secondary"
           size="sm"
-          aria-label={`Choose ${name}`}
-          onClick={() => setCommanders([...commanders, name])}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+          onClick={() => (open ? close() : setOpen(true))}
         >
-          {name}
+          Choose from {candidates.length}{" "}
+          {candidates.length === 1 ? "candidate" : "candidates"}
+          <span className={styles.commanderCaret} aria-hidden="true">
+            ▾
+          </span>
         </Button>
-      ))}
-      {names.length > MAX_CANDIDATES_SHOWN ? (
-        <span className={styles.commanderMore}>
-          +{names.length - MAX_CANDIDATES_SHOWN} more {label} in the pile
+      )
+    ) : commanders.length === 1 && partnerCandidates.length > 0 ? (
+      <Button
+        variant="ghost"
+        size="sm"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => (open ? close() : setOpen(true))}
+      >
+        Add a partner
+        <span className={styles.commanderCaret} aria-hidden="true">
+          ▾
         </span>
-      ) : null}
-    </span>
-  );
+      </Button>
+    ) : null;
 
-  if (commanders.length > 0) {
-    return (
-      <div data-testid="crucible-commander-picker" className={styles.commanderPicker}>
-        <span className={styles.commanderEyebrow}>
-          {commanders.length === 2 ? "Commanders" : "Commander"}
-        </span>
+  return (
+    <div
+      ref={anchorRef}
+      data-testid="crucible-commander-picker"
+      className={styles.commanderPicker}
+    >
+      <span className={styles.commanderEyebrow}>
+        {commanders.length === 2
+          ? "Commanders"
+          : commanders.length === 1
+            ? "Commander"
+            : "Command zone"}
+      </span>
+      <span className={styles.commanderRow}>
         {commanders.map((name) => (
           <span key={name} className={styles.commanderName}>
             {name}
@@ -79,24 +117,48 @@ export default function CommanderPicker() {
             </Button>
           </span>
         ))}
-        {commanders.length === 1 && partnerCandidates.length > 0 ? (
-          <>
-            <span className={styles.commanderMore}>Add a partner:</span>
-            {candidateButtons(partnerCandidates, "legal partners")}
-          </>
-        ) : null}
-      </div>
-    );
-  }
-
-  return (
-    <div data-testid="crucible-commander-picker" className={styles.commanderPicker}>
-      <span className={styles.commanderEyebrow}>Choose a commander</span>
-      {candidates.length === 0 ? (
-        <Tag variant="watch">No legal commanders in the pile</Tag>
-      ) : (
-        candidateButtons(candidates, "legendaries")
-      )}
+        {trigger}
+      </span>
+      <Popover
+        open={open}
+        onClose={close}
+        anchorRef={anchorRef}
+        ariaLabel={commanders.length === 0 ? "Choose a commander" : "Add a partner"}
+        data-testid="crucible-commander-popover"
+      >
+        <div className={styles.commanderFilter}>
+          <Input
+            aria-label="Filter commander candidates"
+            placeholder="Filter legendaries…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+          />
+        </div>
+        <ul className={styles.commanderOptions}>
+          {filtered.map((name) => (
+            <li key={name}>
+              <button
+                type="button"
+                className={styles.commanderOption}
+                aria-label={`Choose ${name}`}
+                onClick={() => choose(name)}
+              >
+                <span className={styles.commanderOptionPips} aria-hidden="true">
+                  {(cardMap?.[name]?.colorIdentity ?? []).map((color) => (
+                    <ManaSymbol key={color} symbol={color} size="sm" />
+                  ))}
+                </span>
+                <span className={styles.commanderOptionName}>{name}</span>
+              </button>
+            </li>
+          ))}
+          {filtered.length === 0 ? (
+            <li className={styles.commanderNoMatch}>
+              No candidates match &ldquo;{filter.trim()}&rdquo;
+            </li>
+          ) : null}
+        </ul>
+      </Popover>
     </div>
   );
 }

--- a/src/components/crucible/CommanderPicker.tsx
+++ b/src/components/crucible/CommanderPicker.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useMemo } from "react";
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { isLegalCommander } from "@/lib/commander-validation";
+import { Button, Tag } from "@/components/ui";
+import styles from "./crucible.module.css";
+
+const MAX_CANDIDATES_SHOWN = 8;
+
+export default function CommanderPicker() {
+  const { payload, cardMap, setCommanders } = useCrucibleSession();
+
+  const candidates = useMemo(() => {
+    if (!payload || !cardMap) return [];
+    return payload.pool
+      .filter((card) => {
+        const enriched = cardMap[card.name];
+        return enriched ? isLegalCommander(enriched) : false;
+      })
+      .map((card) => card.name);
+  }, [payload, cardMap]);
+
+  if (!payload) return null;
+
+  if (payload.commanders.length > 0) {
+    return (
+      <div data-testid="crucible-commander-picker" className={styles.commanderPicker}>
+        <span className={styles.commanderEyebrow}>Commander</span>
+        <span className={styles.commanderName}>{payload.commanders.join(" + ")}</span>
+        <Button variant="ghost" size="sm" onClick={() => setCommanders([])}>
+          Change commander
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="crucible-commander-picker" className={styles.commanderPicker}>
+      <span className={styles.commanderEyebrow}>Choose a commander</span>
+      {candidates.length === 0 ? (
+        <Tag variant="watch">No legal commanders in the pile</Tag>
+      ) : (
+        <span className={styles.commanderCandidates}>
+          {candidates.slice(0, MAX_CANDIDATES_SHOWN).map((name) => (
+            <Button
+              key={name}
+              variant="secondary"
+              size="sm"
+              aria-label={`Choose ${name}`}
+              onClick={() => setCommanders([name])}
+            >
+              {name}
+            </Button>
+          ))}
+          {candidates.length > MAX_CANDIDATES_SHOWN ? (
+            <span className={styles.commanderMore}>
+              +{candidates.length - MAX_CANDIDATES_SHOWN} more legendaries in the pile
+            </span>
+          ) : null}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/crucible/CommanderPicker.tsx
+++ b/src/components/crucible/CommanderPicker.tsx
@@ -26,11 +26,14 @@ export default function CommanderPicker() {
     if (!payload || !cardMap || payload.commanders.length !== 1) return [];
     const chosen = cardMap[payload.commanders[0]];
     if (!chosen) return [];
-    return candidates.filter((name) => {
-      const enriched = cardMap[name];
-      return enriched ? canPairCommanders(chosen, enriched) : false;
-    });
-  }, [payload, cardMap, candidates]);
+    return payload.pool
+      .filter((card) => {
+        if (payload.commanders.includes(card.name)) return false;
+        const enriched = cardMap[card.name];
+        return enriched ? canPairCommanders(chosen, enriched) : false;
+      })
+      .map((card) => card.name);
+  }, [payload, cardMap]);
 
   if (!payload) return null;
 

--- a/src/components/crucible/CommanderPicker.tsx
+++ b/src/components/crucible/CommanderPicker.tsx
@@ -15,6 +15,7 @@ export default function CommanderPicker() {
     if (!payload || !cardMap) return [];
     return payload.pool
       .filter((card) => {
+        if (payload.commanders.includes(card.name)) return false;
         const enriched = cardMap[card.name];
         return enriched ? isLegalCommander(enriched) : false;
       })
@@ -23,14 +24,54 @@ export default function CommanderPicker() {
 
   if (!payload) return null;
 
-  if (payload.commanders.length > 0) {
+  const commanders = payload.commanders;
+
+  const candidateButtons = (label: string) => (
+    <span className={styles.commanderCandidates}>
+      {candidates.slice(0, MAX_CANDIDATES_SHOWN).map((name) => (
+        <Button
+          key={name}
+          variant="secondary"
+          size="sm"
+          aria-label={`Choose ${name}`}
+          onClick={() => setCommanders([...commanders, name])}
+        >
+          {name}
+        </Button>
+      ))}
+      {candidates.length > MAX_CANDIDATES_SHOWN ? (
+        <span className={styles.commanderMore}>
+          +{candidates.length - MAX_CANDIDATES_SHOWN} more {label} in the pile
+        </span>
+      ) : null}
+    </span>
+  );
+
+  if (commanders.length > 0) {
     return (
       <div data-testid="crucible-commander-picker" className={styles.commanderPicker}>
-        <span className={styles.commanderEyebrow}>Commander</span>
-        <span className={styles.commanderName}>{payload.commanders.join(" + ")}</span>
-        <Button variant="ghost" size="sm" onClick={() => setCommanders([])}>
-          Change commander
-        </Button>
+        <span className={styles.commanderEyebrow}>
+          {commanders.length === 2 ? "Commanders" : "Commander"}
+        </span>
+        {commanders.map((name) => (
+          <span key={name} className={styles.commanderName}>
+            {name}
+            <Button
+              variant="ghost"
+              size="sm"
+              aria-label={`Remove ${name}`}
+              onClick={() => setCommanders(commanders.filter((n) => n !== name))}
+            >
+              Remove
+            </Button>
+          </span>
+        ))}
+        {commanders.length === 1 && candidates.length > 0 ? (
+          <>
+            <span className={styles.commanderMore}>Add a partner:</span>
+            {candidateButtons("legendaries")}
+          </>
+        ) : null}
       </div>
     );
   }
@@ -41,24 +82,7 @@ export default function CommanderPicker() {
       {candidates.length === 0 ? (
         <Tag variant="watch">No legal commanders in the pile</Tag>
       ) : (
-        <span className={styles.commanderCandidates}>
-          {candidates.slice(0, MAX_CANDIDATES_SHOWN).map((name) => (
-            <Button
-              key={name}
-              variant="secondary"
-              size="sm"
-              aria-label={`Choose ${name}`}
-              onClick={() => setCommanders([name])}
-            >
-              {name}
-            </Button>
-          ))}
-          {candidates.length > MAX_CANDIDATES_SHOWN ? (
-            <span className={styles.commanderMore}>
-              +{candidates.length - MAX_CANDIDATES_SHOWN} more legendaries in the pile
-            </span>
-          ) : null}
-        </span>
+        candidateButtons("legendaries")
       )}
     </div>
   );

--- a/src/components/crucible/CommanderPicker.tsx
+++ b/src/components/crucible/CommanderPicker.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
-import { isLegalCommander } from "@/lib/commander-validation";
+import { isLegalCommander, canPairCommanders } from "@/lib/commander-validation";
 import { Button, Tag } from "@/components/ui";
 import styles from "./crucible.module.css";
 
@@ -22,13 +22,23 @@ export default function CommanderPicker() {
       .map((card) => card.name);
   }, [payload, cardMap]);
 
+  const partnerCandidates = useMemo(() => {
+    if (!payload || !cardMap || payload.commanders.length !== 1) return [];
+    const chosen = cardMap[payload.commanders[0]];
+    if (!chosen) return [];
+    return candidates.filter((name) => {
+      const enriched = cardMap[name];
+      return enriched ? canPairCommanders(chosen, enriched) : false;
+    });
+  }, [payload, cardMap, candidates]);
+
   if (!payload) return null;
 
   const commanders = payload.commanders;
 
-  const candidateButtons = (label: string) => (
+  const candidateButtons = (names: string[], label: string) => (
     <span className={styles.commanderCandidates}>
-      {candidates.slice(0, MAX_CANDIDATES_SHOWN).map((name) => (
+      {names.slice(0, MAX_CANDIDATES_SHOWN).map((name) => (
         <Button
           key={name}
           variant="secondary"
@@ -39,9 +49,9 @@ export default function CommanderPicker() {
           {name}
         </Button>
       ))}
-      {candidates.length > MAX_CANDIDATES_SHOWN ? (
+      {names.length > MAX_CANDIDATES_SHOWN ? (
         <span className={styles.commanderMore}>
-          +{candidates.length - MAX_CANDIDATES_SHOWN} more {label} in the pile
+          +{names.length - MAX_CANDIDATES_SHOWN} more {label} in the pile
         </span>
       ) : null}
     </span>
@@ -66,10 +76,10 @@ export default function CommanderPicker() {
             </Button>
           </span>
         ))}
-        {commanders.length === 1 && candidates.length > 0 ? (
+        {commanders.length === 1 && partnerCandidates.length > 0 ? (
           <>
             <span className={styles.commanderMore}>Add a partner:</span>
-            {candidateButtons("legendaries")}
+            {candidateButtons(partnerCandidates, "legal partners")}
           </>
         ) : null}
       </div>
@@ -82,7 +92,7 @@ export default function CommanderPicker() {
       {candidates.length === 0 ? (
         <Tag variant="watch">No legal commanders in the pile</Tag>
       ) : (
-        candidateButtons("legendaries")
+        candidateButtons(candidates, "legendaries")
       )}
     </div>
   );

--- a/src/components/crucible/CrucibleCardRow.tsx
+++ b/src/components/crucible/CrucibleCardRow.tsx
@@ -62,7 +62,6 @@ export default function CrucibleCardRow({
             className={styles.preview}
           >
             {enriched.imageUris ? (
-              // eslint-disable-next-line @next/next/no-img-element -- Scryfall CDN art, sized by CSS
               <img
                 src={enriched.imageUris.normal}
                 alt={`${card.name} card`}

--- a/src/components/crucible/CrucibleCardRow.tsx
+++ b/src/components/crucible/CrucibleCardRow.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import type { DeckCard, EnrichedCard } from "@/lib/types";
+import type { CrucibleCardStatus } from "@/lib/crucible-session";
+import ManaCost from "@/components/ManaCost";
+import { Tag } from "@/components/ui";
+import styles from "./crucible.module.css";
+
+export interface CrucibleCardRowProps {
+  card: DeckCard;
+  enriched?: EnrichedCard;
+  status: CrucibleCardStatus;
+  offIdentity?: boolean;
+  synergyScore?: number;
+  /** Optional lens-specific annotation, e.g. "+2 axes" in the axis lens. */
+  badge?: string;
+  onKeep: () => void;
+  onCut: () => void;
+}
+
+export default function CrucibleCardRow({
+  card,
+  enriched,
+  status,
+  offIdentity,
+  synergyScore,
+  badge,
+  onKeep,
+  onCut,
+}: CrucibleCardRowProps) {
+  const [previewOpen, setPreviewOpen] = useState(false);
+
+  const statusClass =
+    status === "cut" ? styles.rowCut : status === "keep" ? styles.rowKept : "";
+
+  return (
+    <div
+      data-testid={`crucible-row-${card.name}`}
+      data-status={status}
+      className={`${styles.row} ${statusClass}`}
+    >
+      <span className={styles.rowQty}>{card.quantity}</span>
+      <span className={styles.rowNameWrap}>
+        <button
+          type="button"
+          data-testid="crucible-card-name"
+          className={styles.rowName}
+          onMouseEnter={() => setPreviewOpen(true)}
+          onMouseLeave={() => setPreviewOpen(false)}
+          onFocus={() => setPreviewOpen(true)}
+          onBlur={() => setPreviewOpen(false)}
+          onClick={() => setPreviewOpen((open) => !open)}
+          aria-label={`${card.name} details`}
+        >
+          {card.name}
+        </button>
+        {previewOpen && enriched ? (
+          <span
+            data-testid="crucible-card-preview"
+            role="tooltip"
+            className={styles.preview}
+          >
+            {enriched.imageUris ? (
+              // eslint-disable-next-line @next/next/no-img-element -- Scryfall CDN art, sized by CSS
+              <img
+                src={enriched.imageUris.normal}
+                alt={`${card.name} card`}
+                className={styles.previewImage}
+              />
+            ) : (
+              <>
+                <span className={styles.previewName}>{card.name}</span>
+                <span className={styles.previewType}>{enriched.typeLine}</span>
+                {enriched.oracleText ? (
+                  <span className={styles.previewOracle}>{enriched.oracleText}</span>
+                ) : null}
+              </>
+            )}
+          </span>
+        ) : null}
+      </span>
+      {enriched?.manaCost ? <ManaCost cost={enriched.manaCost} /> : null}
+      {badge ? <span className={styles.rowBadge}>{badge}</span> : null}
+      {offIdentity ? <Tag variant="warn">Off-identity</Tag> : null}
+      {synergyScore !== undefined ? (
+        <span className={styles.rowSynergy} aria-label={`Synergy score ${synergyScore}`}>
+          {synergyScore}
+        </span>
+      ) : null}
+      <span className={styles.rowTriage}>
+        <button
+          type="button"
+          className={`${styles.triageButton} ${status === "keep" ? styles.triageKeepOn : ""}`}
+          aria-pressed={status === "keep"}
+          aria-label={`Keep ${card.name}`}
+          onClick={onKeep}
+        >
+          ✓
+        </button>
+        <button
+          type="button"
+          className={`${styles.triageButton} ${status === "cut" ? styles.triageCutOn : ""}`}
+          aria-pressed={status === "cut"}
+          aria-label={`Cut ${card.name}`}
+          onClick={onCut}
+        >
+          ✕
+        </button>
+      </span>
+    </div>
+  );
+}

--- a/src/components/crucible/CrucibleCardRow.tsx
+++ b/src/components/crucible/CrucibleCardRow.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import type { DeckCard, EnrichedCard } from "@/lib/types";
 import type { CrucibleCardStatus } from "@/lib/crucible-session";
 import ManaCost from "@/components/ManaCost";
-import { Tag } from "@/components/ui";
+import { Input, Tag } from "@/components/ui";
 import styles from "./crucible.module.css";
 
 export interface CrucibleCardRowProps {
@@ -15,8 +15,14 @@ export interface CrucibleCardRowProps {
   synergyScore?: number;
   /** Optional lens-specific annotation, e.g. "+2 axes" in the axis lens. */
   badge?: string;
+  /** Commanders are forced to "keep"; their triage controls are disabled. */
+  locked?: boolean;
+  /** Currently kept copies (partial-keep aware). Drives the stepper shown on
+   * stacked rows when onSetKeptQuantity is provided. */
+  keptQuantity?: number;
   onKeep: () => void;
   onCut: () => void;
+  onSetKeptQuantity?: (count: number) => void;
 }
 
 export default function CrucibleCardRow({
@@ -26,8 +32,11 @@ export default function CrucibleCardRow({
   offIdentity,
   synergyScore,
   badge,
+  locked,
+  keptQuantity,
   onKeep,
   onCut,
+  onSetKeptQuantity,
 }: CrucibleCardRowProps) {
   const [previewOpen, setPreviewOpen] = useState(false);
 
@@ -88,11 +97,28 @@ export default function CrucibleCardRow({
         </span>
       ) : null}
       <span className={styles.rowTriage}>
+        {card.quantity > 1 && onSetKeptQuantity ? (
+          <Input
+            type="number"
+            mono
+            min={0}
+            max={card.quantity}
+            value={keptQuantity ?? 0}
+            disabled={locked}
+            aria-label={`Kept copies of ${card.name}`}
+            className={styles.rowKeptQty}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              if (Number.isFinite(next)) onSetKeptQuantity(next);
+            }}
+          />
+        ) : null}
         <button
           type="button"
           className={`${styles.triageButton} ${status === "keep" ? styles.triageKeepOn : ""}`}
           aria-pressed={status === "keep"}
           aria-label={`Keep ${card.name}`}
+          disabled={locked}
           onClick={onKeep}
         >
           ✓
@@ -102,6 +128,7 @@ export default function CrucibleCardRow({
           className={`${styles.triageButton} ${status === "cut" ? styles.triageCutOn : ""}`}
           aria-pressed={status === "cut"}
           aria-label={`Cut ${card.name}`}
+          disabled={locked}
           onClick={onCut}
         >
           ✕

--- a/src/components/crucible/CrucibleCharts.tsx
+++ b/src/components/crucible/CrucibleCharts.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { buildFinalDeck } from "@/lib/crucible-session";
+import { computeManaCurve } from "@/lib/mana-curve";
+import {
+  computeColorDistribution,
+  computeManaBaseMetrics,
+  MTG_COLORS,
+} from "@/lib/color-distribution";
+import type { DeckData } from "@/lib/types";
+import { CurveConstellation, type ManaCurve } from "@/components/deck/CurveConstellation";
+import { ColorPie } from "@/components/deck/ColorPie";
+import styles from "./crucible.module.css";
+
+type Scope = "kept" | "pool";
+
+export default function CrucibleCharts() {
+  const { payload, cardMap } = useCrucibleSession();
+  const [scope, setScope] = useState<Scope>("kept");
+
+  const deck = useMemo<DeckData | null>(() => {
+    if (!payload) return null;
+    if (scope === "kept") {
+      // Kept + commanders only; cuts (sideboard) excluded.
+      return { ...buildFinalDeck(payload, "Kept"), sideboard: [] };
+    }
+    return {
+      name: "Pool",
+      source: "text",
+      url: "",
+      commanders: [],
+      mainboard: payload.pool,
+      sideboard: [],
+    };
+  }, [payload, scope]);
+
+  const curve = useMemo<ManaCurve | null>(() => {
+    if (!deck || !cardMap) return null;
+    const buckets = computeManaCurve(deck, cardMap);
+    return {
+      buckets: buckets.map((b) => b.permanents + b.nonPermanents) as ManaCurve["buckets"],
+    };
+  }, [deck, cardMap]);
+
+  const distribution = useMemo(() => {
+    if (!deck || !cardMap) return null;
+    return computeColorDistribution(deck, cardMap);
+  }, [deck, cardMap]);
+
+  const metrics = useMemo(() => {
+    if (!deck || !cardMap) return null;
+    return computeManaBaseMetrics(deck, cardMap);
+  }, [deck, cardMap]);
+
+  if (!payload || !cardMap || !curve || !distribution) return null;
+
+  return (
+    <section data-testid="crucible-charts" aria-label="Charts" className={styles.panel}>
+      <div className={styles.chartsHead}>
+        <h2 className={styles.panelTitle}>Charts</h2>
+        <div className={styles.chartsScope} role="group" aria-label="Chart scope">
+          <button
+            type="button"
+            className={`${styles.scopeButton} ${scope === "kept" ? styles.scopeButtonActive : ""}`}
+            aria-pressed={scope === "kept"}
+            onClick={() => setScope("kept")}
+          >
+            Kept
+          </button>
+          <button
+            type="button"
+            className={`${styles.scopeButton} ${scope === "pool" ? styles.scopeButtonActive : ""}`}
+            aria-pressed={scope === "pool"}
+            onClick={() => setScope("pool")}
+          >
+            Pool
+          </button>
+        </div>
+      </div>
+
+      <h3 className={styles.chartsEyebrow}>Mana Curve</h3>
+      <CurveConstellation curve={curve} />
+
+      <div className={styles.chartsSplit}>
+        <div>
+          <h3 className={styles.chartsEyebrow}>Color Pips</h3>
+          <ColorPie distribution={distribution.pips} />
+        </div>
+        <div className={styles.chartsPips}>
+          <h3 className={styles.chartsEyebrow}>Pip Coverage · sources vs pips</h3>
+          {MTG_COLORS.map((color) => {
+            const sources = distribution.sources[color];
+            const pips = distribution.pips[color];
+            if (sources === 0 && pips === 0) return null;
+            const ratio = pips === 0 ? 1 : Math.min(1, sources / pips);
+            return (
+              <div key={color} className={styles.pipRow}>
+                <span className={styles.pipColor}>{color}</span>
+                <span className={styles.pipBar}>
+                  <span
+                    className={styles.pipFill}
+                    style={{ width: `${Math.round(ratio * 100)}%` }}
+                  />
+                </span>
+                <span className={styles.pipValue}>
+                  {sources} src / {pips} pips
+                </span>
+              </div>
+            );
+          })}
+          {metrics ? (
+            <p className={styles.panelMuted}>
+              {metrics.landCount} lands · {metrics.landPercentage.toFixed(0)}% ·
+              avg mana value {metrics.averageCmc.toFixed(2)}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/crucible/CrucibleCombos.tsx
+++ b/src/components/crucible/CrucibleCombos.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import type { SpellbookCombo } from "@/lib/commander-spellbook";
+import type { CruciblePayload } from "@/lib/crucible-session";
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { Tag } from "@/components/ui";
+import styles from "./crucible.module.css";
+
+export type ComboState = "intact" | "possible" | "broken";
+
+/** Derive a combo's live state from triage statuses: every piece kept means
+ * intact, any piece cut means broken, otherwise still possible. Pieces not in
+ * the pool at all (near-combo missing cards) leave the combo "possible". */
+export function comboState(combo: SpellbookCombo, payload: CruciblePayload): ComboState {
+  let allKept = true;
+  for (const piece of combo.cards) {
+    const status = payload.statuses[piece];
+    if (status === "cut") return "broken";
+    if (status !== "keep") allKept = false;
+  }
+  return allKept && combo.cards.length > 0 ? "intact" : "possible";
+}
+
+const STATE_TAG: Record<ComboState, { variant: "ok" | "watch" | "warn"; label: string }> = {
+  intact: { variant: "ok", label: "Intact" },
+  possible: { variant: "watch", label: "Possible" },
+  broken: { variant: "warn", label: "Broken" },
+};
+
+export default function CrucibleCombos() {
+  const { payload, combos, combosLoading, setStatus, restore } = useCrucibleSession();
+
+  if (!payload) return null;
+
+  const allCombos: SpellbookCombo[] = [
+    ...(combos?.exactCombos ?? []),
+    ...(combos?.nearCombos ?? []),
+  ];
+
+  return (
+    <section data-testid="crucible-combos" aria-label="Combos in pile" className={styles.panel}>
+      <h2 className={styles.panelTitle}>Combos in Pile</h2>
+      {combosLoading ? (
+        <p className={styles.panelMuted}>Consulting the Spellbook…</p>
+      ) : allCombos.length === 0 ? (
+        <p className={styles.panelMuted}>No known combos detected in this pile.</p>
+      ) : (
+        <ul className={styles.comboList}>
+          {allCombos.map((combo) => {
+            const state = comboState(combo, payload);
+            const tag = STATE_TAG[state];
+            const cutPieces = combo.cards.filter(
+              (piece) => payload.statuses[piece] === "cut"
+            );
+            const undecidedPieces = combo.cards.filter(
+              (piece) => payload.statuses[piece] === "undecided"
+            );
+            return (
+              <li key={combo.id} className={`${styles.comboRow} ${styles[`combo_${state}`]}`}>
+                <div className={styles.comboHead}>
+                  <Tag variant={tag.variant}>{tag.label}</Tag>
+                  <span className={styles.comboCards}>{combo.cards.join(" + ")}</span>
+                </div>
+                {combo.produces.length > 0 ? (
+                  <p className={styles.comboProduces}>{combo.produces.join(" · ")}</p>
+                ) : null}
+                {state === "possible" && undecidedPieces.length > 0 ? (
+                  <button
+                    type="button"
+                    className={styles.comboAction}
+                    onClick={() => {
+                      for (const piece of undecidedPieces) setStatus(piece, "keep");
+                    }}
+                  >
+                    Keep all {combo.cards.length}
+                  </button>
+                ) : null}
+                {state === "broken"
+                  ? cutPieces.map((piece) => (
+                      <button
+                        key={piece}
+                        type="button"
+                        className={styles.comboAction}
+                        onClick={() => restore(piece)}
+                      >
+                        Restore {piece}
+                      </button>
+                    ))
+                  : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/crucible/CrucibleCombos.tsx
+++ b/src/components/crucible/CrucibleCombos.tsx
@@ -28,7 +28,8 @@ const STATE_TAG: Record<ComboState, { variant: "ok" | "watch" | "warn"; label: s
 };
 
 export default function CrucibleCombos() {
-  const { payload, combos, combosLoading, setStatus, restore } = useCrucibleSession();
+  const { payload, combos, combosLoading, combosUnavailable, setStatus, restore } =
+    useCrucibleSession();
 
   if (!payload) return null;
 
@@ -40,7 +41,13 @@ export default function CrucibleCombos() {
   return (
     <section data-testid="crucible-combos" aria-label="Combos in pile" className={styles.panel}>
       <h2 className={styles.panelTitle}>Combos in Pile</h2>
-      {combosLoading ? (
+      {combosUnavailable ? (
+        <p className={styles.panelMuted}>
+          Combo detection is unavailable for piles this large — the Spellbook
+          lookup caps out at 250 unique cards. Cut the pile down and combos
+          will appear on your next visit here.
+        </p>
+      ) : combosLoading ? (
         <p className={styles.panelMuted}>Consulting the Spellbook…</p>
       ) : allCombos.length === 0 ? (
         <p className={styles.panelMuted}>No known combos detected in this pile.</p>

--- a/src/components/crucible/CrucibleCombos.tsx
+++ b/src/components/crucible/CrucibleCombos.tsx
@@ -28,7 +28,7 @@ const STATE_TAG: Record<ComboState, { variant: "ok" | "watch" | "warn"; label: s
 };
 
 export default function CrucibleCombos() {
-  const { payload, combos, combosLoading, combosOverBy, setStatus, restore } =
+  const { payload, combos, combosLoading, combosOverBy, keepAll, restore } =
     useCrucibleSession();
 
   if (!payload) return null;
@@ -78,9 +78,7 @@ export default function CrucibleCombos() {
                   <button
                     type="button"
                     className={styles.comboAction}
-                    onClick={() => {
-                      for (const piece of undecidedPieces) setStatus(piece, "keep");
-                    }}
+                    onClick={() => keepAll(undecidedPieces)}
                   >
                     Keep all {combo.cards.length}
                   </button>

--- a/src/components/crucible/CrucibleCombos.tsx
+++ b/src/components/crucible/CrucibleCombos.tsx
@@ -28,7 +28,7 @@ const STATE_TAG: Record<ComboState, { variant: "ok" | "watch" | "warn"; label: s
 };
 
 export default function CrucibleCombos() {
-  const { payload, combos, combosLoading, combosUnavailable, setStatus, restore } =
+  const { payload, combos, combosLoading, combosOverBy, setStatus, restore } =
     useCrucibleSession();
 
   if (!payload) return null;
@@ -41,16 +41,19 @@ export default function CrucibleCombos() {
   return (
     <section data-testid="crucible-combos" aria-label="Combos in pile" className={styles.panel}>
       <h2 className={styles.panelTitle}>Combos in Pile</h2>
-      {combosUnavailable ? (
-        <p className={styles.panelMuted}>
-          Combo detection is unavailable for piles this large — the Spellbook
-          lookup caps out at 250 unique cards. Cut the pile down and combos
-          will appear on your next visit here.
+      {combosOverBy > 0 ? (
+        <p data-testid="crucible-combos-gate" className={styles.panelMuted}>
+          Cut {combosOverBy} more unique {combosOverBy === 1 ? "card" : "cards"}{" "}
+          to enable combo detection — the Spellbook lookup covers at most 250
+          unique kept or undecided cards.
         </p>
-      ) : combosLoading ? (
+      ) : null}
+      {combosLoading ? (
         <p className={styles.panelMuted}>Consulting the Spellbook…</p>
       ) : allCombos.length === 0 ? (
-        <p className={styles.panelMuted}>No known combos detected in this pile.</p>
+        combosOverBy > 0 ? null : (
+          <p className={styles.panelMuted}>No known combos detected in this pile.</p>
+        )
       ) : (
         <ul className={styles.comboList}>
           {allCombos.map((combo) => {

--- a/src/components/crucible/CrucibleImport.tsx
+++ b/src/components/crucible/CrucibleImport.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import SectionHeader from "@/components/reading/SectionHeader";
+import { Button, Textarea } from "@/components/ui";
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { flattenPileParse } from "@/lib/crucible-session";
+import type { ParseResult } from "@/lib/decklist-parser";
+import type { DeckData } from "@/lib/types";
+import styles from "./crucible.module.css";
+
+export default function CrucibleImport() {
+  const { setPile } = useCrucibleSession();
+  const [text, setText] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!text.trim() || submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/deck-parse", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        setError(json?.error ?? "Could not read the pile — check the list format.");
+        return;
+      }
+      // The parse API returns the deck flattened: { ...deck, warnings }.
+      const json = (await res.json()) as DeckData & { warnings?: string[] };
+      const parsed: ParseResult = {
+        deck: {
+          name: json.name,
+          source: json.source,
+          url: json.url,
+          commanders: json.commanders ?? [],
+          mainboard: json.mainboard ?? [],
+          sideboard: json.sideboard ?? [],
+        },
+        warnings: json.warnings ?? [],
+      };
+      const { pool, warnings } = flattenPileParse(parsed);
+      if (pool.length === 0) {
+        setError("No cards found in the pile.");
+        return;
+      }
+      setPile(pool, warnings);
+    } catch {
+      setError("Network error — could not reach the parser.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <main className={styles.importMain}>
+      <SectionHeader
+        slug="crucible"
+        eyebrow="The Crucible"
+        title="Pour in the pile"
+        tagline="Any number of cards. No structure required. Walk out with a legal hundred."
+      />
+      <form onSubmit={handleSubmit} className={styles.importForm}>
+        <label htmlFor="crucible-pile" className={styles.importLabel}>
+          Card pile
+        </label>
+        <Textarea
+          id="crucible-pile"
+          mono
+          rows={14}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={"1 Sol Ring\n1 Swords to Plowshares\n12 Plains\n…"}
+        />
+        {error ? (
+          <p role="alert" className={styles.importError}>
+            {error}
+          </p>
+        ) : null}
+        <div className={styles.importActions}>
+          <Button type="submit" variant="primary" disabled={!text.trim() || submitting}>
+            Begin Refinement
+          </Button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/components/crucible/CrucibleImport.tsx
+++ b/src/components/crucible/CrucibleImport.tsx
@@ -1,19 +1,28 @@
 "use client";
 
-import { useState, type FormEvent } from "react";
+import { useCallback, useState, type FormEvent } from "react";
 import SectionHeader from "@/components/reading/SectionHeader";
+import CardSearchInput from "@/components/CardSearchInput";
 import { Button, Textarea } from "@/components/ui";
 import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
-import { flattenPileParse } from "@/lib/crucible-session";
+import { appendCardToPileText, flattenPileParse } from "@/lib/crucible-session";
 import type { ParseResult } from "@/lib/decklist-parser";
 import type { DeckData } from "@/lib/types";
 import styles from "./crucible.module.css";
+
+/** The search excludes nothing: re-selecting a name bumps its line's count. */
+const EMPTY_NAME_SET = new Set<string>();
+const EMPTY_CANDIDATES: string[] = [];
 
 export default function CrucibleImport() {
   const { setPile } = useCrucibleSession();
   const [text, setText] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  const addFromSearch = useCallback((name: string) => {
+    setText((prev) => appendCardToPileText(prev, name));
+  }, []);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -66,6 +75,11 @@ export default function CrucibleImport() {
         tagline="Any number of cards. No structure required. Walk out with a legal hundred."
       />
       <form onSubmit={handleSubmit} className={styles.importForm}>
+        <CardSearchInput
+          deckCardNames={EMPTY_NAME_SET}
+          candidateNames={EMPTY_CANDIDATES}
+          onAddCard={addFromSearch}
+        />
         <label htmlFor="crucible-pile" className={styles.importLabel}>
           Card pile
         </label>

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -15,6 +15,7 @@ import { TEMPLATE_COMMAND_ZONE } from "@/lib/deck-composition";
 import { keptQuantityOf } from "@/lib/crucible-session";
 import type { DeckCard } from "@/lib/types";
 import { Button } from "@/components/ui";
+import CardSearchInput from "@/components/CardSearchInput";
 import LensSwitcher, { type CrucibleLens } from "./LensSwitcher";
 import CrucibleCardRow from "./CrucibleCardRow";
 import CommanderPicker from "./CommanderPicker";
@@ -28,6 +29,13 @@ import styles from "./crucible.module.css";
 /** Rows rendered per group before the "Show all" expansion. Keeps huge piles
  * responsive without a virtualization library. */
 const ROWS_PER_GROUP = 60;
+
+/** Nothing is excluded from the add-card search: re-adding a name already in
+ * the pile bumps its quantity (useful for basics), and singleton legality
+ * flags any illegal duplicates. Stable references keep the input's exclusion
+ * effect from re-running per render. */
+const EMPTY_NAME_SET = new Set<string>();
+const EMPTY_CANDIDATES: string[] = [];
 
 interface RenderGroup {
   id: string;
@@ -43,6 +51,7 @@ export default function CrucibleWorkbench() {
     notFound,
     tagCache,
     synergy,
+    addCard,
     setStatus,
     setKeptQuantity,
   } = useCrucibleSession();
@@ -177,6 +186,13 @@ export default function CrucibleWorkbench() {
           </p>
         </div>
         <CommanderPicker />
+        <div className={styles.addSearch}>
+          <CardSearchInput
+            deckCardNames={EMPTY_NAME_SET}
+            candidateNames={EMPTY_CANDIDATES}
+            onAddCard={addCard}
+          />
+        </div>
       </header>
 
       {notFound.length > 0 && !notFoundDismissed ? (

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -60,7 +60,9 @@ export default function CrucibleWorkbench() {
   const [undecidedOnly, setUndecidedOnly] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
-  const [notFoundDismissed, setNotFoundDismissed] = useState(false);
+  const [dismissedNotFound, setDismissedNotFound] = useState<Set<string>>(
+    () => new Set()
+  );
 
   const commanderIdentity = useMemo<Set<string> | null>(() => {
     if (!payload || !cardMap || payload.commanders.length === 0) return null;
@@ -195,7 +197,7 @@ export default function CrucibleWorkbench() {
         </div>
       </header>
 
-      {notFound.length > 0 && !notFoundDismissed ? (
+      {notFound.some((name) => !dismissedNotFound.has(name)) ? (
         <div
           role="alert"
           data-testid="crucible-notfound-banner"
@@ -212,7 +214,7 @@ export default function CrucibleWorkbench() {
             variant="ghost"
             size="sm"
             aria-label="Dismiss unresolved-names warning"
-            onClick={() => setNotFoundDismissed(true)}
+            onClick={() => setDismissedNotFound(new Set(notFound))}
           >
             Dismiss
           </Button>

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import {
+  groupByCategory,
+  groupBySynergyAxis,
+  groupByTypeLine,
+  groupByManaValue,
+  groupByColorIdentity,
+  gameChangers,
+  UNALIGNED_AXIS_ID,
+} from "@/lib/crucible-grouping";
+import { TEMPLATE_COMMAND_ZONE } from "@/lib/deck-composition";
+import type { DeckCard } from "@/lib/types";
+import LensSwitcher, { type CrucibleLens } from "./LensSwitcher";
+import CrucibleCardRow from "./CrucibleCardRow";
+import CommanderPicker from "./CommanderPicker";
+import TrackerRail from "./TrackerRail";
+import CrucibleCharts from "./CrucibleCharts";
+import CrucibleCombos from "./CrucibleCombos";
+import SuggestedCuts from "./SuggestedCuts";
+import CutPile from "./CutPile";
+import styles from "./crucible.module.css";
+
+/** Rows rendered per group before the "Show all" expansion. Keeps huge piles
+ * responsive without a virtualization library. */
+const ROWS_PER_GROUP = 60;
+
+interface RenderGroup {
+  id: string;
+  label: string;
+  meta?: string;
+  cards: { card: DeckCard; badge?: string }[];
+}
+
+export default function CrucibleWorkbench() {
+  const {
+    payload,
+    cardMap,
+    tagCache,
+    synergy,
+    setStatus,
+  } = useCrucibleSession();
+
+  const [lens, setLens] = useState<CrucibleLens>("category");
+  const [undecidedOnly, setUndecidedOnly] = useState(false);
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+
+  const commanderIdentity = useMemo<Set<string> | null>(() => {
+    if (!payload || !cardMap || payload.commanders.length === 0) return null;
+    const identity = new Set<string>();
+    for (const name of payload.commanders) {
+      for (const color of cardMap[name]?.colorIdentity ?? []) identity.add(color);
+    }
+    return identity;
+  }, [payload, cardMap]);
+
+  const targetByLabel = useMemo(() => {
+    const map = new Map<string, { min: number; max: number }>();
+    for (const category of TEMPLATE_COMMAND_ZONE.categories) {
+      map.set(category.label, { min: category.min, max: category.max });
+      map.set(category.tag, { min: category.min, max: category.max });
+    }
+    return map;
+  }, []);
+
+  const groups = useMemo<RenderGroup[]>(() => {
+    if (!payload || !cardMap) return [];
+    const pool = payload.pool;
+    switch (lens) {
+      case "category":
+        return groupByCategory(pool, cardMap, tagCache ?? undefined).map((group) => {
+          const target = targetByLabel.get(group.label);
+          const kept = group.cards.reduce(
+            (sum, c) => (payload.statuses[c.name] === "keep" ? sum + c.quantity : sum),
+            0
+          );
+          return {
+            id: group.id,
+            label: group.label,
+            meta: `${group.cards.length} candidates · ${kept} kept${
+              target ? ` · target ${target.min}–${target.max}` : ""
+            }`,
+            cards: group.cards.map((card) => ({ card })),
+          };
+        });
+      case "axis":
+        return groupBySynergyAxis(pool, cardMap).map((group) => ({
+          id: `axis:${group.axisId}`,
+          label: group.axisName,
+          meta:
+            group.axisId === UNALIGNED_AXIS_ID
+              ? `${group.cards.length} cards · no strong theme — prime cut fodder`
+              : `pool strength ${group.strength.toFixed(2)} · ${group.cards.length} cards`,
+          cards: group.cards.map((card) => ({
+            card,
+            badge:
+              card.otherAxes.length > 0 ? `+${card.otherAxes.length} axes` : undefined,
+          })),
+        }));
+      case "type":
+        return groupByTypeLine(pool, cardMap).map((group) => ({
+          id: group.id,
+          label: group.label,
+          meta: `${group.cards.length} cards`,
+          cards: group.cards.map((card) => ({ card })),
+        }));
+      case "mv":
+        return groupByManaValue(pool, cardMap).map((group) => ({
+          id: group.id,
+          label: group.label === "Lands" ? "Lands" : `Mana value ${group.label}`,
+          meta: `${group.cards.length} cards`,
+          cards: group.cards.map((card) => ({ card })),
+        }));
+      case "color":
+        return groupByColorIdentity(pool, cardMap).map((group) => ({
+          id: group.id,
+          label: group.label,
+          meta: `${group.cards.length} cards`,
+          cards: group.cards.map((card) => ({ card })),
+        }));
+      case "gamechangers": {
+        const flagged = gameChangers(pool, cardMap);
+        return [
+          {
+            id: "gamechangers",
+            label: "Game Changers",
+            meta: `${flagged.length} flagged · bracket-relevant`,
+            cards: flagged.map((card) => ({ card })),
+          },
+        ];
+      }
+      case "list":
+        return [
+          {
+            id: "all",
+            label: "All Cards",
+            meta: `${pool.length} unique names`,
+            cards: [...pool]
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((card) => ({ card })),
+          },
+        ];
+      default:
+        return [];
+    }
+  }, [payload, cardMap, tagCache, lens, targetByLabel]);
+
+  if (!payload || !cardMap) return null;
+
+  const poolTotal = payload.pool.reduce((sum, c) => sum + c.quantity, 0);
+  const isInsight = lens === "charts" || lens === "combos" || lens === "cuts" || lens === "cutpile";
+
+  const toggleCollapsed = (id: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  return (
+    <main data-testid="crucible-workbench" className={styles.workbench}>
+      <header className={styles.workbenchHead}>
+        <div>
+          <p className={styles.workbenchEyebrow}>The Crucible</p>
+          <p data-testid="crucible-pool-count" className={styles.workbenchCount}>
+            {poolTotal} cards in the pile
+          </p>
+        </div>
+        <CommanderPicker />
+      </header>
+
+      <div className={styles.workbenchGrid}>
+        <LensSwitcher
+          active={lens}
+          onSelect={setLens}
+          undecidedOnly={undecidedOnly}
+          onToggleUndecided={() => setUndecidedOnly((v) => !v)}
+          cutCount={
+            payload.pool.filter((c) => payload.statuses[c.name] === "cut").length
+          }
+        />
+
+        <div className={styles.workbenchMain}>
+          {lens === "charts" ? <CrucibleCharts /> : null}
+          {lens === "combos" ? <CrucibleCombos /> : null}
+          {lens === "cuts" ? <SuggestedCuts /> : null}
+          {lens === "cutpile" ? <CutPile /> : null}
+          {!isInsight ? (
+            <div data-testid="crucible-groups">
+              {groups.map((group) => {
+                const isCollapsed = collapsed.has(group.id);
+                const visibleCards = undecidedOnly
+                  ? group.cards.filter(
+                      ({ card }) =>
+                        (payload.statuses[card.name] ?? "undecided") === "undecided"
+                    )
+                  : group.cards;
+                const isExpanded = expandedGroups.has(group.id);
+                const shownCards = isExpanded
+                  ? visibleCards
+                  : visibleCards.slice(0, ROWS_PER_GROUP);
+                return (
+                  <section key={group.id} className={styles.group}>
+                    <button
+                      type="button"
+                      className={styles.groupHead}
+                      aria-expanded={!isCollapsed}
+                      aria-label={`${group.label} group`}
+                      onClick={() => toggleCollapsed(group.id)}
+                    >
+                      <span className={styles.groupChevron} aria-hidden="true">
+                        {isCollapsed ? "▸" : "▾"}
+                      </span>
+                      <span className={styles.groupLabel}>{group.label}</span>
+                      {group.meta ? (
+                        <span className={styles.groupMeta}>{group.meta}</span>
+                      ) : null}
+                    </button>
+                    {!isCollapsed
+                      ? shownCards.map(({ card, badge }) => (
+                          <CrucibleCardRow
+                            key={card.name}
+                            card={card}
+                            enriched={cardMap[card.name]}
+                            status={payload.statuses[card.name] ?? "undecided"}
+                            offIdentity={
+                              commanderIdentity !== null &&
+                              (cardMap[card.name]?.colorIdentity ?? []).some(
+                                (color) => !commanderIdentity.has(color)
+                              )
+                            }
+                            synergyScore={synergy?.cardScores[card.name]?.score}
+                            badge={badge}
+                            onKeep={() =>
+                              setStatus(
+                                card.name,
+                                payload.statuses[card.name] === "keep"
+                                  ? "undecided"
+                                  : "keep"
+                              )
+                            }
+                            onCut={() =>
+                              setStatus(
+                                card.name,
+                                payload.statuses[card.name] === "cut"
+                                  ? "undecided"
+                                  : "cut"
+                              )
+                            }
+                          />
+                        ))
+                      : null}
+                    {!isCollapsed && visibleCards.length > shownCards.length ? (
+                      <button
+                        type="button"
+                        className={styles.groupShowAll}
+                        onClick={() =>
+                          setExpandedGroups((prev) => new Set(prev).add(group.id))
+                        }
+                      >
+                        Show all {visibleCards.length}
+                      </button>
+                    ) : null}
+                  </section>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+
+        <TrackerRail />
+      </div>
+    </main>
+  );
+}

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -12,7 +12,9 @@ import {
   UNALIGNED_AXIS_ID,
 } from "@/lib/crucible-grouping";
 import { TEMPLATE_COMMAND_ZONE } from "@/lib/deck-composition";
+import { keptQuantityOf } from "@/lib/crucible-session";
 import type { DeckCard } from "@/lib/types";
+import { Button } from "@/components/ui";
 import LensSwitcher, { type CrucibleLens } from "./LensSwitcher";
 import CrucibleCardRow from "./CrucibleCardRow";
 import CommanderPicker from "./CommanderPicker";
@@ -38,15 +40,18 @@ export default function CrucibleWorkbench() {
   const {
     payload,
     cardMap,
+    notFound,
     tagCache,
     synergy,
     setStatus,
+    setKeptQuantity,
   } = useCrucibleSession();
 
   const [lens, setLens] = useState<CrucibleLens>("category");
   const [undecidedOnly, setUndecidedOnly] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [notFoundDismissed, setNotFoundDismissed] = useState(false);
 
   const commanderIdentity = useMemo<Set<string> | null>(() => {
     if (!payload || !cardMap || payload.commanders.length === 0) return null;
@@ -74,7 +79,7 @@ export default function CrucibleWorkbench() {
         return groupByCategory(pool, cardMap, tagCache ?? undefined).map((group) => {
           const target = targetByLabel.get(group.label);
           const kept = group.cards.reduce(
-            (sum, c) => (payload.statuses[c.name] === "keep" ? sum + c.quantity : sum),
+            (sum, c) => sum + keptQuantityOf(payload, c),
             0
           );
           return {
@@ -174,6 +179,30 @@ export default function CrucibleWorkbench() {
         <CommanderPicker />
       </header>
 
+      {notFound.length > 0 && !notFoundDismissed ? (
+        <div
+          role="alert"
+          data-testid="crucible-notfound-banner"
+          className={styles.notFoundBanner}
+        >
+          <span>
+            {notFound.length} {notFound.length === 1 ? "name" : "names"} could
+            not be resolved and {notFound.length === 1 ? "appears" : "appear"}{" "}
+            under &ldquo;Unresolved&rdquo;:{" "}
+            {notFound.slice(0, 8).join(", ")}
+            {notFound.length > 8 ? ` and ${notFound.length - 8} more` : ""}
+          </span>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Dismiss unresolved-names warning"
+            onClick={() => setNotFoundDismissed(true)}
+          >
+            Dismiss
+          </Button>
+        </div>
+      ) : null}
+
       <div className={styles.workbenchGrid}>
         <LensSwitcher
           active={lens}
@@ -228,6 +257,11 @@ export default function CrucibleWorkbench() {
                             card={card}
                             enriched={cardMap[card.name]}
                             status={payload.statuses[card.name] ?? "undecided"}
+                            locked={payload.commanders.includes(card.name)}
+                            keptQuantity={keptQuantityOf(payload, card)}
+                            onSetKeptQuantity={(count) =>
+                              setKeptQuantity(card.name, count)
+                            }
                             offIdentity={
                               commanderIdentity !== null &&
                               (cardMap[card.name]?.colorIdentity ?? []).some(

--- a/src/components/crucible/CutPile.tsx
+++ b/src/components/crucible/CutPile.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { cutCards } from "@/lib/crucible-session";
+import styles from "./crucible.module.css";
+
+export default function CutPile() {
+  const { payload, restore } = useCrucibleSession();
+
+  if (!payload) return null;
+  const cuts = cutCards(payload);
+
+  return (
+    <section data-testid="crucible-cut-pile" aria-label="Cut pile" className={styles.panel}>
+      <h2 className={styles.panelTitle}>Cut Pile · {cuts.length}</h2>
+      <p className={styles.panelMuted}>
+        Cuts are never deleted. Restore any of them, or seal the deck and they become
+        the sideboard.
+      </p>
+      {cuts.length === 0 ? (
+        <p className={styles.panelMuted}>Nothing has been cut yet.</p>
+      ) : (
+        <ul className={styles.suggestionList}>
+          {cuts.map((card) => (
+            <li
+              key={card.name}
+              data-testid={`crucible-row-${card.name}`}
+              data-status="cut"
+              className={styles.suggestionRow}
+            >
+              <span className={styles.rowQty}>{card.quantity}</span>
+              <span className={styles.suggestionName}>{card.name}</span>
+              <button
+                type="button"
+                className={styles.comboAction}
+                aria-label={`Restore ${card.name}`}
+                onClick={() => restore(card.name)}
+              >
+                ↩ Restore
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/crucible/LensSwitcher.tsx
+++ b/src/components/crucible/LensSwitcher.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import styles from "./crucible.module.css";
+
+export type CrucibleLens =
+  | "category"
+  | "axis"
+  | "type"
+  | "mv"
+  | "color"
+  | "list"
+  | "gamechangers"
+  | "charts"
+  | "combos"
+  | "cuts"
+  | "cutpile";
+
+const LENSES: { id: CrucibleLens; label: string }[] = [
+  { id: "category", label: "By Category" },
+  { id: "axis", label: "By Synergy Axis" },
+  { id: "type", label: "By Type Line" },
+  { id: "mv", label: "By Mana Value" },
+  { id: "color", label: "By Color Identity" },
+  { id: "list", label: "Flat List" },
+  { id: "gamechangers", label: "Game Changers" },
+];
+
+const INSIGHTS: { id: CrucibleLens; label: string }[] = [
+  { id: "charts", label: "Charts" },
+  { id: "combos", label: "Combos in Pile" },
+  { id: "cuts", label: "Suggested Cuts" },
+  { id: "cutpile", label: "Cut Pile" },
+];
+
+export interface LensSwitcherProps {
+  active: CrucibleLens;
+  onSelect: (lens: CrucibleLens) => void;
+  undecidedOnly: boolean;
+  onToggleUndecided: () => void;
+  cutCount: number;
+}
+
+export default function LensSwitcher({
+  active,
+  onSelect,
+  undecidedOnly,
+  onToggleUndecided,
+  cutCount,
+}: LensSwitcherProps) {
+  const renderButton = ({ id, label }: { id: CrucibleLens; label: string }) => (
+    <button
+      key={id}
+      type="button"
+      className={`${styles.lensButton} ${active === id ? styles.lensButtonActive : ""}`}
+      aria-pressed={active === id}
+      onClick={() => onSelect(id)}
+    >
+      <span className={styles.lensDot} aria-hidden="true" />
+      {label}
+      {id === "cutpile" && cutCount > 0 ? (
+        <span className={styles.lensCount}>{cutCount}</span>
+      ) : null}
+    </button>
+  );
+
+  return (
+    <nav
+      data-testid="crucible-lens-switcher"
+      aria-label="Crucible lenses"
+      className={styles.lensNav}
+    >
+      <p className={styles.lensEyebrow}>Lenses</p>
+      {LENSES.map(renderButton)}
+      <hr className={styles.lensDivider} />
+      <p className={styles.lensEyebrow}>Insight</p>
+      {INSIGHTS.map(renderButton)}
+      <hr className={styles.lensDivider} />
+      <p className={styles.lensEyebrow}>Filter</p>
+      <button
+        type="button"
+        className={`${styles.lensButton} ${undecidedOnly ? styles.lensButtonActive : ""}`}
+        aria-pressed={undecidedOnly}
+        onClick={onToggleUndecided}
+      >
+        <span className={styles.lensDot} aria-hidden="true" />
+        Undecided only
+      </button>
+    </nav>
+  );
+}

--- a/src/components/crucible/SuggestedCuts.tsx
+++ b/src/components/crucible/SuggestedCuts.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { Tag } from "@/components/ui";
+import styles from "./crucible.module.css";
+
+const MAX_SHOWN = 15;
+
+export default function SuggestedCuts() {
+  const { payload, cutSuggestions, setStatus, dismissSuggestion } = useCrucibleSession();
+
+  if (!payload) return null;
+
+  const shown = cutSuggestions.slice(0, MAX_SHOWN);
+
+  return (
+    <section
+      data-testid="crucible-suggested-cuts"
+      aria-label="Suggested cuts"
+      className={styles.panel}
+    >
+      <h2 className={styles.panelTitle}>Suggested Cuts</h2>
+      <p className={styles.panelMuted}>
+        Ranked by reason — nothing is cut without your click.
+      </p>
+      {payload.commanders.length === 0 ? (
+        <p className={styles.panelMuted}>
+          Choose a commander to unlock off-identity suggestions.
+        </p>
+      ) : null}
+      {shown.length === 0 ? (
+        <p className={styles.panelMuted}>No cuts to suggest right now.</p>
+      ) : (
+        <ul className={styles.suggestionList}>
+          {shown.map((suggestion) => (
+            <li key={suggestion.name} className={styles.suggestionRow}>
+              <span className={styles.suggestionName}>{suggestion.name}</span>
+              <span className={styles.suggestionReasons}>
+                {suggestion.reasons.map((reason) => (
+                  <Tag key={reason} variant="watch">
+                    {reason}
+                  </Tag>
+                ))}
+              </span>
+              <span className={styles.suggestionActions}>
+                <button
+                  type="button"
+                  className={styles.comboAction}
+                  aria-label={`Cut ${suggestion.name}`}
+                  onClick={() => setStatus(suggestion.name, "cut")}
+                >
+                  Cut {suggestion.name}
+                </button>
+                <button
+                  type="button"
+                  className={styles.suggestionDismiss}
+                  aria-label={`Dismiss ${suggestion.name}`}
+                  onClick={() => dismissSuggestion(suggestion.name)}
+                >
+                  –
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {cutSuggestions.length > MAX_SHOWN ? (
+        <p className={styles.panelMuted}>
+          {cutSuggestions.length - MAX_SHOWN} more suggestions below the fold — act on
+          these first.
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/components/crucible/TrackerRail.tsx
+++ b/src/components/crucible/TrackerRail.tsx
@@ -21,6 +21,7 @@ function TrackerContent() {
     keptScorecard,
     legality,
     combos,
+    combosOverBy,
     finalize,
     clearCrucible,
   } = useCrucibleSession();
@@ -99,7 +100,15 @@ function TrackerContent() {
         </div>
       ) : null}
 
-      {comboSummary ? (
+      {combosOverBy > 0 ? (
+        <div className={styles.trackerSection}>
+          <p className={styles.trackerEyebrow}>Combos</p>
+          <p className={styles.trackerLine}>
+            Cut {combosOverBy} more unique {combosOverBy === 1 ? "card" : "cards"} to
+            enable combo detection
+          </p>
+        </div>
+      ) : comboSummary ? (
         <div className={styles.trackerSection}>
           <p className={styles.trackerEyebrow}>Combos</p>
           <p className={styles.trackerLine}>✓ {comboSummary.intact} intact in kept</p>

--- a/src/components/crucible/TrackerRail.tsx
+++ b/src/components/crucible/TrackerRail.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { useDeckSession } from "@/contexts/DeckSessionContext";
+import { generateDeckId, type DeckSessionPayload } from "@/lib/deck-session";
+import { Button, Sheet } from "@/components/ui";
+import { comboState } from "./CrucibleCombos";
+import styles from "./crucible.module.css";
+
+const DEFAULT_DECK_NAME = "Forged in the Crucible";
+
+/** Categories worth a health bar in the rail (targets from the template). */
+const RAIL_CATEGORIES = ["Lands", "Ramp", "Card Draw", "Removal", "Board Wipe"];
+
+function TrackerContent() {
+  const {
+    payload,
+    keptTotal,
+    keptScorecard,
+    legality,
+    combos,
+    finalize,
+    clearCrucible,
+  } = useCrucibleSession();
+  const { setPayload } = useDeckSession();
+  const router = useRouter();
+  const [sealing, setSealing] = useState(false);
+
+  const comboSummary = useMemo(() => {
+    if (!payload || !combos) return null;
+    const all = [...combos.exactCombos, ...combos.nearCombos];
+    if (all.length === 0) return null;
+    const counts = { intact: 0, possible: 0, broken: 0 };
+    for (const combo of all) counts[comboState(combo, payload)]++;
+    return counts;
+  }, [payload, combos]);
+
+  if (!payload) return null;
+
+  const poolTotal = payload.pool.reduce((sum, c) => sum + c.quantity, 0);
+  const canSeal = legality?.isValid === true && !sealing;
+
+  const handleSeal = () => {
+    const deck = finalize(DEFAULT_DECK_NAME);
+    if (!deck) return;
+    setSealing(true);
+    const readingPayload: DeckSessionPayload = {
+      deckId: generateDeckId(),
+      deck,
+      parseWarnings: [],
+      cardMap: null,
+      notFoundCount: 0,
+      spellbookCombos: null,
+      createdAt: Date.now(),
+    };
+    setPayload(readingPayload);
+    clearCrucible();
+    router.push("/ritual");
+  };
+
+  return (
+    <>
+      <p className={styles.trackerEyebrow}>The Reckoning</p>
+      <p data-testid="crucible-kept-count" className={styles.trackerCount}>
+        {keptTotal}
+        <span className={styles.trackerCountOf}> / 100</span>
+      </p>
+      <p className={styles.trackerSub}>cards kept · {poolTotal} in pool</p>
+
+      {keptScorecard ? (
+        <div data-testid="crucible-category-health" className={styles.trackerSection}>
+          <p className={styles.trackerEyebrow}>Category Health</p>
+          {keptScorecard.categories
+            .filter((category) => RAIL_CATEGORIES.includes(category.label))
+            .map((category) => {
+              const ratio =
+                category.min > 0 ? Math.min(1, category.count / category.min) : 1;
+              return (
+                <div key={category.tag} className={styles.trackerCategory}>
+                  <span className={styles.trackerCategoryName}>{category.label}</span>
+                  <span className={styles.trackerBar}>
+                    <span
+                      className={`${styles.trackerBarFill} ${
+                        category.status === "good" || category.status === "high"
+                          ? styles.trackerBarOk
+                          : ""
+                      }`}
+                      style={{ width: `${Math.round(ratio * 100)}%` }}
+                    />
+                  </span>
+                  <span className={styles.trackerCategoryCount}>
+                    {category.count}/{category.min}
+                  </span>
+                </div>
+              );
+            })}
+        </div>
+      ) : null}
+
+      {comboSummary ? (
+        <div className={styles.trackerSection}>
+          <p className={styles.trackerEyebrow}>Combos</p>
+          <p className={styles.trackerLine}>✓ {comboSummary.intact} intact in kept</p>
+          <p className={styles.trackerLine}>◇ {comboSummary.possible} possible in pool</p>
+          <p className={styles.trackerLine}>✕ {comboSummary.broken} broken by cuts</p>
+        </div>
+      ) : null}
+
+      <div className={styles.trackerSection}>
+        <p className={styles.trackerEyebrow}>Legality</p>
+        {legality === null ? (
+          <p className={styles.trackerLine}>Consulting the format rules…</p>
+        ) : legality.isValid ? (
+          <p className={`${styles.trackerLine} ${styles.trackerOk}`}>
+            ✓ Legal Commander deck
+          </p>
+        ) : (
+          legality.errors.slice(0, 4).map((error) => (
+            <p key={error.message} className={`${styles.trackerLine} ${styles.trackerWarn}`}>
+              ✕ {error.message}
+            </p>
+          ))
+        )}
+      </div>
+
+      <Button
+        variant="primary"
+        className={styles.sealButton}
+        disabled={!canSeal}
+        onClick={handleSeal}
+      >
+        Seal the Deck → Reading
+      </Button>
+    </>
+  );
+}
+
+export default function TrackerRail() {
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  return (
+    <>
+      <aside
+        data-testid="crucible-tracker"
+        aria-label="Deck tracker"
+        className={styles.tracker}
+      >
+        <TrackerContent />
+      </aside>
+      <button
+        type="button"
+        className={styles.trackerToggle}
+        onClick={() => setSheetOpen(true)}
+      >
+        Open tracker
+      </button>
+      <Sheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        eyebrow="The Reckoning"
+        title="Deck tracker"
+      >
+        <TrackerContent />
+      </Sheet>
+    </>
+  );
+}

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -49,6 +49,20 @@
   margin-bottom: var(--space-10);
 }
 
+.notFoundBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+  padding: var(--space-4) var(--space-6);
+  margin-bottom: var(--space-8);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--status-watch-soft);
+  color: var(--ink-secondary);
+  font-size: var(--text-sm);
+}
+
 .workbenchEyebrow {
   font-family: var(--font-mono);
   font-size: var(--text-eyebrow);
@@ -325,8 +339,17 @@
 
 .rowTriage {
   display: flex;
+  align-items: center;
   gap: var(--space-2);
   flex-shrink: 0;
+}
+
+.rowKeptQty {
+  width: var(--space-24);
+  height: var(--space-12);
+  padding: 0 var(--space-3);
+  font-size: var(--text-xs);
+  text-align: right;
 }
 
 .triageButton {
@@ -379,6 +402,9 @@
 }
 
 .commanderName {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
   font-family: var(--font-serif);
   font-size: var(--text-h4);
   color: var(--ink-primary);

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -827,3 +827,9 @@
     transition: none;
   }
 }
+
+/* ─── Add-card search ────────────────────────────────────────── */
+.addSearch {
+  flex: 0 1 280px;
+  min-width: 200px;
+}

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -1,0 +1,803 @@
+/* The Crucible — shared styles for the deck-building workbench. */
+
+/* ─── Import ─────────────────────────────────────────────────── */
+.importMain {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: var(--space-16) var(--space-12) var(--space-32);
+}
+
+.importForm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  margin-top: var(--space-12);
+}
+
+.importLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.importError {
+  color: var(--status-warn);
+  font-size: var(--text-sm);
+  margin: 0;
+}
+
+.importActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/* ─── Workbench frame ────────────────────────────────────────── */
+.workbench {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: var(--space-10) var(--space-8) var(--space-24);
+}
+
+.workbenchHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-8);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-10);
+}
+
+.workbenchEyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--space-2);
+}
+
+.workbenchCount {
+  font-family: var(--font-serif);
+  font-size: var(--text-h3);
+  color: var(--ink-primary);
+  margin: 0;
+}
+
+.workbenchGrid {
+  display: grid;
+  grid-template-columns: 176px minmax(0, 1fr) 256px;
+  gap: var(--space-10);
+  align-items: start;
+}
+
+.workbenchMain {
+  min-width: 0;
+}
+
+/* ─── Lens switcher ──────────────────────────────────────────── */
+.lensNav {
+  position: sticky;
+  top: var(--space-10);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.lensEyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+  margin: var(--space-4) 0 var(--space-2);
+  padding-left: var(--space-5);
+}
+
+.lensDivider {
+  border: none;
+  height: 1px;
+  background: var(--border);
+  margin: var(--space-4) 0;
+}
+
+.lensButton {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  width: 100%;
+  padding: var(--space-4) var(--space-5);
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--ink-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.lensButton:hover {
+  background: var(--surface-2);
+}
+
+.lensButtonActive {
+  background: var(--accent-soft);
+  border-color: var(--border-accent);
+  color: var(--violet-300);
+}
+
+.lensDot {
+  width: 5px;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--ink-disabled);
+  flex-shrink: 0;
+}
+
+.lensButtonActive .lensDot {
+  background: var(--accent);
+  box-shadow: var(--glow-sm);
+}
+
+.lensCount {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  color: var(--ink-tertiary);
+}
+
+/* ─── Groups ─────────────────────────────────────────────────── */
+.group {
+  margin-bottom: var(--space-10);
+}
+
+.groupHead {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-5);
+  width: 100%;
+  padding: var(--space-4) var(--space-2);
+  border: none;
+  background: var(--bg-base);
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.groupChevron {
+  color: var(--ink-tertiary);
+  font-size: var(--text-sm);
+}
+
+.groupLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.groupMeta {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--ink-tertiary);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.groupShowAll {
+  margin: var(--space-2) 0 0;
+  padding: var(--space-3) var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-2);
+  color: var(--ink-secondary);
+  font-size: var(--text-sm);
+  cursor: pointer;
+}
+
+/* ─── Card rows ──────────────────────────────────────────────── */
+.row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  padding: var(--space-4) var(--space-6);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius-xl);
+  background: var(--card-bg);
+  margin-bottom: var(--space-3);
+  transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+.row > * {
+  min-width: 0;
+}
+
+.rowCut {
+  opacity: 0.45;
+}
+
+.rowKept {
+  border-color: rgba(134, 239, 172, 0.35);
+}
+
+.rowQty {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--ink-tertiary);
+  width: var(--space-8);
+  flex-shrink: 0;
+}
+
+.rowNameWrap {
+  position: relative;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.rowName {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--ink-primary);
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.rowName:hover {
+  color: var(--accent-hi);
+}
+
+.preview {
+  position: absolute;
+  left: 0;
+  top: calc(100% + var(--space-2));
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  width: 260px;
+  max-width: 70vw;
+  padding: var(--space-6);
+  border: 1px solid var(--sheet-border);
+  border-radius: var(--radius-xl);
+  background: var(--surface-overlay);
+  box-shadow: var(--shadow-lg);
+}
+
+.previewImage {
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-lg);
+}
+
+.previewName {
+  font-family: var(--font-serif);
+  font-size: var(--text-body-lg);
+  color: var(--ink-primary);
+}
+
+.previewType {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  color: var(--accent);
+}
+
+.previewOracle {
+  font-size: var(--text-sm);
+  color: var(--ink-secondary);
+  white-space: pre-line;
+}
+
+.rowBadge {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  color: var(--ink-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0 var(--space-2);
+  flex-shrink: 0;
+}
+
+.rowSynergy {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--cyan-400);
+  width: var(--space-12);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.rowTriage {
+  display: flex;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.triageButton {
+  width: var(--space-12);
+  height: var(--space-12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--ink-tertiary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.triageButton:hover {
+  background: var(--surface-2-hi);
+}
+
+.triageKeepOn {
+  background: var(--status-ok-soft);
+  border-color: rgba(134, 239, 172, 0.45);
+  color: var(--status-ok);
+}
+
+.triageCutOn {
+  background: var(--status-warn-soft);
+  border-color: rgba(255, 134, 160, 0.45);
+  color: var(--status-warn);
+}
+
+/* ─── Commander picker ───────────────────────────────────────── */
+.commanderPicker {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.commanderEyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+}
+
+.commanderName {
+  font-family: var(--font-serif);
+  font-size: var(--text-h4);
+  color: var(--ink-primary);
+}
+
+.commanderCandidates {
+  display: flex;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.commanderMore {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  color: var(--ink-tertiary);
+}
+
+/* ─── Insight panels ─────────────────────────────────────────── */
+.panel {
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
+  background: var(--card-bg);
+  padding: var(--card-padding);
+}
+
+.panelTitle {
+  font-family: var(--font-serif);
+  font-size: var(--text-h3);
+  font-weight: var(--weight-medium);
+  color: var(--ink-primary);
+  margin: 0 0 var(--space-4);
+}
+
+.panelMuted {
+  color: var(--ink-tertiary);
+  font-size: var(--text-sm);
+  margin: 0 0 var(--space-4);
+}
+
+.comboList,
+.suggestionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.comboRow {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: var(--space-6);
+  background: var(--surface-2);
+}
+
+.combo_intact {
+  border-color: rgba(134, 239, 172, 0.35);
+}
+
+.combo_possible {
+  border-color: rgba(253, 230, 138, 0.3);
+}
+
+.combo_broken {
+  border-color: rgba(255, 134, 160, 0.35);
+}
+
+.comboHead {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+}
+
+.comboCards {
+  font-weight: var(--weight-semibold);
+  font-size: var(--text-body);
+  color: var(--ink-primary);
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.comboProduces {
+  color: var(--ink-secondary);
+  font-size: var(--text-sm);
+  margin: var(--space-2) 0 0;
+}
+
+.comboAction {
+  margin-top: var(--space-3);
+  margin-right: var(--space-3);
+  padding: var(--space-2) var(--space-6);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius-md);
+  background: var(--accent-soft);
+  color: var(--violet-300);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.comboAction:hover {
+  background: var(--accent-soft-hi);
+}
+
+.suggestionRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  flex-wrap: wrap;
+  padding: var(--space-4) var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface-2);
+}
+
+.suggestionName {
+  font-weight: var(--weight-medium);
+  color: var(--ink-primary);
+}
+
+.suggestionReasons {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.suggestionActions {
+  display: flex;
+  gap: var(--space-2);
+  margin-left: auto;
+  align-items: center;
+}
+
+.suggestionDismiss {
+  width: var(--space-12);
+  height: var(--space-12);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  color: var(--ink-tertiary);
+  cursor: pointer;
+}
+
+/* ─── Charts ─────────────────────────────────────────────────── */
+.chartsHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.chartsScope {
+  display: flex;
+  gap: var(--space-2);
+}
+
+.scopeButton {
+  padding: var(--space-2) var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-pill);
+  background: var(--surface-2);
+  color: var(--ink-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.scopeButtonActive {
+  background: var(--accent-soft);
+  border-color: var(--border-accent);
+  color: var(--violet-300);
+}
+
+.chartsEyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+  margin: var(--space-8) 0 var(--space-4);
+  font-weight: var(--weight-medium);
+}
+
+.chartsSplit {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: var(--space-12);
+  align-items: start;
+}
+
+@media (max-width: 640px) {
+  .chartsSplit {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+.chartsPips {
+  min-width: 0;
+}
+
+.pipRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+  margin-bottom: var(--space-3);
+}
+
+.pipColor {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--ink-secondary);
+  width: var(--space-8);
+  flex-shrink: 0;
+}
+
+.pipBar {
+  flex: 1;
+  height: 5px;
+  border-radius: var(--radius-xs);
+  background: var(--surface-2);
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.pipFill {
+  position: absolute;
+  inset: 0;
+  right: auto;
+  background: var(--accent-gradient);
+  border-radius: var(--radius-xs);
+}
+
+.pipValue {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  color: var(--ink-tertiary);
+  flex-shrink: 0;
+}
+
+/* ─── Tracker rail ───────────────────────────────────────────── */
+.tracker {
+  position: sticky;
+  top: var(--space-10);
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
+  background: var(--card-bg);
+  padding: var(--space-10);
+}
+
+.trackerEyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  margin: 0 0 var(--space-3);
+}
+
+.trackerCount {
+  font-family: var(--font-serif);
+  font-size: var(--text-h1);
+  line-height: var(--leading-tight);
+  color: var(--ink-primary);
+  margin: 0;
+}
+
+.trackerCountOf {
+  font-size: var(--text-h4);
+  color: var(--ink-tertiary);
+}
+
+.trackerSub {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
+  color: var(--ink-tertiary);
+  margin: var(--space-1) 0 0;
+}
+
+.trackerSection {
+  margin-top: var(--space-8);
+  padding-top: var(--space-8);
+  border-top: 1px solid var(--border);
+}
+
+.trackerCategory {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
+}
+
+.trackerCategoryName {
+  width: 74px;
+  flex-shrink: 0;
+  font-size: var(--text-xs);
+  color: var(--ink-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trackerBar {
+  flex: 1;
+  height: 3px;
+  border-radius: var(--radius-xs);
+  background: var(--surface-2);
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+}
+
+.trackerBarFill {
+  position: absolute;
+  inset: 0;
+  right: auto;
+  background: var(--status-watch);
+  border-radius: var(--radius-xs);
+}
+
+.trackerBarOk {
+  background: var(--status-ok);
+}
+
+.trackerCategoryCount {
+  font-family: var(--font-mono);
+  font-size: var(--text-caption);
+  color: var(--ink-tertiary);
+  width: var(--space-20);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.trackerLine {
+  font-size: var(--text-xs);
+  color: var(--ink-secondary);
+  margin: 0 0 var(--space-3);
+}
+
+.trackerOk {
+  color: var(--status-ok);
+}
+
+.trackerWarn {
+  color: var(--status-warn);
+}
+
+.sealButton {
+  width: 100%;
+  margin-top: var(--space-8);
+}
+
+.trackerToggle {
+  display: none;
+}
+
+/* ─── Responsive ─────────────────────────────────────────────── */
+@media (max-width: 960px) {
+  .workbenchGrid {
+    grid-template-columns: 148px minmax(0, 1fr);
+  }
+
+  .tracker {
+    display: none;
+  }
+
+  .trackerToggle {
+    display: block;
+    position: fixed;
+    bottom: var(--space-8);
+    right: var(--space-8);
+    z-index: 20;
+    padding: var(--space-5) var(--space-10);
+    border: 1px solid var(--sheet-border);
+    border-radius: var(--radius-pill);
+    background: var(--surface-overlay);
+    color: var(--ink-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    cursor: pointer;
+    box-shadow: var(--shadow-md);
+  }
+}
+
+@media (max-width: 640px) {
+  .workbenchGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .lensNav {
+    position: static;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+  }
+
+  .lensEyebrow,
+  .lensDivider {
+    display: none;
+  }
+
+  .lensButton {
+    width: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .row,
+  .lensButton,
+  .triageButton {
+    transition: none;
+  }
+}

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -386,10 +386,10 @@
 
 /* ─── Commander picker ───────────────────────────────────────── */
 .commanderPicker {
+  position: relative;
   display: flex;
-  align-items: center;
-  gap: var(--space-5);
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -401,6 +401,14 @@
   color: var(--ink-tertiary);
 }
 
+.commanderRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
 .commanderName {
   display: inline-flex;
   align-items: center;
@@ -410,16 +418,60 @@
   color: var(--ink-primary);
 }
 
-.commanderCandidates {
-  display: flex;
-  gap: var(--space-3);
-  flex-wrap: wrap;
-  align-items: center;
+.commanderCaret {
+  margin-left: var(--space-2);
+  font-size: var(--text-eyebrow);
 }
 
-.commanderMore {
-  font-family: var(--font-mono);
-  font-size: var(--text-caption);
+.commanderFilter {
+  padding: var(--space-3) var(--space-3) var(--space-2);
+  border-bottom: 1px solid var(--border);
+}
+
+.commanderOptions {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-2) 0;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.commanderOption {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-2) var(--space-4);
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font-sans);
+  font-size: var(--text-body);
+  color: var(--ink-primary);
+}
+
+.commanderOption:hover,
+.commanderOption:focus-visible {
+  background: var(--accent-soft);
+}
+
+.commanderOptionPips {
+  display: inline-flex;
+  gap: var(--space-1);
+  flex-shrink: 0;
+}
+
+.commanderOptionName {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.commanderNoMatch {
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--text-sm);
   color: var(--ink-tertiary);
 }
 

--- a/src/components/shell/TopNav.tsx
+++ b/src/components/shell/TopNav.tsx
@@ -6,7 +6,10 @@ import styles from "./TopNav.module.css";
 
 type Tab = { href: string; label: string };
 
-const TABS: Tab[] = [{ href: "/compare", label: "Compare Decks" }];
+const TABS: Tab[] = [
+  { href: "/crucible", label: "The Crucible" },
+  { href: "/compare", label: "Compare Decks" },
+];
 
 export function TopNav() {
   const pathname = usePathname();

--- a/src/components/ui/Popover.module.css
+++ b/src/components/ui/Popover.module.css
@@ -1,0 +1,35 @@
+.popover {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  z-index: 40;
+  min-width: 280px;
+  max-width: min(340px, 90vw);
+  background: var(--sheet-bg);
+  border: 1px solid var(--sheet-border);
+  border-radius: var(--radius-2xl);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(var(--blur-md));
+  -webkit-backdrop-filter: blur(var(--blur-md));
+  overflow: hidden;
+  outline: none;
+  animation: popover-in var(--dur-base) var(--ease-out);
+}
+
+@keyframes popover-in {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--space-1)));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .popover {
+    animation: none;
+    transform: none;
+  }
+}

--- a/src/components/ui/Popover.module.css
+++ b/src/components/ui/Popover.module.css
@@ -8,7 +8,7 @@
   background: var(--sheet-bg);
   border: 1px solid var(--sheet-border);
   border-radius: var(--radius-2xl);
-  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.55);
+  box-shadow: var(--popover-shadow);
   backdrop-filter: blur(var(--blur-md));
   -webkit-backdrop-filter: blur(var(--blur-md));
   overflow: hidden;

--- a/src/components/ui/Popover.tsx
+++ b/src/components/ui/Popover.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  type ReactNode,
+  type RefObject,
+} from "react";
+import styles from "./Popover.module.css";
+
+export type PopoverProps = {
+  open: boolean;
+  onClose: () => void;
+  /**
+   * Ref to the positioned container holding both the trigger and this
+   * popover. Clicks outside it close the popover; the container must be
+   * `position: relative` (or otherwise positioned) for anchoring.
+   */
+  anchorRef: RefObject<HTMLElement | null>;
+  ariaLabel?: string;
+  className?: string;
+  children?: ReactNode;
+  "data-testid"?: string;
+};
+
+const FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Non-modal anchored surface: floats below its trigger inside a positioned
+ * anchor, closes on Escape or outside click, and moves focus to its first
+ * focusable on open (restoring it on close). Unlike `Sheet`, it neither
+ * traps focus nor scrims the page — the rest of the UI stays interactive.
+ */
+export function Popover({
+  open,
+  onClose,
+  anchorRef,
+  ariaLabel,
+  className,
+  children,
+  "data-testid": testId,
+}: PopoverProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const restoreRef = useRef<HTMLElement | null>(null);
+
+  // Same latest-callback pattern as Sheet: callers pass inline closures, and
+  // re-running the open effect per parent render would re-snap focus.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    restoreRef.current = document.activeElement as HTMLElement | null;
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onCloseRef.current();
+      }
+    };
+    const handleMouseDown = (e: MouseEvent) => {
+      const anchor = anchorRef.current;
+      if (anchor && !anchor.contains(e.target as Node)) {
+        onCloseRef.current();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    document.addEventListener("mousedown", handleMouseDown);
+
+    const t = window.setTimeout(() => {
+      const node = panelRef.current;
+      if (!node) return;
+      const focusables = node.querySelectorAll<HTMLElement>(FOCUSABLE);
+      (focusables[0] ?? node).focus();
+    }, 0);
+
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.removeEventListener("mousedown", handleMouseDown);
+      window.clearTimeout(t);
+      restoreRef.current?.focus?.();
+    };
+  }, [open, anchorRef]);
+
+  if (!open) return null;
+
+  const classes = [styles.popover, className].filter(Boolean).join(" ");
+  return (
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-label={ariaLabel}
+      className={classes}
+      data-testid={testId}
+      tabIndex={-1}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -15,3 +15,5 @@ export { StatTile } from "./StatTile";
 export type { StatTileProps } from "./StatTile";
 export { Sheet } from "./Sheet";
 export type { SheetProps } from "./Sheet";
+export { Popover } from "./Popover";
+export type { PopoverProps } from "./Popover";

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -30,6 +30,7 @@ import {
   saveCrucibleSession,
   clearCrucibleSession,
   setCardStatus,
+  setKeptQuantity as setKeptQuantityOnPayload,
   keptCards,
   keptCount,
   buildFinalDeck,
@@ -39,6 +40,11 @@ import {
 
 /** /api/deck-enrich rejects requests above this many unique names. */
 const ENRICH_CHUNK_SIZE = 250;
+
+/** /api/deck-combos rejects requests above this many unique names. Combos
+ * cannot be chunked without missing cross-chunk pairs, so larger piles get an
+ * explicit "unavailable" state instead of a doomed request. */
+const COMBOS_MAX_NAMES = 250;
 
 // ---------------------------------------------------------------------------
 // State shape
@@ -72,6 +78,7 @@ interface State {
   enrichProgress: EnrichProgress;
   combos: CrucibleCombos | null;
   combosLoading: boolean;
+  combosUnavailable: boolean;
   rules: CommanderRules | null;
   dismissedSuggestions: string[];
 }
@@ -79,6 +86,7 @@ interface State {
 type Action =
   | { type: "HYDRATE"; payload: CruciblePayload | null }
   | { type: "SET_PAYLOAD"; payload: CruciblePayload }
+  | { type: "NEW_PILE"; payload: CruciblePayload }
   | { type: "ENRICH_START"; total: number }
   | { type: "ENRICH_PROGRESS"; done: number }
   | {
@@ -90,6 +98,7 @@ type Action =
   | { type: "COMBOS_START" }
   | { type: "COMBOS_SUCCESS"; combos: CrucibleCombos }
   | { type: "COMBOS_ERROR" }
+  | { type: "COMBOS_UNAVAILABLE" }
   | { type: "RULES_SUCCESS"; rules: CommanderRules }
   | { type: "DISMISS_SUGGESTION"; name: string }
   | { type: "DISMISS_ENRICH_ERROR" }
@@ -105,6 +114,7 @@ const initialState: State = {
   enrichProgress: { done: 0, total: 0 },
   combos: null,
   combosLoading: false,
+  combosUnavailable: false,
   rules: null,
   dismissedSuggestions: [],
 };
@@ -119,6 +129,13 @@ function reducer(state: State, action: Action): State {
       };
     case "SET_PAYLOAD":
       return { ...state, hydration: "hydrated", payload: action.payload };
+    case "NEW_PILE":
+      return {
+        ...initialState,
+        hydration: "hydrated",
+        payload: action.payload,
+        rules: state.rules,
+      };
     case "ENRICH_START":
       return {
         ...state,
@@ -154,6 +171,8 @@ function reducer(state: State, action: Action): State {
         combosLoading: false,
         combos: state.combos ?? { exactCombos: [], nearCombos: [] },
       };
+    case "COMBOS_UNAVAILABLE":
+      return { ...state, combosLoading: false, combosUnavailable: true };
     case "RULES_SUCCESS":
       return { ...state, rules: action.rules };
     case "DISMISS_SUGGESTION":
@@ -184,6 +203,9 @@ interface CrucibleSessionContextValue {
   enrichProgress: EnrichProgress;
   combos: CrucibleCombos | null;
   combosLoading: boolean;
+  /** True when the pile exceeds the combo lookup's unique-name cap, so combo
+   * detection cannot run at all. */
+  combosUnavailable: boolean;
   /** Tag cache over the enriched pool. Null until enrichment completes. */
   tagCache: Map<string, string[]> | null;
   /** Synergy over the whole pool (synthetic deck: commanders + pool). */
@@ -200,6 +222,8 @@ interface CrucibleSessionContextValue {
    * enrichment + combo fetches in the background. */
   setPile: (pool: DeckCard[], warnings: string[]) => void;
   setStatus: (name: string, status: CrucibleCardStatus) => void;
+  /** Keep a partial count of a stacked card. Zero returns it to undecided. */
+  setKeptQuantity: (name: string, count: number) => void;
   /** Choose commanders (0-2 names from the pool). Chosen names are forced to
    * "keep" so they count toward the 100. */
   setCommanders: (names: string[]) => void;
@@ -302,6 +326,11 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     const uniqueNames = [...new Set(payload.pool.map((c) => c.name))];
     if (uniqueNames.length === 0) return;
 
+    if (uniqueNames.length > COMBOS_MAX_NAMES) {
+      dispatch({ type: "COMBOS_UNAVAILABLE" });
+      return;
+    }
+
     combosAbortRef.current?.abort();
     const controller = new AbortController();
     combosAbortRef.current = controller;
@@ -357,19 +386,29 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     }
   }, [state.hydration, state.payload, state.combos, fetchCombos]);
 
-  // Banned list + game changers, fetched once per provider lifetime.
+  // Banned list + game changers, fetched once per provider lifetime. The
+  // effect re-runs on every payload change, so it must NOT abort in its
+  // cleanup — a triage click mid-fetch would kill the request and leave
+  // legality null forever. Abort only on provider unmount, and clear the
+  // fetched flag on failure so a later payload change retries.
+  const rulesAbortRef = useRef<AbortController | null>(null);
+  useEffect(() => () => rulesAbortRef.current?.abort(), []);
   useEffect(() => {
     if (state.hydration !== "hydrated" || !state.payload || rulesFetchedRef.current) {
       return;
     }
     rulesFetchedRef.current = true;
     const controller = new AbortController();
+    rulesAbortRef.current = controller;
     void (async () => {
       try {
         const res = await fetch("/api/commander-rules", {
           signal: AbortSignal.any([controller.signal, AbortSignal.timeout(20_000)]),
         });
-        if (!res.ok) return;
+        if (!res.ok) {
+          rulesFetchedRef.current = false;
+          return;
+        }
         const json = await res.json();
         dispatch({
           type: "RULES_SUCCESS",
@@ -381,10 +420,10 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
           },
         });
       } catch {
-        // Legality stays null; the gate simply cannot open without rules.
+        // Legality stays null for now; allow a retry on the next change.
+        rulesFetchedRef.current = false;
       }
     })();
-    return () => controller.abort();
   }, [state.hydration, state.payload]);
 
   // ------------------------------------------------------------------
@@ -396,19 +435,23 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     [state.cardMap]
   );
 
+  // Keyed on pool + commanders (stable across triage clicks), NOT the whole
+  // payload — the O(n²) synergy engine must not re-run on every keep/cut.
+  const pool = state.payload?.pool ?? null;
+  const commanders = state.payload?.commanders ?? null;
   const synergy = useMemo<DeckSynergyAnalysis | null>(() => {
-    if (!state.payload || !state.cardMap) return null;
-    const commanderSet = new Set(state.payload.commanders);
+    if (!pool || !commanders || !state.cardMap) return null;
+    const commanderSet = new Set(commanders);
     const syntheticDeck: DeckData = {
       name: "Crucible Pool",
       source: "text",
       url: "",
-      commanders: state.payload.commanders.map((n) => ({ name: n, quantity: 1 })),
-      mainboard: state.payload.pool.filter((c) => !commanderSet.has(c.name)),
+      commanders: commanders.map((n) => ({ name: n, quantity: 1 })),
+      mainboard: pool.filter((c) => !commanderSet.has(c.name)),
       sideboard: [],
     };
     return analyzeDeckSynergy(syntheticDeck, state.cardMap, tagCache ?? undefined);
-  }, [state.payload, state.cardMap, tagCache]);
+  }, [pool, commanders, state.cardMap, tagCache]);
 
   const keptDeck = useMemo<DeckData | null>(() => {
     if (!state.payload) return null;
@@ -465,15 +508,29 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     combosIdRef.current = null;
     const payload = createCrucibleSession(pool, warnings);
     saveCrucibleSession(payload);
-    dispatch({ type: "SET_PAYLOAD", payload });
+    dispatch({ type: "NEW_PILE", payload });
   }, []);
 
   const setStatus = useCallback(
     (name: string, status: CrucibleCardStatus) => {
       if (!state.payload) return;
+      // Commanders are forced to "keep"; triage cannot move them.
+      if (state.payload.commanders.includes(name)) return;
       dispatch({
         type: "SET_PAYLOAD",
         payload: setCardStatus(state.payload, name, status),
+      });
+    },
+    [state.payload]
+  );
+
+  const setKeptQuantity = useCallback(
+    (name: string, count: number) => {
+      if (!state.payload) return;
+      if (state.payload.commanders.includes(name)) return;
+      dispatch({
+        type: "SET_PAYLOAD",
+        payload: setKeptQuantityOnPayload(state.payload, name, count),
       });
     },
     [state.payload]
@@ -539,6 +596,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       enrichProgress: state.enrichProgress,
       combos: state.combos,
       combosLoading: state.combosLoading,
+      combosUnavailable: state.combosUnavailable,
       tagCache,
       synergy,
       keptScorecard,
@@ -547,6 +605,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       keptTotal,
       setPile,
       setStatus,
+      setKeptQuantity,
       setCommanders,
       restore,
       dismissSuggestion,
@@ -565,6 +624,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       state.enrichProgress,
       state.combos,
       state.combosLoading,
+      state.combosUnavailable,
       tagCache,
       synergy,
       keptScorecard,
@@ -573,6 +633,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       keptTotal,
       setPile,
       setStatus,
+      setKeptQuantity,
       setCommanders,
       restore,
       dismissSuggestion,

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -29,6 +29,7 @@ import {
   loadCrucibleSession,
   saveCrucibleSession,
   clearCrucibleSession,
+  addCardToPool,
   setCardStatus,
   setKeptQuantity as setKeptQuantityOnPayload,
   keptCards,
@@ -99,6 +100,11 @@ type Action =
       notFound: string[];
     }
   | { type: "ENRICH_ERROR"; error: string }
+  | {
+      type: "ENRICH_MERGE";
+      cardMap: Record<string, EnrichedCard>;
+      notFound: string[];
+    }
   | { type: "COMBOS_START" }
   | { type: "COMBOS_SUCCESS"; combos: CrucibleCombos }
   | { type: "COMBOS_ERROR" }
@@ -163,6 +169,12 @@ function reducer(state: State, action: Action): State {
       };
     case "ENRICH_ERROR":
       return { ...state, enrichLoading: false, enrichError: action.error };
+    case "ENRICH_MERGE":
+      return {
+        ...state,
+        cardMap: { ...(state.cardMap ?? {}), ...action.cardMap },
+        notFound: [...new Set([...state.notFound, ...action.notFound])],
+      };
     case "COMBOS_START":
       return { ...state, combosLoading: true };
     case "COMBOS_SUCCESS": {
@@ -239,6 +251,10 @@ interface CrucibleSessionContextValue {
   /** Start a fresh crucible from an imported pile. Persists and triggers
    * enrichment + combo fetches in the background. */
   setPile: (pool: DeckCard[], warnings: string[]) => void;
+  /** Add a single card to the pile mid-triage (new name arrives undecided;
+   * an existing name gets a quantity bump). Enriches it incrementally and
+   * refreshes combo detection where the pile size allows. */
+  addCard: (name: string) => void;
   setStatus: (name: string, status: CrucibleCardStatus) => void;
   /** Keep a partial count of a stacked card. Zero returns it to undecided. */
   setKeptQuantity: (name: string, count: number) => void;
@@ -575,6 +591,50 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     dispatch({ type: "NEW_PILE", payload });
   }, []);
 
+  const addCard = useCallback(
+    (name: string) => {
+      if (!state.payload) return;
+      const next = addCardToPool(state.payload, name);
+      dispatch({ type: "SET_PAYLOAD", payload: next });
+
+      // Enrich the newcomer incrementally; a failure surfaces it as
+      // unresolved rather than blocking the whole session.
+      if (!state.cardMap || !(name in state.cardMap)) {
+        void (async () => {
+          try {
+            const res = await fetch("/api/deck-enrich", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ cardNames: [name] }),
+              signal: AbortSignal.timeout(30_000),
+            });
+            if (!res.ok) {
+              dispatch({ type: "ENRICH_MERGE", cardMap: {}, notFound: [name] });
+              return;
+            }
+            const json = await res.json();
+            dispatch({
+              type: "ENRICH_MERGE",
+              cardMap: (json.cards as Record<string, EnrichedCard>) ?? {},
+              notFound: (json.notFound as string[] | undefined) ?? [],
+            });
+          } catch {
+            dispatch({ type: "ENRICH_MERGE", cardMap: {}, notFound: [name] });
+          }
+        })();
+      }
+
+      // Small piles fetch combos once up front, so a mid-triage addition
+      // needs an explicit refresh (results merge in the reducer). Large
+      // piles are covered by the keep+undecided subset effect.
+      const uniqueNames = [...new Set(next.pool.map((c) => c.name))];
+      if (uniqueNames.length <= COMBOS_MAX_NAMES) {
+        void fetchCombos(uniqueNames, next.commanders);
+      }
+    },
+    [state.payload, state.cardMap, fetchCombos]
+  );
+
   const setStatus = useCallback(
     (name: string, status: CrucibleCardStatus) => {
       if (!state.payload) return;
@@ -670,6 +730,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       cutSuggestions,
       keptTotal,
       setPile,
+      addCard,
       setStatus,
       setKeptQuantity,
       setCommanders,
@@ -698,6 +759,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       cutSuggestions,
       keptTotal,
       setPile,
+      addCard,
       setStatus,
       setKeptQuantity,
       setCommanders,

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -169,12 +169,16 @@ function reducer(state: State, action: Action): State {
       };
     case "ENRICH_ERROR":
       return { ...state, enrichLoading: false, enrichError: action.error };
-    case "ENRICH_MERGE":
+    case "ENRICH_MERGE": {
+      const cardMap = { ...(state.cardMap ?? {}), ...action.cardMap };
       return {
         ...state,
-        cardMap: { ...(state.cardMap ?? {}), ...action.cardMap },
-        notFound: [...new Set([...state.notFound, ...action.notFound])],
+        cardMap,
+        notFound: [...new Set([...state.notFound, ...action.notFound])].filter(
+          (name) => !(name in cardMap)
+        ),
       };
+    }
     case "COMBOS_START":
       return { ...state, combosLoading: true };
     case "COMBOS_SUCCESS": {
@@ -594,6 +598,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const addCard = useCallback(
     (name: string) => {
       if (!state.payload) return;
+      const wasInPool = state.payload.pool.some((card) => card.name === name);
       const next = addCardToPool(state.payload, name);
       dispatch({ type: "SET_PAYLOAD", payload: next });
 
@@ -626,10 +631,13 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
 
       // Small piles fetch combos once up front, so a mid-triage addition
       // needs an explicit refresh (results merge in the reducer). Large
-      // piles are covered by the keep+undecided subset effect.
-      const uniqueNames = [...new Set(next.pool.map((c) => c.name))];
-      if (uniqueNames.length <= COMBOS_MAX_NAMES) {
-        void fetchCombos(uniqueNames, next.commanders);
+      // piles are covered by the keep+undecided subset effect. A quantity
+      // bump leaves the unique-name set unchanged, so no refetch needed.
+      if (!wasInPool) {
+        const uniqueNames = [...new Set(next.pool.map((c) => c.name))];
+        if (uniqueNames.length <= COMBOS_MAX_NAMES) {
+          void fetchCombos(uniqueNames, next.commanders);
+        }
       }
     },
     [state.payload, state.cardMap, fetchCombos]

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -296,6 +296,10 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const combosSubsetKeyRef = useRef<string | null>(null);
   const combosDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rulesFetchedRef = useRef(false);
+  const addCardPayloadRef = useRef<CruciblePayload | null>(state.payload);
+  useEffect(() => {
+    addCardPayloadRef.current = state.payload;
+  }, [state.payload]);
 
   // Hydrate from sessionStorage on mount.
   useEffect(() => {
@@ -612,12 +616,15 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
 
   const addCard = useCallback(
     (name: string) => {
-      if (!state.payload) return;
+      const current = addCardPayloadRef.current;
+      if (!current) return;
       const target = name.trim().toLowerCase();
-      const wasInPool = state.payload.pool.some(
+      const wasInPool = current.pool.some(
         (card) => card.name.toLowerCase() === target
       );
       dispatch({ type: "ADD_CARD", name });
+      const next = addCardToPool(current, name);
+      addCardPayloadRef.current = next;
 
       // Enrich the newcomer incrementally; a failure surfaces it as
       // unresolved rather than blocking the whole session.
@@ -651,14 +658,13 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       // piles are covered by the keep+undecided subset effect. A quantity
       // bump leaves the unique-name set unchanged, so no refetch needed.
       if (!wasInPool) {
-        const next = addCardToPool(state.payload, name);
         const uniqueNames = [...new Set(next.pool.map((c) => c.name))];
         if (uniqueNames.length <= COMBOS_MAX_NAMES) {
           void fetchCombos(uniqueNames, next.commanders);
         }
       }
     },
-    [state.payload, state.cardMap, fetchCombos]
+    [state.cardMap, fetchCombos]
   );
 
   const setStatus = useCallback(

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -89,6 +89,7 @@ interface State {
 type Action =
   | { type: "HYDRATE"; payload: CruciblePayload | null }
   | { type: "SET_PAYLOAD"; payload: CruciblePayload }
+  | { type: "ADD_CARD"; name: string }
   | { type: "NEW_PILE"; payload: CruciblePayload }
   | { type: "ENRICH_START"; total: number }
   | { type: "ENRICH_PROGRESS"; done: number }
@@ -135,6 +136,10 @@ function reducer(state: State, action: Action): State {
       };
     case "SET_PAYLOAD":
       return { ...state, hydration: "hydrated", payload: action.payload };
+    case "ADD_CARD":
+      return state.payload
+        ? { ...state, payload: addCardToPool(state.payload, action.name) }
+        : state;
     case "NEW_PILE":
       return {
         ...initialState,
@@ -417,14 +422,14 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (state.hydration !== "hydrated" || !state.payload) return;
-    if (state.combos !== null || combosIdRef.current === state.payload.crucibleId) {
-      return;
-    }
     const uniqueNames = [...new Set(state.payload.pool.map((c) => c.name))];
     if (uniqueNames.length > COMBOS_MAX_NAMES) return;
-    combosIdRef.current = state.payload.crucibleId;
+    const commanderKey = [...state.payload.commanders].sort().join(",");
+    const key = `${state.payload.crucibleId}::${commanderKey}`;
+    if (combosIdRef.current === key) return;
+    combosIdRef.current = key;
     void fetchCombos(uniqueNames, state.payload.commanders);
-  }, [state.hydration, state.payload, state.combos, fetchCombos]);
+  }, [state.hydration, state.payload, fetchCombos]);
 
   // Large piles: combo detection runs over the keep+undecided subset once
   // cuts bring its unique-name count under the cap. First crossing fetches
@@ -444,7 +449,8 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       ),
     ];
     if (subset.length > COMBOS_MAX_NAMES) return;
-    const key = [...subset].sort().join("\n");
+    const commanderKey = [...commanders].sort().join(",");
+    const key = `${[...subset].sort().join("\n")}::${commanderKey}`;
     if (combosSubsetKeyRef.current === key) return;
     const delay =
       combosSubsetKeyRef.current === null ? 0 : COMBOS_REFETCH_DEBOUNCE_MS;
@@ -607,9 +613,11 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const addCard = useCallback(
     (name: string) => {
       if (!state.payload) return;
-      const wasInPool = state.payload.pool.some((card) => card.name === name);
-      const next = addCardToPool(state.payload, name);
-      dispatch({ type: "SET_PAYLOAD", payload: next });
+      const target = name.trim().toLowerCase();
+      const wasInPool = state.payload.pool.some(
+        (card) => card.name.toLowerCase() === target
+      );
+      dispatch({ type: "ADD_CARD", name });
 
       // Enrich the newcomer incrementally; a failure surfaces it as
       // unresolved rather than blocking the whole session.
@@ -643,6 +651,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       // piles are covered by the keep+undecided subset effect. A quantity
       // bump leaves the unique-name set unchanged, so no refetch needed.
       if (!wasInPool) {
+        const next = addCardToPool(state.payload, name);
         const uniqueNames = [...new Set(next.pool.map((c) => c.name))];
         if (uniqueNames.length <= COMBOS_MAX_NAMES) {
           void fetchCombos(uniqueNames, next.commanders);

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -1,0 +1,604 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  type ReactNode,
+} from "react";
+import type { DeckCard, DeckData, DeckSynergyAnalysis, EnrichedCard } from "@/lib/types";
+import type { SpellbookCombo } from "@/lib/commander-spellbook";
+import { buildTagCache } from "@/lib/card-tags";
+import { analyzeDeckSynergy } from "@/lib/synergy-engine";
+import {
+  computeCompositionScorecard,
+  TEMPLATE_COMMAND_ZONE,
+  type CompositionScorecardResult,
+} from "@/lib/deck-composition";
+import {
+  validateCommanderDeck,
+  type CommanderValidationResult,
+} from "@/lib/commander-validation";
+import { suggestCuts, type CutSuggestion } from "@/lib/cut-suggestions";
+import {
+  createCrucibleSession,
+  loadCrucibleSession,
+  saveCrucibleSession,
+  clearCrucibleSession,
+  setCardStatus,
+  keptCards,
+  keptCount,
+  buildFinalDeck,
+  type CruciblePayload,
+  type CrucibleCardStatus,
+} from "@/lib/crucible-session";
+
+/** /api/deck-enrich rejects requests above this many unique names. */
+const ENRICH_CHUNK_SIZE = 250;
+
+// ---------------------------------------------------------------------------
+// State shape
+// ---------------------------------------------------------------------------
+
+type Hydration = "pending" | "hydrated" | "absent";
+
+export interface EnrichProgress {
+  done: number;
+  total: number;
+}
+
+interface CrucibleCombos {
+  exactCombos: SpellbookCombo[];
+  nearCombos: SpellbookCombo[];
+}
+
+interface CommanderRules {
+  bannedSet: Set<string>;
+  gameChangerNames: Set<string>;
+}
+
+interface State {
+  hydration: Hydration;
+  payload: CruciblePayload | null;
+  /** Runtime-only; re-fetched on hydrate like the reading session. */
+  cardMap: Record<string, EnrichedCard> | null;
+  notFound: string[];
+  enrichLoading: boolean;
+  enrichError: string | null;
+  enrichProgress: EnrichProgress;
+  combos: CrucibleCombos | null;
+  combosLoading: boolean;
+  rules: CommanderRules | null;
+  dismissedSuggestions: string[];
+}
+
+type Action =
+  | { type: "HYDRATE"; payload: CruciblePayload | null }
+  | { type: "SET_PAYLOAD"; payload: CruciblePayload }
+  | { type: "ENRICH_START"; total: number }
+  | { type: "ENRICH_PROGRESS"; done: number }
+  | {
+      type: "ENRICH_SUCCESS";
+      cardMap: Record<string, EnrichedCard>;
+      notFound: string[];
+    }
+  | { type: "ENRICH_ERROR"; error: string }
+  | { type: "COMBOS_START" }
+  | { type: "COMBOS_SUCCESS"; combos: CrucibleCombos }
+  | { type: "COMBOS_ERROR" }
+  | { type: "RULES_SUCCESS"; rules: CommanderRules }
+  | { type: "DISMISS_SUGGESTION"; name: string }
+  | { type: "DISMISS_ENRICH_ERROR" }
+  | { type: "CLEAR" };
+
+const initialState: State = {
+  hydration: "pending",
+  payload: null,
+  cardMap: null,
+  notFound: [],
+  enrichLoading: false,
+  enrichError: null,
+  enrichProgress: { done: 0, total: 0 },
+  combos: null,
+  combosLoading: false,
+  rules: null,
+  dismissedSuggestions: [],
+};
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case "HYDRATE":
+      return {
+        ...state,
+        hydration: action.payload ? "hydrated" : "absent",
+        payload: action.payload,
+      };
+    case "SET_PAYLOAD":
+      return { ...state, hydration: "hydrated", payload: action.payload };
+    case "ENRICH_START":
+      return {
+        ...state,
+        enrichLoading: true,
+        enrichError: null,
+        enrichProgress: { done: 0, total: action.total },
+      };
+    case "ENRICH_PROGRESS":
+      return {
+        ...state,
+        enrichProgress: { ...state.enrichProgress, done: action.done },
+      };
+    case "ENRICH_SUCCESS":
+      return {
+        ...state,
+        enrichLoading: false,
+        cardMap: action.cardMap,
+        notFound: action.notFound,
+        enrichProgress: {
+          done: state.enrichProgress.total,
+          total: state.enrichProgress.total,
+        },
+      };
+    case "ENRICH_ERROR":
+      return { ...state, enrichLoading: false, enrichError: action.error };
+    case "COMBOS_START":
+      return { ...state, combosLoading: true };
+    case "COMBOS_SUCCESS":
+      return { ...state, combosLoading: false, combos: action.combos };
+    case "COMBOS_ERROR":
+      return {
+        ...state,
+        combosLoading: false,
+        combos: state.combos ?? { exactCombos: [], nearCombos: [] },
+      };
+    case "RULES_SUCCESS":
+      return { ...state, rules: action.rules };
+    case "DISMISS_SUGGESTION":
+      return {
+        ...state,
+        dismissedSuggestions: [...state.dismissedSuggestions, action.name],
+      };
+    case "DISMISS_ENRICH_ERROR":
+      return { ...state, enrichError: null };
+    case "CLEAR":
+      return { ...initialState, hydration: "absent" };
+    default:
+      return state;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Context value
+// ---------------------------------------------------------------------------
+
+interface CrucibleSessionContextValue {
+  hydration: Hydration;
+  payload: CruciblePayload | null;
+  cardMap: Record<string, EnrichedCard> | null;
+  notFound: string[];
+  enrichLoading: boolean;
+  enrichError: string | null;
+  enrichProgress: EnrichProgress;
+  combos: CrucibleCombos | null;
+  combosLoading: boolean;
+  /** Tag cache over the enriched pool. Null until enrichment completes. */
+  tagCache: Map<string, string[]> | null;
+  /** Synergy over the whole pool (synthetic deck: commanders + pool). */
+  synergy: DeckSynergyAnalysis | null;
+  /** Composition scorecard for the kept subset vs the Command Zone template. */
+  keptScorecard: CompositionScorecardResult | null;
+  /** Commander-format legality of (commanders + kept). Null until the banned
+   * list and enrichment have both loaded. */
+  legality: CommanderValidationResult | null;
+  /** Ranked cut suggestions, minus dismissed ones. */
+  cutSuggestions: CutSuggestion[];
+  keptTotal: number;
+  /** Start a fresh crucible from an imported pile. Persists and triggers
+   * enrichment + combo fetches in the background. */
+  setPile: (pool: DeckCard[], warnings: string[]) => void;
+  setStatus: (name: string, status: CrucibleCardStatus) => void;
+  /** Choose commanders (0-2 names from the pool). Chosen names are forced to
+   * "keep" so they count toward the 100. */
+  setCommanders: (names: string[]) => void;
+  /** Flip a cut card back to undecided. */
+  restore: (name: string) => void;
+  dismissSuggestion: (name: string) => void;
+  /** Build the final DeckData for handoff. Caller navigates the journey. */
+  finalize: (deckName: string) => DeckData | null;
+  retryEnrichment: () => void;
+  dismissEnrichError: () => void;
+  clearCrucible: () => void;
+}
+
+const CrucibleSessionContext = createContext<CrucibleSessionContextValue | null>(null);
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+  const enrichAbortRef = useRef<AbortController | null>(null);
+  const combosAbortRef = useRef<AbortController | null>(null);
+  const enrichedIdRef = useRef<string | null>(null);
+  const combosIdRef = useRef<string | null>(null);
+  const rulesFetchedRef = useRef(false);
+
+  // Hydrate from sessionStorage on mount.
+  useEffect(() => {
+    dispatch({ type: "HYDRATE", payload: loadCrucibleSession() });
+  }, []);
+
+  // Persist payload changes so refreshes keep triage state.
+  useEffect(() => {
+    if (state.hydration === "hydrated" && state.payload) {
+      saveCrucibleSession(state.payload);
+    }
+  }, [state.hydration, state.payload]);
+
+  const enrich = useCallback(async (pool: DeckCard[]) => {
+    const uniqueNames = [...new Set(pool.map((c) => c.name))];
+    if (uniqueNames.length === 0) return;
+
+    enrichAbortRef.current?.abort();
+    const controller = new AbortController();
+    enrichAbortRef.current = controller;
+
+    const chunks = chunk(uniqueNames, ENRICH_CHUNK_SIZE);
+    dispatch({ type: "ENRICH_START", total: chunks.length });
+
+    const cardMap: Record<string, EnrichedCard> = {};
+    const notFound: string[] = [];
+
+    try {
+      for (let i = 0; i < chunks.length; i++) {
+        const res = await fetch("/api/deck-enrich", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cardNames: chunks[i] }),
+          signal: AbortSignal.any([
+            controller.signal,
+            AbortSignal.timeout(30_000),
+          ]),
+        });
+        if (!res.ok) {
+          dispatch({
+            type: "ENRICH_ERROR",
+            error:
+              res.status === 502
+                ? "Card data service temporarily unavailable"
+                : "Could not load card details",
+          });
+          return;
+        }
+        const json = await res.json();
+        Object.assign(cardMap, json.cards as Record<string, EnrichedCard>);
+        notFound.push(...((json.notFound as string[] | undefined) ?? []));
+        dispatch({ type: "ENRICH_PROGRESS", done: i + 1 });
+      }
+      dispatch({ type: "ENRICH_SUCCESS", cardMap, notFound });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      dispatch({
+        type: "ENRICH_ERROR",
+        error:
+          err instanceof TypeError
+            ? "Network error — could not reach card data service"
+            : "Could not load card details",
+      });
+    }
+  }, []);
+
+  const fetchCombos = useCallback(async (payload: CruciblePayload) => {
+    const uniqueNames = [...new Set(payload.pool.map((c) => c.name))];
+    if (uniqueNames.length === 0) return;
+
+    combosAbortRef.current?.abort();
+    const controller = new AbortController();
+    combosAbortRef.current = controller;
+
+    dispatch({ type: "COMBOS_START" });
+
+    try {
+      const res = await fetch("/api/deck-combos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cardNames: uniqueNames,
+          commanders: payload.commanders,
+        }),
+        signal: AbortSignal.any([
+          controller.signal,
+          AbortSignal.timeout(20_000),
+        ]),
+      });
+      if (!res.ok) {
+        dispatch({ type: "COMBOS_ERROR" });
+        return;
+      }
+      const json = await res.json();
+      dispatch({
+        type: "COMBOS_SUCCESS",
+        combos: {
+          exactCombos: json.exactCombos ?? [],
+          nearCombos: json.nearCombos ?? [],
+        },
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      dispatch({ type: "COMBOS_ERROR" });
+    }
+  }, []);
+
+  // After hydration, kick off enrichment + combos when missing.
+  useEffect(() => {
+    if (state.hydration !== "hydrated" || !state.payload) return;
+    const { crucibleId, pool } = state.payload;
+    if (state.cardMap === null && enrichedIdRef.current !== crucibleId) {
+      enrichedIdRef.current = crucibleId;
+      void enrich(pool);
+    }
+  }, [state.hydration, state.payload, state.cardMap, enrich]);
+
+  useEffect(() => {
+    if (state.hydration !== "hydrated" || !state.payload) return;
+    if (state.combos === null && combosIdRef.current !== state.payload.crucibleId) {
+      combosIdRef.current = state.payload.crucibleId;
+      void fetchCombos(state.payload);
+    }
+  }, [state.hydration, state.payload, state.combos, fetchCombos]);
+
+  // Banned list + game changers, fetched once per provider lifetime.
+  useEffect(() => {
+    if (state.hydration !== "hydrated" || !state.payload || rulesFetchedRef.current) {
+      return;
+    }
+    rulesFetchedRef.current = true;
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const res = await fetch("/api/commander-rules", {
+          signal: AbortSignal.any([controller.signal, AbortSignal.timeout(20_000)]),
+        });
+        if (!res.ok) return;
+        const json = await res.json();
+        dispatch({
+          type: "RULES_SUCCESS",
+          rules: {
+            bannedSet: new Set<string>(json.banned ?? []),
+            gameChangerNames: new Set<string>(
+              ((json.gameChangers ?? []) as { name: string }[]).map((g) => g.name)
+            ),
+          },
+        });
+      } catch {
+        // Legality stays null; the gate simply cannot open without rules.
+      }
+    })();
+    return () => controller.abort();
+  }, [state.hydration, state.payload]);
+
+  // ------------------------------------------------------------------
+  // Derived state
+  // ------------------------------------------------------------------
+
+  const tagCache = useMemo(
+    () => (state.cardMap ? buildTagCache(state.cardMap) : null),
+    [state.cardMap]
+  );
+
+  const synergy = useMemo<DeckSynergyAnalysis | null>(() => {
+    if (!state.payload || !state.cardMap) return null;
+    const commanderSet = new Set(state.payload.commanders);
+    const syntheticDeck: DeckData = {
+      name: "Crucible Pool",
+      source: "text",
+      url: "",
+      commanders: state.payload.commanders.map((n) => ({ name: n, quantity: 1 })),
+      mainboard: state.payload.pool.filter((c) => !commanderSet.has(c.name)),
+      sideboard: [],
+    };
+    return analyzeDeckSynergy(syntheticDeck, state.cardMap, tagCache ?? undefined);
+  }, [state.payload, state.cardMap, tagCache]);
+
+  const keptDeck = useMemo<DeckData | null>(() => {
+    if (!state.payload) return null;
+    return buildFinalDeck(state.payload, "Crucible Kept");
+  }, [state.payload]);
+
+  const keptScorecard = useMemo<CompositionScorecardResult | null>(() => {
+    if (!keptDeck || !state.cardMap) return null;
+    // Score only commanders + kept mainboard; drop the sideboard (cuts).
+    const keptOnly: DeckData = { ...keptDeck, sideboard: [] };
+    return computeCompositionScorecard(
+      keptOnly,
+      state.cardMap,
+      TEMPLATE_COMMAND_ZONE,
+      tagCache ?? undefined
+    );
+  }, [keptDeck, state.cardMap, tagCache]);
+
+  const legality = useMemo<CommanderValidationResult | null>(() => {
+    if (!keptDeck || !state.cardMap || !state.rules) return null;
+    const keptOnly: DeckData = { ...keptDeck, sideboard: [] };
+    return validateCommanderDeck(
+      keptOnly,
+      state.cardMap,
+      state.rules.bannedSet,
+      state.rules.gameChangerNames
+    );
+  }, [keptDeck, state.cardMap, state.rules]);
+
+  const cutSuggestions = useMemo<CutSuggestion[]>(() => {
+    if (!state.payload || !state.cardMap) return [];
+    return suggestCuts(
+      state.payload,
+      state.cardMap,
+      synergy,
+      keptScorecard,
+      new Set(state.dismissedSuggestions)
+    );
+  }, [state.payload, state.cardMap, synergy, keptScorecard, state.dismissedSuggestions]);
+
+  const keptTotal = useMemo(
+    () => (state.payload ? keptCount(state.payload) : 0),
+    [state.payload]
+  );
+
+  // ------------------------------------------------------------------
+  // Actions
+  // ------------------------------------------------------------------
+
+  const setPile = useCallback((pool: DeckCard[], warnings: string[]) => {
+    enrichAbortRef.current?.abort();
+    combosAbortRef.current?.abort();
+    enrichedIdRef.current = null;
+    combosIdRef.current = null;
+    const payload = createCrucibleSession(pool, warnings);
+    saveCrucibleSession(payload);
+    dispatch({ type: "SET_PAYLOAD", payload });
+  }, []);
+
+  const setStatus = useCallback(
+    (name: string, status: CrucibleCardStatus) => {
+      if (!state.payload) return;
+      dispatch({
+        type: "SET_PAYLOAD",
+        payload: setCardStatus(state.payload, name, status),
+      });
+    },
+    [state.payload]
+  );
+
+  const setCommanders = useCallback(
+    (names: string[]) => {
+      if (!state.payload) return;
+      let next: CruciblePayload = { ...state.payload, commanders: names.slice(0, 2) };
+      for (const name of next.commanders) {
+        next = setCardStatus(next, name, "keep");
+      }
+      dispatch({ type: "SET_PAYLOAD", payload: next });
+    },
+    [state.payload]
+  );
+
+  const restore = useCallback(
+    (name: string) => setStatus(name, "undecided"),
+    [setStatus]
+  );
+
+  const dismissSuggestion = useCallback((name: string) => {
+    dispatch({ type: "DISMISS_SUGGESTION", name });
+  }, []);
+
+  const finalize = useCallback(
+    (deckName: string): DeckData | null => {
+      if (!state.payload) return null;
+      return buildFinalDeck(state.payload, deckName);
+    },
+    [state.payload]
+  );
+
+  const retryEnrichment = useCallback(() => {
+    if (state.payload) {
+      enrichedIdRef.current = null;
+      void enrich(state.payload.pool);
+    }
+  }, [state.payload, enrich]);
+
+  const dismissEnrichError = useCallback(() => {
+    dispatch({ type: "DISMISS_ENRICH_ERROR" });
+  }, []);
+
+  const clearCrucible = useCallback(() => {
+    enrichAbortRef.current?.abort();
+    combosAbortRef.current?.abort();
+    enrichedIdRef.current = null;
+    combosIdRef.current = null;
+    clearCrucibleSession();
+    dispatch({ type: "CLEAR" });
+  }, []);
+
+  const value = useMemo<CrucibleSessionContextValue>(
+    () => ({
+      hydration: state.hydration,
+      payload: state.payload,
+      cardMap: state.cardMap,
+      notFound: state.notFound,
+      enrichLoading: state.enrichLoading,
+      enrichError: state.enrichError,
+      enrichProgress: state.enrichProgress,
+      combos: state.combos,
+      combosLoading: state.combosLoading,
+      tagCache,
+      synergy,
+      keptScorecard,
+      legality,
+      cutSuggestions,
+      keptTotal,
+      setPile,
+      setStatus,
+      setCommanders,
+      restore,
+      dismissSuggestion,
+      finalize,
+      retryEnrichment,
+      dismissEnrichError,
+      clearCrucible,
+    }),
+    [
+      state.hydration,
+      state.payload,
+      state.cardMap,
+      state.notFound,
+      state.enrichLoading,
+      state.enrichError,
+      state.enrichProgress,
+      state.combos,
+      state.combosLoading,
+      tagCache,
+      synergy,
+      keptScorecard,
+      legality,
+      cutSuggestions,
+      keptTotal,
+      setPile,
+      setStatus,
+      setCommanders,
+      restore,
+      dismissSuggestion,
+      finalize,
+      retryEnrichment,
+      dismissEnrichError,
+      clearCrucible,
+    ]
+  );
+
+  return (
+    <CrucibleSessionContext.Provider value={value}>
+      {children}
+    </CrucibleSessionContext.Provider>
+  );
+}
+
+export function useCrucibleSession(): CrucibleSessionContextValue {
+  const ctx = useContext(CrucibleSessionContext);
+  if (!ctx) {
+    throw new Error(
+      "useCrucibleSession must be used within a CrucibleSessionProvider"
+    );
+  }
+  return ctx;
+}
+
+/** Kept cards helper re-exported for components that need the list shape. */
+export { keptCards };

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -38,9 +38,7 @@ import {
   type CruciblePayload,
   type CrucibleCardStatus,
 } from "@/lib/crucible-session";
-
-/** /api/deck-enrich rejects requests above this many unique names. */
-const ENRICH_CHUNK_SIZE = 250;
+import { ENRICH_CHUNK_SIZE, chunk } from "@/lib/enrich-chunking";
 
 /** /api/deck-combos rejects requests above this many unique names. Combos
  * cannot be chunked without missing cross-chunk pairs, so for larger piles
@@ -260,6 +258,9 @@ interface CrucibleSessionContextValue {
    * refreshes combo detection where the pile size allows. */
   addCard: (name: string) => void;
   setStatus: (name: string, status: CrucibleCardStatus) => void;
+  /** Flip every listed card to "keep" in a single update, so one click can
+   * keep all of a combo's pieces without dispatches overwriting each other. */
+  keepAll: (names: string[]) => void;
   /** Keep a partial count of a stacked card. Zero returns it to undecided. */
   setKeptQuantity: (name: string, count: number) => void;
   /** Choose commanders (0-2 names from the pool). Chosen names are forced to
@@ -280,12 +281,6 @@ const CrucibleSessionContext = createContext<CrucibleSessionContextValue | null>
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
-
-function chunk<T>(items: T[], size: number): T[][] {
-  const out: T[][] = [];
-  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
-  return out;
-}
 
 export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -362,45 +357,53 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const fetchCombos = useCallback(async (cardNames: string[], commanders: string[]) => {
-    if (cardNames.length === 0 || cardNames.length > COMBOS_MAX_NAMES) return;
-
-    combosAbortRef.current?.abort();
-    const controller = new AbortController();
-    combosAbortRef.current = controller;
-
-    dispatch({ type: "COMBOS_START" });
-
-    try {
-      const res = await fetch("/api/deck-combos", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          cardNames,
-          commanders,
-        }),
-        signal: AbortSignal.any([
-          controller.signal,
-          AbortSignal.timeout(20_000),
-        ]),
-      });
-      if (!res.ok) {
-        dispatch({ type: "COMBOS_ERROR" });
-        return;
+  const fetchCombos = useCallback(
+    async (cardNames: string[], commanders: string[]): Promise<boolean> => {
+      if (cardNames.length === 0 || cardNames.length > COMBOS_MAX_NAMES) {
+        return false;
       }
-      const json = await res.json();
-      dispatch({
-        type: "COMBOS_SUCCESS",
-        combos: {
-          exactCombos: json.exactCombos ?? [],
-          nearCombos: json.nearCombos ?? [],
-        },
-      });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      dispatch({ type: "COMBOS_ERROR" });
-    }
-  }, []);
+
+      combosAbortRef.current?.abort();
+      const controller = new AbortController();
+      combosAbortRef.current = controller;
+
+      dispatch({ type: "COMBOS_START" });
+
+      try {
+        const res = await fetch("/api/deck-combos", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            cardNames,
+            commanders,
+          }),
+          signal: AbortSignal.any([
+            controller.signal,
+            AbortSignal.timeout(20_000),
+          ]),
+        });
+        if (!res.ok) {
+          dispatch({ type: "COMBOS_ERROR" });
+          return false;
+        }
+        const json = await res.json();
+        dispatch({
+          type: "COMBOS_SUCCESS",
+          combos: {
+            exactCombos: json.exactCombos ?? [],
+            nearCombos: json.nearCombos ?? [],
+          },
+        });
+        return true;
+      } catch (err) {
+        // A superseding fetch owns the state now; don't report failure.
+        if (err instanceof DOMException && err.name === "AbortError") return true;
+        dispatch({ type: "COMBOS_ERROR" });
+        return false;
+      }
+    },
+    []
+  );
 
   // After hydration, kick off enrichment + combos when missing.
   useEffect(() => {
@@ -448,7 +451,13 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     if (combosDebounceRef.current) clearTimeout(combosDebounceRef.current);
     combosDebounceRef.current = setTimeout(() => {
       combosSubsetKeyRef.current = key;
-      void fetchCombos(subset, commanders);
+      void fetchCombos(subset, commanders).then((ok) => {
+        // Failed fetches release the key so the next payload change retries,
+        // matching the rules fetch's clear-flag-on-failure behavior.
+        if (!ok && combosSubsetKeyRef.current === key) {
+          combosSubsetKeyRef.current = null;
+        }
+      });
     }, delay);
     return () => {
       if (combosDebounceRef.current) clearTimeout(combosDebounceRef.current);
@@ -656,6 +665,20 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     [state.payload]
   );
 
+  const keepAll = useCallback(
+    (names: string[]) => {
+      if (!state.payload) return;
+      let next = state.payload;
+      for (const name of names) {
+        if (next.commanders.includes(name)) continue;
+        next = setCardStatus(next, name, "keep");
+      }
+      if (next === state.payload) return;
+      dispatch({ type: "SET_PAYLOAD", payload: next });
+    },
+    [state.payload]
+  );
+
   const setKeptQuantity = useCallback(
     (name: string, count: number) => {
       if (!state.payload) return;
@@ -740,6 +763,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       setPile,
       addCard,
       setStatus,
+      keepAll,
       setKeptQuantity,
       setCommanders,
       restore,
@@ -769,6 +793,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       setPile,
       addCard,
       setStatus,
+      keepAll,
       setKeptQuantity,
       setCommanders,
       restore,

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -42,9 +42,14 @@ import {
 const ENRICH_CHUNK_SIZE = 250;
 
 /** /api/deck-combos rejects requests above this many unique names. Combos
- * cannot be chunked without missing cross-chunk pairs, so larger piles get an
- * explicit "unavailable" state instead of a doomed request. */
+ * cannot be chunked without missing cross-chunk pairs, so for larger piles
+ * detection runs over the keep+undecided subset once cuts bring it under the
+ * cap — until then the UI shows how many more unique cuts are needed. */
 const COMBOS_MAX_NAMES = 250;
+
+/** Debounce for combo refetches after the first threshold crossing, so triage
+ * clicks never fire a request each. */
+const COMBOS_REFETCH_DEBOUNCE_MS = 1500;
 
 // ---------------------------------------------------------------------------
 // State shape
@@ -78,7 +83,6 @@ interface State {
   enrichProgress: EnrichProgress;
   combos: CrucibleCombos | null;
   combosLoading: boolean;
-  combosUnavailable: boolean;
   rules: CommanderRules | null;
   dismissedSuggestions: string[];
 }
@@ -98,7 +102,6 @@ type Action =
   | { type: "COMBOS_START" }
   | { type: "COMBOS_SUCCESS"; combos: CrucibleCombos }
   | { type: "COMBOS_ERROR" }
-  | { type: "COMBOS_UNAVAILABLE" }
   | { type: "RULES_SUCCESS"; rules: CommanderRules }
   | { type: "DISMISS_SUGGESTION"; name: string }
   | { type: "DISMISS_ENRICH_ERROR" }
@@ -114,7 +117,6 @@ const initialState: State = {
   enrichProgress: { done: 0, total: 0 },
   combos: null,
   combosLoading: false,
-  combosUnavailable: false,
   rules: null,
   dismissedSuggestions: [],
 };
@@ -163,16 +165,31 @@ function reducer(state: State, action: Action): State {
       return { ...state, enrichLoading: false, enrichError: action.error };
     case "COMBOS_START":
       return { ...state, combosLoading: true };
-    case "COMBOS_SUCCESS":
-      return { ...state, combosLoading: false, combos: action.combos };
+    case "COMBOS_SUCCESS": {
+      const prev = state.combos;
+      if (!prev) {
+        return { ...state, combosLoading: false, combos: action.combos };
+      }
+      const exactById = new Map(prev.exactCombos.map((c) => [c.id, c]));
+      for (const combo of action.combos.exactCombos) exactById.set(combo.id, combo);
+      const nearById = new Map(prev.nearCombos.map((c) => [c.id, c]));
+      for (const combo of action.combos.nearCombos) nearById.set(combo.id, combo);
+      for (const id of exactById.keys()) nearById.delete(id);
+      return {
+        ...state,
+        combosLoading: false,
+        combos: {
+          exactCombos: [...exactById.values()],
+          nearCombos: [...nearById.values()],
+        },
+      };
+    }
     case "COMBOS_ERROR":
       return {
         ...state,
         combosLoading: false,
         combos: state.combos ?? { exactCombos: [], nearCombos: [] },
       };
-    case "COMBOS_UNAVAILABLE":
-      return { ...state, combosLoading: false, combosUnavailable: true };
     case "RULES_SUCCESS":
       return { ...state, rules: action.rules };
     case "DISMISS_SUGGESTION":
@@ -203,9 +220,10 @@ interface CrucibleSessionContextValue {
   enrichProgress: EnrichProgress;
   combos: CrucibleCombos | null;
   combosLoading: boolean;
-  /** True when the pile exceeds the combo lookup's unique-name cap, so combo
-   * detection cannot run at all. */
-  combosUnavailable: boolean;
+  /** How many unique keep/undecided cards over the combo lookup's cap the
+   * pile currently is. Zero means combo detection is available; positive
+   * means "cut this many more unique cards" to unlock it. */
+  combosOverBy: number;
   /** Tag cache over the enriched pool. Null until enrichment completes. */
   tagCache: Map<string, string[]> | null;
   /** Synergy over the whole pool (synthetic deck: commanders + pool). */
@@ -255,6 +273,8 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const combosAbortRef = useRef<AbortController | null>(null);
   const enrichedIdRef = useRef<string | null>(null);
   const combosIdRef = useRef<string | null>(null);
+  const combosSubsetKeyRef = useRef<string | null>(null);
+  const combosDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const rulesFetchedRef = useRef(false);
 
   // Hydrate from sessionStorage on mount.
@@ -322,14 +342,8 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const fetchCombos = useCallback(async (payload: CruciblePayload) => {
-    const uniqueNames = [...new Set(payload.pool.map((c) => c.name))];
-    if (uniqueNames.length === 0) return;
-
-    if (uniqueNames.length > COMBOS_MAX_NAMES) {
-      dispatch({ type: "COMBOS_UNAVAILABLE" });
-      return;
-    }
+  const fetchCombos = useCallback(async (cardNames: string[], commanders: string[]) => {
+    if (cardNames.length === 0 || cardNames.length > COMBOS_MAX_NAMES) return;
 
     combosAbortRef.current?.abort();
     const controller = new AbortController();
@@ -342,8 +356,8 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          cardNames: uniqueNames,
-          commanders: payload.commanders,
+          cardNames,
+          commanders,
         }),
         signal: AbortSignal.any([
           controller.signal,
@@ -380,11 +394,46 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (state.hydration !== "hydrated" || !state.payload) return;
-    if (state.combos === null && combosIdRef.current !== state.payload.crucibleId) {
-      combosIdRef.current = state.payload.crucibleId;
-      void fetchCombos(state.payload);
+    if (state.combos !== null || combosIdRef.current === state.payload.crucibleId) {
+      return;
     }
+    const uniqueNames = [...new Set(state.payload.pool.map((c) => c.name))];
+    if (uniqueNames.length > COMBOS_MAX_NAMES) return;
+    combosIdRef.current = state.payload.crucibleId;
+    void fetchCombos(uniqueNames, state.payload.commanders);
   }, [state.hydration, state.payload, state.combos, fetchCombos]);
+
+  // Large piles: combo detection runs over the keep+undecided subset once
+  // cuts bring its unique-name count under the cap. First crossing fetches
+  // immediately; later subset changes are debounced so individual triage
+  // clicks never fire a request each. Results merge in the reducer so combos
+  // whose pieces are later cut keep rendering as Broken.
+  useEffect(() => {
+    if (state.hydration !== "hydrated" || !state.payload) return;
+    const { pool, statuses, commanders } = state.payload;
+    const poolUnique = new Set(pool.map((c) => c.name));
+    if (poolUnique.size <= COMBOS_MAX_NAMES) return;
+    const subset = [
+      ...new Set(
+        pool
+          .filter((c) => (statuses[c.name] ?? "undecided") !== "cut")
+          .map((c) => c.name)
+      ),
+    ];
+    if (subset.length > COMBOS_MAX_NAMES) return;
+    const key = [...subset].sort().join("\n");
+    if (combosSubsetKeyRef.current === key) return;
+    const delay =
+      combosSubsetKeyRef.current === null ? 0 : COMBOS_REFETCH_DEBOUNCE_MS;
+    if (combosDebounceRef.current) clearTimeout(combosDebounceRef.current);
+    combosDebounceRef.current = setTimeout(() => {
+      combosSubsetKeyRef.current = key;
+      void fetchCombos(subset, commanders);
+    }, delay);
+    return () => {
+      if (combosDebounceRef.current) clearTimeout(combosDebounceRef.current);
+    };
+  }, [state.hydration, state.payload, fetchCombos]);
 
   // Banned list + game changers, fetched once per provider lifetime. The
   // effect re-runs on every payload change, so it must NOT abort in its
@@ -497,6 +546,19 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     [state.payload]
   );
 
+  const combosOverBy = useMemo(() => {
+    if (!state.payload) return 0;
+    const { pool: fullPool, statuses } = state.payload;
+    const poolUnique = new Set(fullPool.map((c) => c.name));
+    if (poolUnique.size <= COMBOS_MAX_NAMES) return 0;
+    const subsetUnique = new Set(
+      fullPool
+        .filter((c) => (statuses[c.name] ?? "undecided") !== "cut")
+        .map((c) => c.name)
+    );
+    return Math.max(0, subsetUnique.size - COMBOS_MAX_NAMES);
+  }, [state.payload]);
+
   // ------------------------------------------------------------------
   // Actions
   // ------------------------------------------------------------------
@@ -504,8 +566,10 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const setPile = useCallback((pool: DeckCard[], warnings: string[]) => {
     enrichAbortRef.current?.abort();
     combosAbortRef.current?.abort();
+    if (combosDebounceRef.current) clearTimeout(combosDebounceRef.current);
     enrichedIdRef.current = null;
     combosIdRef.current = null;
+    combosSubsetKeyRef.current = null;
     const payload = createCrucibleSession(pool, warnings);
     saveCrucibleSession(payload);
     dispatch({ type: "NEW_PILE", payload });
@@ -579,8 +643,10 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const clearCrucible = useCallback(() => {
     enrichAbortRef.current?.abort();
     combosAbortRef.current?.abort();
+    if (combosDebounceRef.current) clearTimeout(combosDebounceRef.current);
     enrichedIdRef.current = null;
     combosIdRef.current = null;
+    combosSubsetKeyRef.current = null;
     clearCrucibleSession();
     dispatch({ type: "CLEAR" });
   }, []);
@@ -596,7 +662,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       enrichProgress: state.enrichProgress,
       combos: state.combos,
       combosLoading: state.combosLoading,
-      combosUnavailable: state.combosUnavailable,
+      combosOverBy,
       tagCache,
       synergy,
       keptScorecard,
@@ -624,7 +690,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       state.enrichProgress,
       state.combos,
       state.combosLoading,
-      state.combosUnavailable,
+      combosOverBy,
       tagCache,
       synergy,
       keptScorecard,

--- a/src/contexts/DeckSessionContext.tsx
+++ b/src/contexts/DeckSessionContext.tsx
@@ -165,6 +165,16 @@ const DeckSessionContext = createContext<DeckSessionContextValue | null>(null);
 // Provider
 // ---------------------------------------------------------------------------
 
+/** /api/deck-enrich rejects requests above this many unique names, so large
+ * decks (e.g. a Crucible handoff with a big sideboard) enrich in batches. */
+const ENRICH_CHUNK_SIZE = 250;
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
 export function DeckSessionProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const enrichAbortRef = useRef<AbortController | null>(null);
@@ -198,34 +208,38 @@ export function DeckSessionProvider({ children }: { children: ReactNode }) {
 
     dispatch({ type: "ENRICH_START" });
 
-    try {
-      const res = await fetch("/api/deck-enrich", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ cardNames: uniqueNames }),
-        signal: AbortSignal.any([
-          controller.signal,
-          AbortSignal.timeout(30_000),
-        ]),
-      });
+    const cardMap: Record<string, EnrichedCard> = {};
+    let notFoundCount = 0;
 
-      if (!res.ok) {
-        dispatch({
-          type: "ENRICH_ERROR",
-          error:
-            res.status === 502
-              ? "Card data service temporarily unavailable"
-              : "Could not load card details",
+    try {
+      for (const names of chunk(uniqueNames, ENRICH_CHUNK_SIZE)) {
+        const res = await fetch("/api/deck-enrich", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cardNames: names }),
+          signal: AbortSignal.any([
+            controller.signal,
+            AbortSignal.timeout(30_000),
+          ]),
         });
-        return;
+
+        if (!res.ok) {
+          dispatch({
+            type: "ENRICH_ERROR",
+            error:
+              res.status === 502
+                ? "Card data service temporarily unavailable"
+                : "Could not load card details",
+          });
+          return;
+        }
+
+        const json = await res.json();
+        Object.assign(cardMap, json.cards as Record<string, EnrichedCard>);
+        notFoundCount += json.notFound?.length ?? 0;
       }
 
-      const json = await res.json();
-      dispatch({
-        type: "ENRICH_SUCCESS",
-        cardMap: json.cards as Record<string, EnrichedCard>,
-        notFoundCount: json.notFound?.length ?? 0,
-      });
+      dispatch({ type: "ENRICH_SUCCESS", cardMap, notFoundCount });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       dispatch({

--- a/src/contexts/DeckSessionContext.tsx
+++ b/src/contexts/DeckSessionContext.tsx
@@ -23,6 +23,7 @@ import {
   clearDeckSession,
   type DeckSessionPayload,
 } from "@/lib/deck-session";
+import { ENRICH_CHUNK_SIZE, chunk } from "@/lib/enrich-chunking";
 
 // ---------------------------------------------------------------------------
 // State shape
@@ -164,16 +165,6 @@ const DeckSessionContext = createContext<DeckSessionContextValue | null>(null);
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
-
-/** /api/deck-enrich rejects requests above this many unique names, so large
- * decks (e.g. a Crucible handoff with a big sideboard) enrich in batches. */
-const ENRICH_CHUNK_SIZE = 250;
-
-function chunk<T>(items: T[], size: number): T[][] {
-  const out: T[][] = [];
-  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
-  return out;
-}
 
 export function DeckSessionProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);

--- a/src/lib/commander-validation.ts
+++ b/src/lib/commander-validation.ts
@@ -64,7 +64,8 @@ export function getMaxQuantity(
   return 1;
 }
 
-const PLAIN_PARTNER_RE = /\bPartner\b(?!\s+with)/;
+const PLAIN_PARTNER_RE = /\bPartner\b(?!\s+with)(?!\s*[-—])/;
+const RESTRICTED_PARTNER_RE = /\bPartner\s*[-—]\s*([^.\n]+)/;
 const FRIENDS_FOREVER_RE = /\bFriends forever\b/i;
 const DOCTORS_COMPANION_RE = /Doctor(?:'|’)s companion/i;
 const CHOOSE_BACKGROUND_RE = /\bChoose a Background\b/i;
@@ -73,11 +74,21 @@ const TIME_LORD_DOCTOR_RE = /\bTime Lord\b.*\bDoctor\b/;
 
 /**
  * Whether two cards form a rules-legal two-commander pairing: both have plain
- * Partner, they mutually "Partner with" each other, both have Friends Forever,
- * a Time Lord Doctor pairs with a Doctor's companion, or a "Choose a
+ * Partner, both have restricted-group Partner ("Partner - <Group>") naming
+ * the same group, they mutually "Partner with" each other, both have Friends
+ * Forever, a Time Lord Doctor pairs with a Doctor's companion, or a "Choose a
  * Background" commander pairs with a Background enchantment.
  */
 export function canPairCommanders(a: EnrichedCard, b: EnrichedCard): boolean {
+  const aRestricted = a.oracleText.match(RESTRICTED_PARTNER_RE);
+  const bRestricted = b.oracleText.match(RESTRICTED_PARTNER_RE);
+  if (aRestricted || bRestricted) {
+    return (
+      aRestricted !== null &&
+      bRestricted !== null &&
+      aRestricted[1].trim().toLowerCase() === bRestricted[1].trim().toLowerCase()
+    );
+  }
   if (PLAIN_PARTNER_RE.test(a.oracleText) && PLAIN_PARTNER_RE.test(b.oracleText)) {
     return true;
   }

--- a/src/lib/commander-validation.ts
+++ b/src/lib/commander-validation.ts
@@ -64,6 +64,38 @@ export function getMaxQuantity(
   return 1;
 }
 
+const PLAIN_PARTNER_RE = /\bPartner\b(?!\s+with)/;
+const FRIENDS_FOREVER_RE = /\bFriends forever\b/i;
+const DOCTORS_COMPANION_RE = /Doctor(?:'|’)s companion/i;
+const CHOOSE_BACKGROUND_RE = /\bChoose a Background\b/i;
+const BACKGROUND_TYPE_RE = /\bBackground\b/;
+const TIME_LORD_DOCTOR_RE = /\bTime Lord\b.*\bDoctor\b/;
+
+/**
+ * Whether two cards form a rules-legal two-commander pairing: both have plain
+ * Partner, they mutually "Partner with" each other, both have Friends Forever,
+ * a Time Lord Doctor pairs with a Doctor's companion, or a "Choose a
+ * Background" commander pairs with a Background enchantment.
+ */
+export function canPairCommanders(a: EnrichedCard, b: EnrichedCard): boolean {
+  if (PLAIN_PARTNER_RE.test(a.oracleText) && PLAIN_PARTNER_RE.test(b.oracleText)) {
+    return true;
+  }
+  if (
+    a.oracleText.includes(`Partner with ${b.name}`) &&
+    b.oracleText.includes(`Partner with ${a.name}`)
+  ) {
+    return true;
+  }
+  if (FRIENDS_FOREVER_RE.test(a.oracleText) && FRIENDS_FOREVER_RE.test(b.oracleText)) {
+    return true;
+  }
+  const pairsOneWay = (x: EnrichedCard, y: EnrichedCard): boolean =>
+    (CHOOSE_BACKGROUND_RE.test(x.oracleText) && BACKGROUND_TYPE_RE.test(y.typeLine)) ||
+    (TIME_LORD_DOCTOR_RE.test(x.typeLine) && DOCTORS_COMPANION_RE.test(y.oracleText));
+  return pairsOneWay(a, b) || pairsOneWay(b, a);
+}
+
 /**
  * Validate a deck against Commander format rules.
  */
@@ -80,6 +112,16 @@ export function validateCommanderDeck(
   if (!hasCommander) {
     errors.push({ message: "No commander detected in this deck." });
     return { hasCommander, isValid: false, errors, commanderNames };
+  }
+
+  if (deck.commanders.length === 2) {
+    const [first, second] = commanderNames.map((name) => cardMap[name]);
+    if (first && second && !canPairCommanders(first, second)) {
+      errors.push({
+        message: `${commanderNames[0]} and ${commanderNames[1]} cannot be paired — two commanders need Partner, "Partner with" each other, Friends Forever, a Doctor's companion, or a Background pairing.`,
+        cards: commanderNames,
+      });
+    }
   }
 
   // Total card count (commanders + mainboard)

--- a/src/lib/crucible-grouping.ts
+++ b/src/lib/crucible-grouping.ts
@@ -7,6 +7,8 @@ import { TEMPLATE_COMMAND_ZONE } from "@/lib/deck-composition";
 export const UNCATEGORIZED_LABEL = "Uncategorized";
 export const LANDS_LABEL = "Lands";
 export const UNALIGNED_AXIS_ID = "unaligned";
+export const UNRESOLVED_LABEL = "Unresolved";
+export const UNRESOLVED_GROUP_ID = "unresolved";
 
 /** Minimum axis relevance for a card to be considered aligned to that axis. */
 export const AXIS_RELEVANCE_MIN = 0.2;
@@ -40,6 +42,31 @@ function isLand(typeLine: string): boolean {
 
 function byName(a: DeckCard, b: DeckCard): number {
   return a.name.localeCompare(b.name);
+}
+
+function unresolvedCards(
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>
+): DeckCard[] {
+  return pool.filter((card) => !cardMap[card.name]).sort(byName);
+}
+
+/** Append an "Unresolved" group for names enrichment could not resolve, so
+ * every grouped lens accounts for the full pool. */
+function withUnresolved(
+  groups: CrucibleGroup[],
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>
+): CrucibleGroup[] {
+  const unresolved = unresolvedCards(pool, cardMap);
+  if (unresolved.length > 0) {
+    groups.push({
+      id: UNRESOLVED_GROUP_ID,
+      label: UNRESOLVED_LABEL,
+      cards: unresolved,
+    });
+  }
+  return groups;
 }
 
 /**
@@ -104,7 +131,7 @@ export function groupByCategory(
       cards: untagged.sort(byName),
     });
   }
-  return groups;
+  return withUnresolved(groups, pool, cardMap);
 }
 
 /**
@@ -184,6 +211,16 @@ export function groupBySynergyAxis(
       cards: unaligned.sort(byRelevance),
     });
   }
+
+  const unresolved = unresolvedCards(pool, cardMap);
+  if (unresolved.length > 0) {
+    groups.push({
+      axisId: UNRESOLVED_GROUP_ID,
+      axisName: UNRESOLVED_LABEL,
+      strength: 0,
+      cards: unresolved.map((card) => ({ ...card, relevance: 0, otherAxes: [] })),
+    });
+  }
   return groups;
 }
 
@@ -203,11 +240,12 @@ export function groupByTypeLine(
     if (existing) existing.push(card);
     else buckets.set(label, [card]);
   }
-  return Array.from(buckets, ([label, cards]) => ({
+  const groups = Array.from(buckets, ([label, cards]) => ({
     id: `type:${label}`,
     label,
     cards: cards.sort(byName),
   })).sort((a, b) => b.cards.length - a.cards.length || a.label.localeCompare(b.label));
+  return withUnresolved(groups, pool, cardMap);
 }
 
 const MV_BUCKETS = ["0–1", "2", "3", "4", "5", "6", "7+"] as const;
@@ -233,13 +271,14 @@ export function groupByManaValue(
     else buckets.set(label, [card]);
   }
   const order: string[] = [...MV_BUCKETS, LANDS_LABEL];
-  return order
+  const groups = order
     .filter((label) => buckets.has(label))
     .map((label) => ({
       id: `mv:${label}`,
       label,
       cards: buckets.get(label)!.sort(byName),
     }));
+  return withUnresolved(groups, pool, cardMap);
 }
 
 const COLOR_LABELS: Record<string, string> = {
@@ -271,13 +310,14 @@ export function groupByColorIdentity(
     else buckets.set(label, [card]);
   }
   const order = ["White", "Blue", "Black", "Red", "Green", "Multicolor", "Colorless"];
-  return order
+  const groups = order
     .filter((label) => buckets.has(label))
     .map((label) => ({
       id: `color:${label}`,
       label,
       cards: buckets.get(label)!.sort(byName),
     }));
+  return withUnresolved(groups, pool, cardMap);
 }
 
 /** Cards flagged as game changers (bracket-relevant). */

--- a/src/lib/crucible-grouping.ts
+++ b/src/lib/crucible-grouping.ts
@@ -1,0 +1,291 @@
+import type { DeckCard, EnrichedCard } from "@/lib/types";
+import { getTagsCached } from "@/lib/card-tags";
+import { SYNERGY_AXES } from "@/lib/synergy-axes";
+import { extractCardType } from "@/lib/mana-curve";
+import { TEMPLATE_COMMAND_ZONE } from "@/lib/deck-composition";
+
+export const UNCATEGORIZED_LABEL = "Uncategorized";
+export const LANDS_LABEL = "Lands";
+export const UNALIGNED_AXIS_ID = "unaligned";
+
+/** Minimum axis relevance for a card to be considered aligned to that axis. */
+export const AXIS_RELEVANCE_MIN = 0.2;
+
+export interface CrucibleGroup {
+  id: string;
+  label: string;
+  cards: DeckCard[];
+}
+
+export interface AxisGroupCard extends DeckCard {
+  /** The card's relevance to this axis (0-1). */
+  relevance: number;
+  /** Names of other axes where this card also clears AXIS_RELEVANCE_MIN. */
+  otherAxes: string[];
+}
+
+export interface AxisGroup {
+  axisId: string;
+  axisName: string;
+  /** Mean relevance of this axis across the whole pool (0-1). */
+  strength: number;
+  cards: AxisGroupCard[];
+}
+
+const LAND_RE = /\bLand\b/;
+
+function isLand(typeLine: string): boolean {
+  return LAND_RE.test(typeLine);
+}
+
+function byName(a: DeckCard, b: DeckCard): number {
+  return a.name.localeCompare(b.name);
+}
+
+/**
+ * Group the pool by card tag. A card with several tags appears in each of its
+ * tag groups (its triage status is shared, so deciding once decides
+ * everywhere). Lands get their own group; tagless cards land in
+ * "Uncategorized". Groups follow the Command Zone template order for known
+ * tags, then remaining tags by size, with Uncategorized last.
+ */
+export function groupByCategory(
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>,
+  tagCache?: Map<string, string[]>
+): CrucibleGroup[] {
+  const tagGroups = new Map<string, DeckCard[]>();
+  const lands: DeckCard[] = [];
+  const untagged: DeckCard[] = [];
+
+  for (const card of pool) {
+    const enriched = cardMap[card.name];
+    if (!enriched) continue;
+    if (isLand(enriched.typeLine)) {
+      lands.push(card);
+      continue;
+    }
+    const tags = getTagsCached(enriched, tagCache);
+    if (tags.length === 0) {
+      untagged.push(card);
+      continue;
+    }
+    for (const tag of tags) {
+      const existing = tagGroups.get(tag);
+      if (existing) existing.push(card);
+      else tagGroups.set(tag, [card]);
+    }
+  }
+
+  const templateOrder = new Map<string, number>(
+    TEMPLATE_COMMAND_ZONE.categories.map((c, i) => [c.tag, i])
+  );
+  const sortedTags = Array.from(tagGroups.keys()).sort((a, b) => {
+    const ai = templateOrder.get(a);
+    const bi = templateOrder.get(b);
+    if (ai !== undefined && bi !== undefined) return ai - bi;
+    if (ai !== undefined) return -1;
+    if (bi !== undefined) return 1;
+    const sizeDiff = tagGroups.get(b)!.length - tagGroups.get(a)!.length;
+    return sizeDiff !== 0 ? sizeDiff : a.localeCompare(b);
+  });
+
+  const groups: CrucibleGroup[] = [];
+  if (lands.length > 0) {
+    groups.push({ id: "lands", label: LANDS_LABEL, cards: lands.sort(byName) });
+  }
+  for (const tag of sortedTags) {
+    groups.push({ id: `tag:${tag}`, label: tag, cards: tagGroups.get(tag)!.sort(byName) });
+  }
+  if (untagged.length > 0) {
+    groups.push({
+      id: "uncategorized",
+      label: UNCATEGORIZED_LABEL,
+      cards: untagged.sort(byName),
+    });
+  }
+  return groups;
+}
+
+/**
+ * Group the pool by synergy axis. Each card appears exactly once, under its
+ * strongest axis (ties broken by axis order); its other qualifying axes are
+ * listed on the entry. Cards with no axis clearing AXIS_RELEVANCE_MIN collect
+ * in the "Unaligned" bucket — prime cut candidates. Groups sort by pool-wide
+ * strength; cards within a group sort by relevance desc, then name.
+ */
+export function groupBySynergyAxis(
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>
+): AxisGroup[] {
+  const assignments = new Map<string, AxisGroupCard[]>();
+  const axisTotals = new Map<string, number>();
+  const unaligned: AxisGroupCard[] = [];
+  let enrichedCount = 0;
+
+  for (const card of pool) {
+    const enriched = cardMap[card.name];
+    if (!enriched) continue;
+    enrichedCount++;
+
+    let bestAxisId: string | null = null;
+    let bestRelevance = 0;
+    const qualifying: { axisId: string; axisName: string; relevance: number }[] = [];
+
+    for (const axis of SYNERGY_AXES) {
+      const relevance = axis.detect(enriched);
+      axisTotals.set(axis.id, (axisTotals.get(axis.id) ?? 0) + relevance);
+      if (relevance >= AXIS_RELEVANCE_MIN) {
+        qualifying.push({ axisId: axis.id, axisName: axis.name, relevance });
+        if (relevance > bestRelevance) {
+          bestRelevance = relevance;
+          bestAxisId = axis.id;
+        }
+      }
+    }
+
+    if (bestAxisId === null) {
+      unaligned.push({ ...card, relevance: 0, otherAxes: [] });
+      continue;
+    }
+    const entry: AxisGroupCard = {
+      ...card,
+      relevance: bestRelevance,
+      otherAxes: qualifying
+        .filter((q) => q.axisId !== bestAxisId)
+        .map((q) => q.axisName),
+    };
+    const existing = assignments.get(bestAxisId);
+    if (existing) existing.push(entry);
+    else assignments.set(bestAxisId, [entry]);
+  }
+
+  const byRelevance = (a: AxisGroupCard, b: AxisGroupCard) =>
+    b.relevance - a.relevance || a.name.localeCompare(b.name);
+
+  const groups: AxisGroup[] = [];
+  for (const axis of SYNERGY_AXES) {
+    const cards = assignments.get(axis.id);
+    if (!cards || cards.length === 0) continue;
+    groups.push({
+      axisId: axis.id,
+      axisName: axis.name,
+      strength: enrichedCount > 0 ? (axisTotals.get(axis.id) ?? 0) / enrichedCount : 0,
+      cards: cards.sort(byRelevance),
+    });
+  }
+  groups.sort((a, b) => b.strength - a.strength || a.axisName.localeCompare(b.axisName));
+
+  if (unaligned.length > 0) {
+    groups.push({
+      axisId: UNALIGNED_AXIS_ID,
+      axisName: "Unaligned",
+      strength: 0,
+      cards: unaligned.sort(byRelevance),
+    });
+  }
+  return groups;
+}
+
+/** Group by primary card type, with lands separate and unknowns in "Other". */
+export function groupByTypeLine(
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>
+): CrucibleGroup[] {
+  const buckets = new Map<string, DeckCard[]>();
+  for (const card of pool) {
+    const enriched = cardMap[card.name];
+    if (!enriched) continue;
+    const label = isLand(enriched.typeLine)
+      ? LANDS_LABEL
+      : extractCardType(enriched.typeLine) ?? "Other";
+    const existing = buckets.get(label);
+    if (existing) existing.push(card);
+    else buckets.set(label, [card]);
+  }
+  return Array.from(buckets, ([label, cards]) => ({
+    id: `type:${label}`,
+    label,
+    cards: cards.sort(byName),
+  })).sort((a, b) => b.cards.length - a.cards.length || a.label.localeCompare(b.label));
+}
+
+const MV_BUCKETS = ["0–1", "2", "3", "4", "5", "6", "7+"] as const;
+
+function manaValueBucket(cmc: number): (typeof MV_BUCKETS)[number] {
+  if (cmc <= 1) return "0–1";
+  if (cmc >= 7) return "7+";
+  return String(Math.floor(cmc)) as (typeof MV_BUCKETS)[number];
+}
+
+/** Group by mana value buckets (0–1, 2 … 7+), with lands in their own group. */
+export function groupByManaValue(
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>
+): CrucibleGroup[] {
+  const buckets = new Map<string, DeckCard[]>();
+  for (const card of pool) {
+    const enriched = cardMap[card.name];
+    if (!enriched) continue;
+    const label = isLand(enriched.typeLine) ? LANDS_LABEL : manaValueBucket(enriched.cmc);
+    const existing = buckets.get(label);
+    if (existing) existing.push(card);
+    else buckets.set(label, [card]);
+  }
+  const order: string[] = [...MV_BUCKETS, LANDS_LABEL];
+  return order
+    .filter((label) => buckets.has(label))
+    .map((label) => ({
+      id: `mv:${label}`,
+      label,
+      cards: buckets.get(label)!.sort(byName),
+    }));
+}
+
+const COLOR_LABELS: Record<string, string> = {
+  W: "White",
+  U: "Blue",
+  B: "Black",
+  R: "Red",
+  G: "Green",
+};
+
+/** Group by color identity: mono colors, Multicolor, Colorless. */
+export function groupByColorIdentity(
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>
+): CrucibleGroup[] {
+  const buckets = new Map<string, DeckCard[]>();
+  for (const card of pool) {
+    const enriched = cardMap[card.name];
+    if (!enriched) continue;
+    const identity = enriched.colorIdentity;
+    const label =
+      identity.length === 0
+        ? "Colorless"
+        : identity.length === 1
+          ? COLOR_LABELS[identity[0]] ?? "Colorless"
+          : "Multicolor";
+    const existing = buckets.get(label);
+    if (existing) existing.push(card);
+    else buckets.set(label, [card]);
+  }
+  const order = ["White", "Blue", "Black", "Red", "Green", "Multicolor", "Colorless"];
+  return order
+    .filter((label) => buckets.has(label))
+    .map((label) => ({
+      id: `color:${label}`,
+      label,
+      cards: buckets.get(label)!.sort(byName),
+    }));
+}
+
+/** Cards flagged as game changers (bracket-relevant). */
+export function gameChangers(
+  pool: DeckCard[],
+  cardMap: Record<string, EnrichedCard>
+): DeckCard[] {
+  return pool
+    .filter((card) => cardMap[card.name]?.isGameChanger)
+    .sort(byName);
+}

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -234,7 +234,12 @@ export function parseCruciblePayload(raw: string | null): CruciblePayload | null
     if (!parsed?.crucibleId || !Array.isArray(parsed.pool) || !parsed.statuses) {
       return null;
     }
-    return { ...parsed, keptQuantities: parsed.keptQuantities ?? {} };
+    return {
+      ...parsed,
+      keptQuantities: parsed.keptQuantities ?? {},
+      commanders: parsed.commanders ?? [],
+      parseWarnings: parsed.parseWarnings ?? [],
+    };
   } catch {
     return null;
   }

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -86,6 +86,30 @@ export function flattenPileParse(parsed: ParseResult): {
   };
 }
 
+const PILE_LINE_RE = /^(\d+)(x?)\s+(.+)$/i;
+
+/**
+ * Append a card chosen from search into raw pile text, for the import form.
+ * The textarea stays the single source of truth: an existing line for the
+ * same name (case-insensitive, `N Name` or `Nx Name`) gets its count bumped
+ * in place; otherwise a `1 Name` line is appended. All other lines are left
+ * exactly as typed.
+ */
+export function appendCardToPileText(text: string, name: string): string {
+  const target = name.trim().toLowerCase();
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].trim().match(PILE_LINE_RE);
+    if (match && match[3].trim().toLowerCase() === target) {
+      const count = Number(match[1]) + 1;
+      lines[i] = lines[i].replace(PILE_LINE_RE, `${count}${match[2]} ${match[3]}`);
+      return lines.join("\n");
+    }
+  }
+  const trimmed = text.replace(/\s+$/, "");
+  return trimmed ? `${trimmed}\n1 ${name}` : `1 ${name}`;
+}
+
 /**
  * Add a card to an existing pile mid-triage. A new name is appended with
  * quantity 1 and status "undecided"; a name already in the pool has its

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -99,10 +99,11 @@ export function appendCardToPileText(text: string, name: string): string {
   const target = name.trim().toLowerCase();
   const lines = text.split(/\r?\n/);
   for (let i = 0; i < lines.length; i++) {
-    const match = lines[i].trim().match(PILE_LINE_RE);
+    const trimmedLine = lines[i].trim();
+    const match = trimmedLine.match(PILE_LINE_RE);
     if (match && match[3].trim().toLowerCase() === target) {
       const count = Number(match[1]) + 1;
-      lines[i] = lines[i].replace(PILE_LINE_RE, `${count}${match[2]} ${match[3]}`);
+      lines[i] = trimmedLine.replace(PILE_LINE_RE, `${count}${match[2]} ${match[3]}`);
       return lines.join("\n");
     }
   }
@@ -120,12 +121,15 @@ export function addCardToPool(
   name: string,
   quantity = 1
 ): CruciblePayload {
-  const existing = payload.pool.find((card) => card.name === name);
+  const target = name.trim().toLowerCase();
+  const existing = payload.pool.find(
+    (card) => card.name.toLowerCase() === target
+  );
   if (existing) {
     return {
       ...payload,
       pool: payload.pool.map((card) =>
-        card.name === name
+        card.name.toLowerCase() === target
           ? { ...card, quantity: card.quantity + quantity }
           : card
       ),

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -86,6 +86,34 @@ export function flattenPileParse(parsed: ParseResult): {
   };
 }
 
+/**
+ * Add a card to an existing pile mid-triage. A new name is appended with
+ * quantity 1 and status "undecided"; a name already in the pool has its
+ * quantity bumped, leaving its triage status (and any partial keep) intact.
+ */
+export function addCardToPool(
+  payload: CruciblePayload,
+  name: string,
+  quantity = 1
+): CruciblePayload {
+  const existing = payload.pool.find((card) => card.name === name);
+  if (existing) {
+    return {
+      ...payload,
+      pool: payload.pool.map((card) =>
+        card.name === name
+          ? { ...card, quantity: card.quantity + quantity }
+          : card
+      ),
+    };
+  }
+  return {
+    ...payload,
+    pool: [...payload.pool, { name, quantity }],
+    statuses: { ...payload.statuses, [name]: "undecided" },
+  };
+}
+
 export function setCardStatus(
   payload: CruciblePayload,
   name: string,

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -181,9 +181,14 @@ export function undecidedCards(payload: CruciblePayload): DeckCard[] {
   return withStatus(payload, "undecided");
 }
 
-/** Total kept quantity (not unique names). Commanders count via their keep status. */
+/** Total kept quantity (not unique names). Commanders count as a single copy
+ * each, matching the one copy the command zone consumes in the final deck. */
 export function keptCount(payload: CruciblePayload): number {
-  return keptCards(payload).reduce((sum, c) => sum + c.quantity, 0);
+  const commanderSet = new Set(payload.commanders);
+  return keptCards(payload).reduce(
+    (sum, c) => sum + (commanderSet.has(c.name) ? 1 : c.quantity),
+    0
+  );
 }
 
 /**
@@ -196,7 +201,11 @@ export function buildFinalDeck(payload: CruciblePayload, name: string): DeckData
   const mainboard: DeckCard[] = [];
   const sideboard: DeckCard[] = [];
   for (const card of payload.pool) {
-    if (commanderSet.has(card.name)) continue;
+    if (commanderSet.has(card.name)) {
+      const surplus = card.quantity - 1;
+      if (surplus > 0) sideboard.push({ name: card.name, quantity: surplus });
+      continue;
+    }
     const status = payload.statuses[card.name] ?? "undecided";
     if (status === "keep") {
       const kept = keptQuantityOf(payload, card);

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -1,0 +1,180 @@
+import type { DeckCard, DeckData } from "@/lib/types";
+import type { ParseResult } from "@/lib/decklist-parser";
+
+const SESSION_KEY = "astral.crucible-session.v1";
+
+export type CrucibleCardStatus = "keep" | "cut" | "undecided";
+
+/**
+ * Snapshot of an in-progress Crucible triage session. Persisted to
+ * sessionStorage under its own key so it can coexist with the reading session.
+ *
+ * Lifecycle:
+ *   - /crucible import success → createCrucibleSession + save
+ *   - triage                    → setCardStatus / commanders updates + save
+ *   - "Seal the Deck"           → buildFinalDeck → setPayload → /ritual
+ */
+export interface CruciblePayload {
+  /** Stable id for this crucible session. Generated at import time. */
+  crucibleId: string;
+  /** Every imported card, quantity-aware. Never mutated by triage. */
+  pool: DeckCard[];
+  /** Triage status per card name. Every pool name has an entry. */
+  statuses: Record<string, CrucibleCardStatus>;
+  /** Chosen commander names (0-2). Must be names present in the pool. */
+  commanders: string[];
+  /** Non-fatal parse warnings from the pile import. */
+  parseWarnings: string[];
+  /** Wall-clock timestamp at import. */
+  createdAt: number;
+}
+
+const isBrowser = () =>
+  typeof window !== "undefined" && typeof window.sessionStorage !== "undefined";
+
+export function generateCrucibleId(): string {
+  if (isBrowser() && typeof window.crypto?.randomUUID === "function") {
+    return window.crypto.randomUUID();
+  }
+  return `crucible-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function createCrucibleSession(
+  pool: DeckCard[],
+  parseWarnings: string[]
+): CruciblePayload {
+  const statuses: Record<string, CrucibleCardStatus> = {};
+  for (const card of pool) statuses[card.name] = "undecided";
+  return {
+    crucibleId: generateCrucibleId(),
+    pool,
+    statuses,
+    commanders: [],
+    parseWarnings,
+    createdAt: Date.now(),
+  };
+}
+
+/**
+ * Fold a parsed decklist back into a flat pile. The parser's commander
+ * inference ("trailing 1-2 cards are the commander") misfires on plain piles,
+ * so the Crucible flattens every zone into one pool and lets the user pick a
+ * commander explicitly. Duplicate names across zones merge, summing quantity.
+ */
+export function flattenPileParse(parsed: ParseResult): {
+  pool: DeckCard[];
+  warnings: string[];
+} {
+  const merged = new Map<string, number>();
+  const zones = [
+    parsed.deck.commanders,
+    parsed.deck.mainboard,
+    parsed.deck.sideboard,
+  ];
+  for (const zone of zones) {
+    for (const card of zone) {
+      merged.set(card.name, (merged.get(card.name) ?? 0) + card.quantity);
+    }
+  }
+  return {
+    pool: Array.from(merged, ([name, quantity]) => ({ name, quantity })),
+    warnings: parsed.warnings,
+  };
+}
+
+export function setCardStatus(
+  payload: CruciblePayload,
+  name: string,
+  status: CrucibleCardStatus
+): CruciblePayload {
+  if (!(name in payload.statuses)) return payload;
+  return { ...payload, statuses: { ...payload.statuses, [name]: status } };
+}
+
+function withStatus(payload: CruciblePayload, status: CrucibleCardStatus): DeckCard[] {
+  return payload.pool.filter((card) => (payload.statuses[card.name] ?? "undecided") === status);
+}
+
+export function keptCards(payload: CruciblePayload): DeckCard[] {
+  return withStatus(payload, "keep");
+}
+
+export function cutCards(payload: CruciblePayload): DeckCard[] {
+  return withStatus(payload, "cut");
+}
+
+export function undecidedCards(payload: CruciblePayload): DeckCard[] {
+  return withStatus(payload, "undecided");
+}
+
+/** Total kept quantity (not unique names). Commanders count via their keep status. */
+export function keptCount(payload: CruciblePayload): number {
+  return keptCards(payload).reduce((sum, c) => sum + c.quantity, 0);
+}
+
+/**
+ * Build the final DeckData for handoff to the reading journey: commanders in
+ * the command zone, kept cards as the mainboard (commanders excluded), and
+ * everything else (cuts and remaining undecided) preserved as the sideboard.
+ */
+export function buildFinalDeck(payload: CruciblePayload, name: string): DeckData {
+  const commanderSet = new Set(payload.commanders);
+  const mainboard: DeckCard[] = [];
+  const sideboard: DeckCard[] = [];
+  for (const card of payload.pool) {
+    if (commanderSet.has(card.name)) continue;
+    const status = payload.statuses[card.name] ?? "undecided";
+    if (status === "keep") mainboard.push(card);
+    else sideboard.push(card);
+  }
+  return {
+    name,
+    source: "text",
+    url: "",
+    commanders: payload.commanders.map((n) => ({ name: n, quantity: 1 })),
+    mainboard,
+    sideboard,
+  };
+}
+
+/** Parse a serialized payload, returning null for corrupt or foreign JSON. */
+export function parseCruciblePayload(raw: string | null): CruciblePayload | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as CruciblePayload;
+    if (!parsed?.crucibleId || !Array.isArray(parsed.pool) || !parsed.statuses) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function loadCrucibleSession(): CruciblePayload | null {
+  if (!isBrowser()) return null;
+  try {
+    return parseCruciblePayload(window.sessionStorage.getItem(SESSION_KEY));
+  } catch {
+    return null;
+  }
+}
+
+export function saveCrucibleSession(payload: CruciblePayload): void {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.setItem(SESSION_KEY, JSON.stringify(payload));
+  } catch {
+    // sessionStorage can throw on quota exceeded or in restrictive private
+    // modes — fail silently; the in-memory context is still valid.
+  }
+}
+
+export function clearCrucibleSession(): void {
+  if (!isBrowser()) return;
+  try {
+    window.sessionStorage.removeItem(SESSION_KEY);
+  } catch {
+    // Ignore.
+  }
+}

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -21,6 +21,9 @@ export interface CruciblePayload {
   pool: DeckCard[];
   /** Triage status per card name. Every pool name has an entry. */
   statuses: Record<string, CrucibleCardStatus>;
+  /** Partial keeps for stacked cards: kept copies per name. Only present for
+   * kept cards keeping fewer than their full pool quantity. */
+  keptQuantities: Record<string, number>;
   /** Chosen commander names (0-2). Must be names present in the pool. */
   commanders: string[];
   /** Non-fatal parse warnings from the pile import. */
@@ -49,6 +52,7 @@ export function createCrucibleSession(
     crucibleId: generateCrucibleId(),
     pool,
     statuses,
+    keptQuantities: {},
     commanders: [],
     parseWarnings,
     createdAt: Date.now(),
@@ -88,7 +92,46 @@ export function setCardStatus(
   status: CrucibleCardStatus
 ): CruciblePayload {
   if (!(name in payload.statuses)) return payload;
-  return { ...payload, statuses: { ...payload.statuses, [name]: status } };
+  const next: CruciblePayload = {
+    ...payload,
+    statuses: { ...payload.statuses, [name]: status },
+  };
+  if (payload.keptQuantities && name in payload.keptQuantities) {
+    const keptQuantities = { ...payload.keptQuantities };
+    delete keptQuantities[name];
+    next.keptQuantities = keptQuantities;
+  }
+  return next;
+}
+
+/**
+ * Keep a partial count of a stacked card (e.g. 30 of 59 Forest). Clamped to
+ * [0, pool quantity]. Zero returns the card to undecided; the full quantity
+ * is a plain keep with no partial entry.
+ */
+export function setKeptQuantity(
+  payload: CruciblePayload,
+  name: string,
+  count: number
+): CruciblePayload {
+  const poolCard = payload.pool.find((card) => card.name === name);
+  if (!poolCard) return payload;
+  const clamped = Math.max(0, Math.min(Math.floor(count), poolCard.quantity));
+  if (clamped === 0) return setCardStatus(payload, name, "undecided");
+  const kept = setCardStatus(payload, name, "keep");
+  if (clamped >= poolCard.quantity) return kept;
+  return {
+    ...kept,
+    keptQuantities: { ...kept.keptQuantities, [name]: clamped },
+  };
+}
+
+/** Kept copies of a pool card: full quantity for a plain keep, the partial
+ * count when one is set, zero when the card is not kept. */
+export function keptQuantityOf(payload: CruciblePayload, card: DeckCard): number {
+  if ((payload.statuses[card.name] ?? "undecided") !== "keep") return 0;
+  const partial = payload.keptQuantities?.[card.name];
+  return partial === undefined ? card.quantity : Math.min(partial, card.quantity);
 }
 
 function withStatus(payload: CruciblePayload, status: CrucibleCardStatus): DeckCard[] {
@@ -96,7 +139,10 @@ function withStatus(payload: CruciblePayload, status: CrucibleCardStatus): DeckC
 }
 
 export function keptCards(payload: CruciblePayload): DeckCard[] {
-  return withStatus(payload, "keep");
+  return withStatus(payload, "keep").map((card) => ({
+    ...card,
+    quantity: keptQuantityOf(payload, card),
+  }));
 }
 
 export function cutCards(payload: CruciblePayload): DeckCard[] {
@@ -124,8 +170,14 @@ export function buildFinalDeck(payload: CruciblePayload, name: string): DeckData
   for (const card of payload.pool) {
     if (commanderSet.has(card.name)) continue;
     const status = payload.statuses[card.name] ?? "undecided";
-    if (status === "keep") mainboard.push(card);
-    else sideboard.push(card);
+    if (status === "keep") {
+      const kept = keptQuantityOf(payload, card);
+      if (kept > 0) mainboard.push({ name: card.name, quantity: kept });
+      const remainder = card.quantity - kept;
+      if (remainder > 0) sideboard.push({ name: card.name, quantity: remainder });
+    } else {
+      sideboard.push(card);
+    }
   }
   return {
     name,
@@ -145,7 +197,7 @@ export function parseCruciblePayload(raw: string | null): CruciblePayload | null
     if (!parsed?.crucibleId || !Array.isArray(parsed.pool) || !parsed.statuses) {
       return null;
     }
-    return parsed;
+    return { ...parsed, keptQuantities: parsed.keptQuantities ?? {} };
   } catch {
     return null;
   }

--- a/src/lib/crucible-session.ts
+++ b/src/lib/crucible-session.ts
@@ -69,7 +69,7 @@ export function flattenPileParse(parsed: ParseResult): {
   pool: DeckCard[];
   warnings: string[];
 } {
-  const merged = new Map<string, number>();
+  const merged = new Map<string, { name: string; quantity: number }>();
   const zones = [
     parsed.deck.commanders,
     parsed.deck.mainboard,
@@ -77,11 +77,16 @@ export function flattenPileParse(parsed: ParseResult): {
   ];
   for (const zone of zones) {
     for (const card of zone) {
-      merged.set(card.name, (merged.get(card.name) ?? 0) + card.quantity);
+      const key = card.name.toLowerCase();
+      const existing = merged.get(key);
+      merged.set(key, {
+        name: existing?.name ?? card.name,
+        quantity: (existing?.quantity ?? 0) + card.quantity,
+      });
     }
   }
   return {
-    pool: Array.from(merged, ([name, quantity]) => ({ name, quantity })),
+    pool: Array.from(merged.values()),
     warnings: parsed.warnings,
   };
 }

--- a/src/lib/cut-suggestions.ts
+++ b/src/lib/cut-suggestions.ts
@@ -1,0 +1,113 @@
+import type { DeckSynergyAnalysis, EnrichedCard } from "@/lib/types";
+import type { CompositionScorecardResult } from "@/lib/deck-composition";
+import type { CruciblePayload } from "@/lib/crucible-session";
+import { WEAK_CARD_THRESHOLD } from "@/lib/card-suggestions";
+import { LANDS_LABEL } from "@/lib/crucible-grouping";
+
+export interface CutSuggestion {
+  name: string;
+  /** Human-readable reasons, e.g. "Low synergy (12)", "Off-identity (B)". */
+  reasons: string[];
+  /** Ranking weight; higher = stronger cut case. */
+  score: number;
+}
+
+const OFF_IDENTITY_WEIGHT = 50;
+const OVERFULL_WEIGHT = 10;
+
+/**
+ * Rank cut candidates for the Crucible's Suggested Cuts panel. Purely
+ * advisory: nothing is cut without an explicit user action.
+ *
+ * Reasons, strongest first:
+ *  - Off-identity: card's color identity is not a subset of the commanders'.
+ *  - Low synergy: synergy score below WEAK_CARD_THRESHOLD (mirrors the
+ *    weak-card detection in card-suggestions.ts).
+ *  - Category overfull: for a scorecard category over its max, the
+ *    (count - max) lowest-synergy members. The Lands category is skipped:
+ *    land counts are tuned in the Charts lens, not by generic cuts.
+ */
+export function suggestCuts(
+  payload: CruciblePayload,
+  cardMap: Record<string, EnrichedCard>,
+  synergy: DeckSynergyAnalysis | null,
+  scorecard: CompositionScorecardResult | null,
+  dismissed?: Set<string> | string[]
+): CutSuggestion[] {
+  const dismissedSet =
+    dismissed instanceof Set ? dismissed : new Set(dismissed ?? []);
+  const commanderSet = new Set(payload.commanders);
+
+  const eligible = (name: string): boolean =>
+    name in payload.statuses &&
+    payload.statuses[name] !== "cut" &&
+    !commanderSet.has(name) &&
+    !dismissedSet.has(name);
+
+  const suggestions = new Map<string, CutSuggestion>();
+  const add = (name: string, reason: string, weight: number) => {
+    const existing = suggestions.get(name);
+    if (existing) {
+      existing.reasons.push(reason);
+      existing.score += weight;
+    } else {
+      suggestions.set(name, { name, reasons: [reason], score: weight });
+    }
+  };
+
+  // Off-identity, once commanders are chosen.
+  if (payload.commanders.length > 0) {
+    const identity = new Set<string>();
+    for (const name of payload.commanders) {
+      for (const color of cardMap[name]?.colorIdentity ?? []) identity.add(color);
+    }
+    for (const card of payload.pool) {
+      if (!eligible(card.name)) continue;
+      const enriched = cardMap[card.name];
+      if (!enriched) continue;
+      const offColors = enriched.colorIdentity.filter((c) => !identity.has(c));
+      if (offColors.length > 0) {
+        add(card.name, `Off-identity (${offColors.join("")})`, OFF_IDENTITY_WEIGHT);
+      }
+    }
+  }
+
+  // Low synergy.
+  if (synergy) {
+    for (const card of payload.pool) {
+      if (!eligible(card.name)) continue;
+      const score = synergy.cardScores[card.name]?.score;
+      if (score !== undefined && score < WEAK_CARD_THRESHOLD) {
+        add(card.name, `Low synergy (${score})`, WEAK_CARD_THRESHOLD - score);
+      }
+    }
+  }
+
+  // Category overfull: weakest members beyond the max.
+  if (scorecard) {
+    for (const category of scorecard.categories) {
+      if (category.label === LANDS_LABEL || category.tag === LANDS_LABEL) continue;
+      const over = category.count - category.max;
+      if (over <= 0) continue;
+      const members = category.cards
+        .filter((c) => eligible(c.name))
+        .sort((a, b) => {
+          const sa = synergy?.cardScores[a.name]?.score ?? 50;
+          const sb = synergy?.cardScores[b.name]?.score ?? 50;
+          return sa - sb || a.name.localeCompare(b.name);
+        })
+        .slice(0, over);
+      for (const member of members) {
+        add(
+          member.name,
+          `${category.label} overfull (${category.count}/${category.max})`,
+          OVERFULL_WEIGHT
+        );
+      }
+    }
+  }
+
+  return Array.from(suggestions.values()).sort(
+    (a, b) => b.score - a.score || a.name.localeCompare(b.name)
+  );
+}

--- a/src/lib/enrich-chunking.ts
+++ b/src/lib/enrich-chunking.ts
@@ -1,0 +1,10 @@
+/** /api/deck-enrich rejects requests above this many unique names, so
+ * clients enrich larger pools in batches of this size. The route derives its
+ * MAX_UNIQUE_NAMES cap from this constant, keeping the two in sync. */
+export const ENRICH_CHUNK_SIZE = 250;
+
+export function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}

--- a/src/lib/scryfall.ts
+++ b/src/lib/scryfall.ts
@@ -5,6 +5,16 @@ const SCRYFALL_API_BASE = "https://api.scryfall.com";
 const BATCH_SIZE = 75;
 const BATCH_DELAY_MS = 100;
 
+/**
+ * Scryfall rejects HTTP clients that send no User-Agent (Node's fetch sends
+ * none by default, yielding 400s), so every server-side Scryfall request must
+ * carry these headers. Matches the UA already used by /api/commander-rules.
+ */
+export const SCRYFALL_REQUEST_HEADERS = {
+  Accept: "application/json",
+  "User-Agent": "DeckEvaluator/1.0",
+} as const;
+
 export interface ScryfallCardFace {
   name?: string;
   mana_cost?: string;
@@ -56,7 +66,7 @@ export async function fetchCardByName(
   const res = await fetch(
     `${SCRYFALL_API_BASE}/cards/named?exact=${encodeURIComponent(name)}`,
     {
-      headers: { Accept: "application/json" },
+      headers: SCRYFALL_REQUEST_HEADERS,
       cache: "no-store",
       signal: AbortSignal.timeout(10_000),
     }
@@ -196,7 +206,7 @@ export async function fetchScryfallSearch(
 
   for (let attempt = 0; attempt <= 1; attempt++) {
     const res = await fetch(url, {
-      headers: { Accept: "application/json" },
+      headers: SCRYFALL_REQUEST_HEADERS,
       cache: "no-store",
       signal: AbortSignal.timeout(10_000),
     });
@@ -238,8 +248,8 @@ async function fetchBatchWithRetry(
     const res = await fetch(`${SCRYFALL_API_BASE}/cards/collection`, {
       method: "POST",
       headers: {
+        ...SCRYFALL_REQUEST_HEADERS,
         "Content-Type": "application/json",
-        Accept: "application/json",
       },
       body: JSON.stringify({ identifiers }),
       signal: signal ?? AbortSignal.timeout(10_000),

--- a/tests/unit/commander-validation.spec.ts
+++ b/tests/unit/commander-validation.spec.ts
@@ -3,6 +3,7 @@ import {
   isSingletonExempt,
   getMaxQuantity,
   validateCommanderDeck,
+  canPairCommanders,
   isLegalCommander,
   validateCommanderSelection,
   validateCommanderLegality,
@@ -172,6 +173,147 @@ test.describe("validateCommanderDeck", () => {
     const result = validateCommanderDeck(deck, {}, bannedSet, gameChangerNames);
     // Should be valid (100 cards total, no singleton violations)
     expect(result.isValid).toBe(true);
+  });
+
+  const PARTNER_REMINDER =
+    "Partner (You can have two commanders if both have partner.)";
+
+  function twoCommanderDeck(a: string, b: string) {
+    const commanders = [
+      { name: a, quantity: 1 },
+      { name: b, quantity: 1 },
+    ];
+    const mainboard = Array.from({ length: 98 }, (_, i) => ({
+      name: `Card ${i + 1}`,
+      quantity: 1,
+    }));
+    return makeDeck({ commanders, mainboard });
+  }
+
+  test("two commanders that both have Partner validate", () => {
+    const cardMap: Record<string, EnrichedCard> = {
+      "Thrasios, Triton Hero": makeCard({
+        name: "Thrasios, Triton Hero",
+        typeLine: "Legendary Creature — Merfolk Wizard",
+        supertypes: ["Legendary"],
+        oracleText: `{4}: Scry 1.\n${PARTNER_REMINDER}`,
+      }),
+      "Tymna the Weaver": makeCard({
+        name: "Tymna the Weaver",
+        typeLine: "Legendary Creature — Human Cleric",
+        supertypes: ["Legendary"],
+        oracleText: `Lifelink\n${PARTNER_REMINDER}`,
+      }),
+    };
+    const deck = twoCommanderDeck("Thrasios, Triton Hero", "Tymna the Weaver");
+    const result = validateCommanderDeck(deck, cardMap, bannedSet, gameChangerNames);
+    expect(result.isValid).toBe(true);
+  });
+
+  test("two commanders without a legal pairing produce a validation error", () => {
+    const cardMap: Record<string, EnrichedCard> = {
+      "Atraxa, Praetors' Voice": makeCard({
+        name: "Atraxa, Praetors' Voice",
+        typeLine: "Legendary Creature — Phyrexian Angel Horror",
+        supertypes: ["Legendary"],
+        oracleText: "Flying, vigilance, deathtouch, lifelink",
+      }),
+      "Ezuri, Stalker of Spheres": makeCard({
+        name: "Ezuri, Stalker of Spheres",
+        typeLine: "Legendary Creature — Phyrexian Elf",
+        supertypes: ["Legendary"],
+        oracleText: "Whenever you cast a noncreature spell, draw a card.",
+      }),
+    };
+    const deck = twoCommanderDeck(
+      "Atraxa, Praetors' Voice",
+      "Ezuri, Stalker of Spheres"
+    );
+    const result = validateCommanderDeck(deck, cardMap, bannedSet, gameChangerNames);
+    expect(result.isValid).toBe(false);
+    expect(result.errors.some((e) => /cannot be paired/i.test(e.message))).toBe(true);
+  });
+});
+
+// --- canPairCommanders ---
+
+test.describe("canPairCommanders", () => {
+  const PARTNER_REMINDER =
+    "Partner (You can have two commanders if both have partner.)";
+
+  test("both plain Partner pair; one-sided Partner does not", () => {
+    const a = makeCard({ name: "A", oracleText: `Vigilance\n${PARTNER_REMINDER}` });
+    const b = makeCard({ name: "B", oracleText: `Flying\n${PARTNER_REMINDER}` });
+    const c = makeCard({ name: "C", oracleText: "Flying" });
+    expect(canPairCommanders(a, b)).toBe(true);
+    expect(canPairCommanders(a, c)).toBe(false);
+  });
+
+  test("mutual 'Partner with' pairs; naming a different card does not", () => {
+    const brallin = makeCard({
+      name: "Brallin, Skyshark Rider",
+      oracleText: "Partner with Shabraz, the Skyshark",
+    });
+    const shabraz = makeCard({
+      name: "Shabraz, the Skyshark",
+      oracleText: "Partner with Brallin, Skyshark Rider",
+    });
+    const stranger = makeCard({
+      name: "Stranger",
+      oracleText: "Partner with Someone Else",
+    });
+    expect(canPairCommanders(brallin, shabraz)).toBe(true);
+    expect(canPairCommanders(brallin, stranger)).toBe(false);
+    // "Partner with" is not plain Partner.
+    expect(canPairCommanders(brallin, makeCard({ name: "P", oracleText: PARTNER_REMINDER }))).toBe(false);
+  });
+
+  test("Friends forever on both pairs", () => {
+    const a = makeCard({
+      name: "Bjorna",
+      oracleText: "Friends forever (You can have two commanders if both have friends forever.)",
+    });
+    const b = makeCard({
+      name: "Elmar",
+      oracleText: "Friends forever (You can have two commanders if both have friends forever.)",
+    });
+    expect(canPairCommanders(a, b)).toBe(true);
+    expect(canPairCommanders(a, makeCard({ name: "C", oracleText: "" }))).toBe(false);
+  });
+
+  test("Choose a Background pairs with a Background enchantment, either order", () => {
+    const wilson = makeCard({
+      name: "Wilson, Refined Grizzly",
+      typeLine: "Legendary Creature — Bear",
+      oracleText: "Choose a Background (You can have a Background as a second commander.)",
+    });
+    const background = makeCard({
+      name: "Raised by Giants",
+      typeLine: "Legendary Enchantment — Background",
+      oracleText: "Commander creatures you own have base power and toughness 10/10.",
+    });
+    expect(canPairCommanders(wilson, background)).toBe(true);
+    expect(canPairCommanders(background, wilson)).toBe(true);
+    expect(
+      canPairCommanders(background, makeCard({ name: "C", oracleText: "" }))
+    ).toBe(false);
+  });
+
+  test("a Time Lord Doctor pairs with a Doctor's companion", () => {
+    const doctor = makeCard({
+      name: "The Tenth Doctor",
+      typeLine: "Legendary Creature — Time Lord Doctor",
+      oracleText: "Allons-y!",
+    });
+    const companion = makeCard({
+      name: "Rose Tyler",
+      typeLine: "Legendary Creature — Human",
+      oracleText:
+        "Doctor's companion (You can have two commanders if the other is the Doctor.)",
+    });
+    expect(canPairCommanders(doctor, companion)).toBe(true);
+    expect(canPairCommanders(companion, doctor)).toBe(true);
+    expect(canPairCommanders(doctor, makeCard({ name: "C", oracleText: "" }))).toBe(false);
   });
 });
 

--- a/tests/unit/commander-validation.spec.ts
+++ b/tests/unit/commander-validation.spec.ts
@@ -268,6 +268,25 @@ test.describe("canPairCommanders", () => {
     expect(canPairCommanders(brallin, makeCard({ name: "P", oracleText: PARTNER_REMINDER }))).toBe(false);
   });
 
+  test("restricted-group Partner pairs only within the same group", () => {
+    const alphaOne = makeCard({
+      name: "Alpha One",
+      oracleText: "Partner — Advisors (You can have two commanders if both have partner with the same group.)",
+    });
+    const alphaTwo = makeCard({
+      name: "Alpha Two",
+      oracleText: "Partner — Advisors (You can have two commanders if both have partner with the same group.)",
+    });
+    const betaOne = makeCard({
+      name: "Beta One",
+      oracleText: "Partner — Warlords (You can have two commanders if both have partner with the same group.)",
+    });
+    const plainPartner = makeCard({ name: "Plain", oracleText: PARTNER_REMINDER });
+    expect(canPairCommanders(alphaOne, alphaTwo)).toBe(true);
+    expect(canPairCommanders(alphaOne, betaOne)).toBe(false);
+    expect(canPairCommanders(alphaOne, plainPartner)).toBe(false);
+  });
+
   test("Friends forever on both pairs", () => {
     const a = makeCard({
       name: "Bjorna",

--- a/tests/unit/crucible-grouping.spec.ts
+++ b/tests/unit/crucible-grouping.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect } from "@playwright/test";
+import {
+  groupByCategory,
+  groupBySynergyAxis,
+  groupByTypeLine,
+  groupByManaValue,
+  groupByColorIdentity,
+  gameChangers,
+  UNCATEGORIZED_LABEL,
+  UNALIGNED_AXIS_ID,
+  AXIS_RELEVANCE_MIN,
+} from "../../src/lib/crucible-grouping";
+import { makeCard } from "../helpers";
+import type { DeckCard, EnrichedCard } from "../../src/lib/types";
+
+const SOL_RING = makeCard({
+  name: "Sol Ring",
+  typeLine: "Artifact",
+  manaCost: "{1}",
+  cmc: 1,
+  oracleText: "{T}: Add {C}{C}.",
+  isGameChanger: true,
+});
+
+const PLAINS = makeCard({
+  name: "Plains",
+  typeLine: "Basic Land — Plains",
+  cmc: 0,
+  supertypes: ["Basic"],
+});
+
+const VANILLA = makeCard({
+  name: "Grizzly Bears",
+  typeLine: "Creature — Bear",
+  manaCost: "{1}{G}",
+  cmc: 2,
+  colors: ["G"],
+  colorIdentity: ["G"],
+});
+
+const TOKEN_MAKER = makeCard({
+  name: "Secure the Wastes",
+  typeLine: "Instant",
+  manaCost: "{X}{W}",
+  cmc: 1,
+  colors: ["W"],
+  colorIdentity: ["W"],
+  oracleText: "Create X 1/1 white Warrior creature tokens.",
+});
+
+const GOLD_CARD = makeCard({
+  name: "Wilt-Leaf Liege",
+  typeLine: "Creature — Elf Knight",
+  manaCost: "{1}{G/W}{G/W}{G/W}",
+  cmc: 4,
+  colors: ["G", "W"],
+  colorIdentity: ["G", "W"],
+});
+
+const BIG_SPELL = makeCard({
+  name: "Expropriate",
+  typeLine: "Sorcery",
+  manaCost: "{7}{U}{U}",
+  cmc: 9,
+  colors: ["U"],
+  colorIdentity: ["U"],
+});
+
+function pool(...cards: EnrichedCard[]): {
+  pool: DeckCard[];
+  cardMap: Record<string, EnrichedCard>;
+} {
+  return {
+    pool: cards.map((c) => ({ name: c.name, quantity: 1 })),
+    cardMap: Object.fromEntries(cards.map((c) => [c.name, c])),
+  };
+}
+
+test.describe("groupByCategory", () => {
+  test("lands get their own group, untagged cards land in Uncategorized", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, PLAINS, VANILLA);
+    const groups = groupByCategory(p, cardMap);
+
+    const lands = groups.find((g) => g.label === "Lands");
+    expect(lands?.cards).toEqual([{ name: "Plains", quantity: 1 }]);
+
+    const ramp = groups.find((g) => g.label === "Ramp");
+    expect(ramp?.cards.map((c) => c.name)).toContain("Sol Ring");
+
+    const uncategorized = groups.find((g) => g.label === UNCATEGORIZED_LABEL);
+    expect(uncategorized?.cards.map((c) => c.name)).toContain("Grizzly Bears");
+  });
+
+  test("cards missing from the cardMap are skipped, group cards sort by name", () => {
+    const { cardMap } = pool(SOL_RING, PLAINS);
+    const p: DeckCard[] = [
+      { name: "Sol Ring", quantity: 1 },
+      { name: "Unenriched Mystery", quantity: 1 },
+      { name: "Plains", quantity: 1 },
+    ];
+    const groups = groupByCategory(p, cardMap);
+    const all = groups.flatMap((g) => g.cards.map((c) => c.name));
+    expect(all).not.toContain("Unenriched Mystery");
+    for (const g of groups) {
+      const names = g.cards.map((c) => c.name);
+      expect(names).toEqual([...names].sort());
+    }
+  });
+});
+
+test.describe("groupBySynergyAxis", () => {
+  test("assigns each card to its strongest axis only, with other homes listed", () => {
+    const { pool: p, cardMap } = pool(TOKEN_MAKER, VANILLA);
+    const groups = groupBySynergyAxis(p, cardMap);
+
+    const tokenGroup = groups.find((g) => g.axisId === "tokens");
+    expect(tokenGroup).toBeTruthy();
+    const entry = tokenGroup!.cards.find((c) => c.name === "Secure the Wastes");
+    expect(entry).toBeTruthy();
+    expect(entry!.relevance).toBeGreaterThanOrEqual(AXIS_RELEVANCE_MIN);
+
+    // The card must not appear in any other axis group.
+    for (const g of groups) {
+      if (g.axisId === "tokens" || g.axisId === UNALIGNED_AXIS_ID) continue;
+      expect(g.cards.map((c) => c.name)).not.toContain("Secure the Wastes");
+    }
+  });
+
+  test("cards with no axis above the threshold collect in the unaligned bucket", () => {
+    const { pool: p, cardMap } = pool(VANILLA);
+    const groups = groupBySynergyAxis(p, cardMap);
+    const unaligned = groups.find((g) => g.axisId === UNALIGNED_AXIS_ID);
+    expect(unaligned?.cards.map((c) => c.name)).toContain("Grizzly Bears");
+  });
+
+  test("axis groups sort cards by relevance desc, then name", () => {
+    const { pool: p, cardMap } = pool(TOKEN_MAKER, VANILLA, SOL_RING);
+    const groups = groupBySynergyAxis(p, cardMap);
+    for (const g of groups) {
+      for (let i = 1; i < g.cards.length; i++) {
+        const prev = g.cards[i - 1];
+        const cur = g.cards[i];
+        const ordered =
+          prev.relevance > cur.relevance ||
+          (prev.relevance === cur.relevance && prev.name <= cur.name);
+        expect(ordered).toBe(true);
+      }
+    }
+  });
+});
+
+test.describe("groupByTypeLine", () => {
+  test("buckets by primary card type with lands separate", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, PLAINS, VANILLA, TOKEN_MAKER);
+    const groups = groupByTypeLine(p, cardMap);
+    expect(groups.find((g) => g.label === "Creature")?.cards.map((c) => c.name)).toContain("Grizzly Bears");
+    expect(groups.find((g) => g.label === "Artifact")?.cards.map((c) => c.name)).toContain("Sol Ring");
+    expect(groups.find((g) => g.label === "Instant")?.cards.map((c) => c.name)).toContain("Secure the Wastes");
+    expect(groups.find((g) => g.label === "Lands")?.cards.map((c) => c.name)).toContain("Plains");
+  });
+});
+
+test.describe("groupByManaValue", () => {
+  test("buckets 0-1, 2, 7+ and keeps lands out of the numeric buckets", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, PLAINS, VANILLA, BIG_SPELL);
+    const groups = groupByManaValue(p, cardMap);
+    expect(groups.find((g) => g.label === "0–1")?.cards.map((c) => c.name)).toContain("Sol Ring");
+    expect(groups.find((g) => g.label === "2")?.cards.map((c) => c.name)).toContain("Grizzly Bears");
+    expect(groups.find((g) => g.label === "7+")?.cards.map((c) => c.name)).toContain("Expropriate");
+    const numeric = groups.filter((g) => g.label !== "Lands");
+    for (const g of numeric) {
+      expect(g.cards.map((c) => c.name)).not.toContain("Plains");
+    }
+    expect(groups.find((g) => g.label === "Lands")?.cards.map((c) => c.name)).toContain("Plains");
+  });
+});
+
+test.describe("groupByColorIdentity", () => {
+  test("mono, multicolor, and colorless bucket correctly", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, VANILLA, TOKEN_MAKER, GOLD_CARD);
+    const groups = groupByColorIdentity(p, cardMap);
+    expect(groups.find((g) => g.label === "White")?.cards.map((c) => c.name)).toContain("Secure the Wastes");
+    expect(groups.find((g) => g.label === "Green")?.cards.map((c) => c.name)).toContain("Grizzly Bears");
+    expect(groups.find((g) => g.label === "Multicolor")?.cards.map((c) => c.name)).toContain("Wilt-Leaf Liege");
+    expect(groups.find((g) => g.label === "Colorless")?.cards.map((c) => c.name)).toContain("Sol Ring");
+  });
+});
+
+test.describe("gameChangers", () => {
+  test("filters cards flagged isGameChanger", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, VANILLA);
+    expect(gameChangers(p, cardMap)).toEqual([{ name: "Sol Ring", quantity: 1 }]);
+  });
+});

--- a/tests/unit/crucible-grouping.spec.ts
+++ b/tests/unit/crucible-grouping.spec.ts
@@ -93,7 +93,7 @@ test.describe("groupByCategory", () => {
     expect(uncategorized?.cards.map((c) => c.name)).toContain("Grizzly Bears");
   });
 
-  test("cards missing from the cardMap are skipped, group cards sort by name", () => {
+  test("cards missing from the cardMap surface only in Unresolved, group cards sort by name", () => {
     const { cardMap } = pool(SOL_RING, PLAINS);
     const p: DeckCard[] = [
       { name: "Sol Ring", quantity: 1 },
@@ -101,10 +101,13 @@ test.describe("groupByCategory", () => {
       { name: "Plains", quantity: 1 },
     ];
     const groups = groupByCategory(p, cardMap);
-    const all = groups.flatMap((g) => g.cards.map((c) => c.name));
-    expect(all).not.toContain("Unenriched Mystery");
+    const unresolved = groups.find((g) => g.id === UNRESOLVED_GROUP_ID);
+    expect(unresolved?.cards.map((c) => c.name)).toEqual(["Unenriched Mystery"]);
     for (const g of groups) {
       const names = g.cards.map((c) => c.name);
+      if (g.id !== UNRESOLVED_GROUP_ID) {
+        expect(names).not.toContain("Unenriched Mystery");
+      }
       expect(names).toEqual([...names].sort());
     }
   });

--- a/tests/unit/crucible-grouping.spec.ts
+++ b/tests/unit/crucible-grouping.spec.ts
@@ -8,6 +8,8 @@ import {
   gameChangers,
   UNCATEGORIZED_LABEL,
   UNALIGNED_AXIS_ID,
+  UNRESOLVED_LABEL,
+  UNRESOLVED_GROUP_ID,
   AXIS_RELEVANCE_MIN,
 } from "../../src/lib/crucible-grouping";
 import { makeCard } from "../helpers";
@@ -190,5 +192,44 @@ test.describe("gameChangers", () => {
   test("filters cards flagged isGameChanger", () => {
     const { pool: p, cardMap } = pool(SOL_RING, VANILLA);
     expect(gameChangers(p, cardMap)).toEqual([{ name: "Sol Ring", quantity: 1 }]);
+  });
+});
+
+test.describe("unresolved cards", () => {
+  const TYPO = { name: "Lighming Bolt", quantity: 2 };
+
+  test("collect in a trailing Unresolved group so counts add up", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, PLAINS);
+    for (const grouper of [
+      groupByCategory,
+      groupByTypeLine,
+      groupByManaValue,
+      groupByColorIdentity,
+    ]) {
+      const groups = grouper([...p, TYPO], cardMap);
+      const unresolved = groups[groups.length - 1];
+      expect(unresolved.id).toBe(UNRESOLVED_GROUP_ID);
+      expect(unresolved.label).toBe(UNRESOLVED_LABEL);
+      expect(unresolved.cards).toEqual([TYPO]);
+      const grouped = groups.flatMap((g) => g.cards.map((c) => c.name));
+      expect(new Set(grouped)).toEqual(
+        new Set([...p.map((c) => c.name), TYPO.name])
+      );
+    }
+  });
+
+  test("appear as a trailing axis group in the synergy lens", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, TOKEN_MAKER);
+    const groups = groupBySynergyAxis([...p, TYPO], cardMap);
+    const last = groups[groups.length - 1];
+    expect(last.axisId).toBe(UNRESOLVED_GROUP_ID);
+    expect(last.axisName).toBe(UNRESOLVED_LABEL);
+    expect(last.cards).toEqual([{ ...TYPO, relevance: 0, otherAxes: [] }]);
+  });
+
+  test("no Unresolved group when every card enriched", () => {
+    const { pool: p, cardMap } = pool(SOL_RING, PLAINS);
+    const groups = groupByCategory(p, cardMap);
+    expect(groups.some((g) => g.id === UNRESOLVED_GROUP_ID)).toBe(false);
   });
 });

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -253,4 +253,16 @@ test.describe("parseCruciblePayload", () => {
     expect(parseCruciblePayload(JSON.stringify({ hello: "world" }))).toBeNull();
     expect(parseCruciblePayload(null)).toBeNull();
   });
+
+  test("defaults missing commanders, parseWarnings, and keptQuantities", () => {
+    const { commanders, parseWarnings, keptQuantities, ...partial } = session();
+    void commanders;
+    void parseWarnings;
+    void keptQuantities;
+    const restored = parseCruciblePayload(JSON.stringify(partial));
+    expect(restored).not.toBeNull();
+    expect(restored?.commanders).toEqual([]);
+    expect(restored?.parseWarnings).toEqual([]);
+    expect(restored?.keptQuantities).toEqual({});
+  });
 });

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import {
   createCrucibleSession,
   flattenPileParse,
+  addCardToPool,
   setCardStatus,
   setKeptQuantity,
   keptQuantityOf,
@@ -73,6 +74,33 @@ test.describe("flattenPileParse", () => {
     };
     const { pool } = flattenPileParse(parsed);
     expect(pool).toEqual([{ name: "Plains", quantity: 8 }]);
+  });
+});
+
+test.describe("addCardToPool", () => {
+  test("appends a new card as quantity 1 with undecided status (immutable)", () => {
+    const before = session();
+    const after = addCardToPool(before, "Birds of Paradise");
+    expect(after).not.toBe(before);
+    expect(after.pool).toContainEqual({ name: "Birds of Paradise", quantity: 1 });
+    expect(after.statuses["Birds of Paradise"]).toBe("undecided");
+    expect(before.pool.find((c) => c.name === "Birds of Paradise")).toBeUndefined();
+  });
+
+  test("bumps quantity for a name already in the pool, preserving its status", () => {
+    let payload = session();
+    payload = setCardStatus(payload, "Sol Ring", "keep");
+    const after = addCardToPool(payload, "Sol Ring");
+    expect(after.pool.find((c) => c.name === "Sol Ring")?.quantity).toBe(2);
+    expect(after.statuses["Sol Ring"]).toBe("keep");
+  });
+
+  test("preserves a partial keep count when bumping a stacked card", () => {
+    let payload = session();
+    payload = setKeptQuantity(payload, "Plains", 5);
+    const after = addCardToPool(payload, "Plains");
+    expect(after.pool.find((c) => c.name === "Plains")?.quantity).toBe(13);
+    expect(keptQuantityOf(after, { name: "Plains", quantity: 13 })).toBe(5);
   });
 });
 

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -76,6 +76,18 @@ test.describe("flattenPileParse", () => {
     const { pool } = flattenPileParse(parsed);
     expect(pool).toEqual([{ name: "Plains", quantity: 8 }]);
   });
+
+  test("merges duplicate names across zones case-insensitively", () => {
+    const parsed = {
+      deck: makeDeck({
+        mainboard: [{ name: "Sol Ring", quantity: 1 }],
+        sideboard: [{ name: "sol ring", quantity: 1 }],
+      }),
+      warnings: [],
+    };
+    const { pool } = flattenPileParse(parsed);
+    expect(pool).toEqual([{ name: "Sol Ring", quantity: 2 }]);
+  });
 });
 
 test.describe("appendCardToPileText", () => {

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -106,6 +106,10 @@ test.describe("appendCardToPileText", () => {
       `${text}\n1 Counterspell`
     );
   });
+
+  test("bumps the count of an indented line instead of silently no-oping", () => {
+    expect(appendCardToPileText("  3 Sol Ring", "Sol Ring")).toBe("4 Sol Ring");
+  });
 });
 
 test.describe("addCardToPool", () => {
@@ -132,6 +136,13 @@ test.describe("addCardToPool", () => {
     const after = addCardToPool(payload, "Plains");
     expect(after.pool.find((c) => c.name === "Plains")?.quantity).toBe(13);
     expect(keptQuantityOf(after, { name: "Plains", quantity: 13 })).toBe(5);
+  });
+
+  test("matches an existing pool entry case-insensitively instead of duplicating it", () => {
+    const before = session();
+    const after = addCardToPool(before, "sol ring");
+    expect(after.pool.filter((c) => c.name.toLowerCase() === "sol ring")).toHaveLength(1);
+    expect(after.pool.find((c) => c.name === "Sol Ring")?.quantity).toBe(2);
   });
 });
 

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -3,6 +3,7 @@ import {
   createCrucibleSession,
   flattenPileParse,
   addCardToPool,
+  appendCardToPileText,
   setCardStatus,
   setKeptQuantity,
   keptQuantityOf,
@@ -74,6 +75,36 @@ test.describe("flattenPileParse", () => {
     };
     const { pool } = flattenPileParse(parsed);
     expect(pool).toEqual([{ name: "Plains", quantity: 8 }]);
+  });
+});
+
+test.describe("appendCardToPileText", () => {
+  test("empty text becomes a single quantity-1 line", () => {
+    expect(appendCardToPileText("", "Sol Ring")).toBe("1 Sol Ring");
+    expect(appendCardToPileText("   \n", "Sol Ring")).toBe("1 Sol Ring");
+  });
+
+  test("appends a new line after existing entries", () => {
+    expect(appendCardToPileText("1 Sol Ring", "Cultivate")).toBe(
+      "1 Sol Ring\n1 Cultivate"
+    );
+  });
+
+  test("bumps the count of an existing line instead of duplicating it", () => {
+    expect(appendCardToPileText("1 Sol Ring\n3 Forest", "Forest")).toBe(
+      "1 Sol Ring\n4 Forest"
+    );
+  });
+
+  test("preserves the Nx count form and matches names case-insensitively", () => {
+    expect(appendCardToPileText("4x forest", "Forest")).toBe("5x forest");
+  });
+
+  test("leaves untouched lines exactly as typed", () => {
+    const text = "COMMANDER:\n1 Atraxa, Praetors' Voice\n\n1 Sol Ring";
+    expect(appendCardToPileText(text, "Counterspell")).toBe(
+      `${text}\n1 Counterspell`
+    );
   });
 });
 

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -3,6 +3,8 @@ import {
   createCrucibleSession,
   flattenPileParse,
   setCardStatus,
+  setKeptQuantity,
+  keptQuantityOf,
   keptCards,
   cutCards,
   undecidedCards,
@@ -90,6 +92,43 @@ test.describe("setCardStatus", () => {
   });
 });
 
+test.describe("setKeptQuantity", () => {
+  test("keeps a partial count of a stacked card", () => {
+    const payload = setKeptQuantity(session(), "Plains", 5);
+    expect(payload.statuses["Plains"]).toBe("keep");
+    expect(payload.keptQuantities["Plains"]).toBe(5);
+    expect(keptQuantityOf(payload, { name: "Plains", quantity: 12 })).toBe(5);
+    expect(keptCount(payload)).toBe(5);
+  });
+
+  test("clamps to the pool quantity and drops the partial entry at full", () => {
+    const payload = setKeptQuantity(session(), "Plains", 40);
+    expect(payload.statuses["Plains"]).toBe("keep");
+    expect(payload.keptQuantities["Plains"]).toBeUndefined();
+    expect(keptCount(payload)).toBe(12);
+  });
+
+  test("zero returns the card to undecided", () => {
+    let payload = setKeptQuantity(session(), "Plains", 5);
+    payload = setKeptQuantity(payload, "Plains", 0);
+    expect(payload.statuses["Plains"]).toBe("undecided");
+    expect(payload.keptQuantities["Plains"]).toBeUndefined();
+    expect(keptCount(payload)).toBe(0);
+  });
+
+  test("ignores names not in the pool", () => {
+    const before = session();
+    expect(setKeptQuantity(before, "Black Lotus", 3)).toBe(before);
+  });
+
+  test("the all-or-nothing shortcut clears a partial keep", () => {
+    let payload = setKeptQuantity(session(), "Plains", 5);
+    payload = setCardStatus(payload, "Plains", "keep");
+    expect(payload.keptQuantities["Plains"]).toBeUndefined();
+    expect(keptCount(payload)).toBe(12);
+  });
+});
+
 test.describe("partitions", () => {
   test("kept / cut / undecided partition the pool, quantity-aware", () => {
     let payload = session();
@@ -131,6 +170,15 @@ test.describe("buildFinalDeck", () => {
       "Cultivate",
       "Plains",
     ]);
+  });
+
+  test("a partial keep splits the stack: kept portion mainboard, remainder sideboard", () => {
+    let payload = session();
+    payload = setKeptQuantity(payload, "Plains", 5);
+
+    const deck = buildFinalDeck(payload, "Split Stack");
+    expect(deck.mainboard).toContainEqual({ name: "Plains", quantity: 5 });
+    expect(deck.sideboard).toContainEqual({ name: "Plains", quantity: 7 });
   });
 });
 

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -177,6 +177,16 @@ test.describe("partitions", () => {
     payload = setCardStatus(payload, "Sol Ring", "keep");
     expect(keptCount(payload)).toBe(13);
   });
+
+  test("keptCount counts a stacked commander as a single copy", () => {
+    let payload = session({
+      pool: [...POOL.slice(0, 3), { name: "Adeline, Resplendent Cathar", quantity: 2 }],
+      commanders: ["Adeline, Resplendent Cathar"],
+    });
+    payload = setCardStatus(payload, "Adeline, Resplendent Cathar", "keep");
+    payload = setCardStatus(payload, "Sol Ring", "keep");
+    expect(keptCount(payload)).toBe(2);
+  });
 });
 
 test.describe("buildFinalDeck", () => {
@@ -207,6 +217,26 @@ test.describe("buildFinalDeck", () => {
     const deck = buildFinalDeck(payload, "Split Stack");
     expect(deck.mainboard).toContainEqual({ name: "Plains", quantity: 5 });
     expect(deck.sideboard).toContainEqual({ name: "Plains", quantity: 7 });
+  });
+
+  test("surplus commander copies land in the sideboard, one copy in the command zone", () => {
+    let payload = session({
+      pool: [...POOL.slice(0, 3), { name: "Adeline, Resplendent Cathar", quantity: 2 }],
+      commanders: ["Adeline, Resplendent Cathar"],
+    });
+    payload = setCardStatus(payload, "Adeline, Resplendent Cathar", "keep");
+
+    const deck = buildFinalDeck(payload, "Double Adeline");
+    expect(deck.commanders).toEqual([
+      { name: "Adeline, Resplendent Cathar", quantity: 1 },
+    ]);
+    expect(deck.mainboard.map((c) => c.name)).not.toContain(
+      "Adeline, Resplendent Cathar"
+    );
+    expect(deck.sideboard).toContainEqual({
+      name: "Adeline, Resplendent Cathar",
+      quantity: 1,
+    });
   });
 });
 

--- a/tests/unit/crucible-session.spec.ts
+++ b/tests/unit/crucible-session.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from "@playwright/test";
+import {
+  createCrucibleSession,
+  flattenPileParse,
+  setCardStatus,
+  keptCards,
+  cutCards,
+  undecidedCards,
+  keptCount,
+  buildFinalDeck,
+  parseCruciblePayload,
+  type CruciblePayload,
+} from "../../src/lib/crucible-session";
+import { makeDeck } from "../helpers";
+import type { DeckCard } from "../../src/lib/types";
+
+const POOL: DeckCard[] = [
+  { name: "Sol Ring", quantity: 1 },
+  { name: "Cultivate", quantity: 1 },
+  { name: "Plains", quantity: 12 },
+  { name: "Adeline, Resplendent Cathar", quantity: 1 },
+];
+
+function session(overrides: Partial<CruciblePayload> = {}): CruciblePayload {
+  return { ...createCrucibleSession(POOL, []), ...overrides };
+}
+
+test.describe("createCrucibleSession", () => {
+  test("defaults every card to undecided and generates an id", () => {
+    const payload = createCrucibleSession(POOL, ["warn one"]);
+    expect(payload.crucibleId).toBeTruthy();
+    expect(payload.parseWarnings).toEqual(["warn one"]);
+    expect(payload.commanders).toEqual([]);
+    expect(payload.pool).toEqual(POOL);
+    for (const card of POOL) {
+      expect(payload.statuses[card.name]).toBe("undecided");
+    }
+  });
+
+  test("two sessions get distinct ids", () => {
+    const a = createCrucibleSession(POOL, []);
+    const b = createCrucibleSession(POOL, []);
+    expect(a.crucibleId).not.toBe(b.crucibleId);
+  });
+});
+
+test.describe("flattenPileParse", () => {
+  test("folds parser-inferred commanders back into the pool", () => {
+    const parsed = {
+      deck: makeDeck({
+        commanders: [{ name: "Adeline, Resplendent Cathar", quantity: 1 }],
+        mainboard: [{ name: "Sol Ring", quantity: 1 }],
+        sideboard: [{ name: "Swords to Plowshares", quantity: 1 }],
+      }),
+      warnings: ["a warning"],
+    };
+    const { pool, warnings } = flattenPileParse(parsed);
+    expect(warnings).toEqual(["a warning"]);
+    expect(pool).toContainEqual({ name: "Adeline, Resplendent Cathar", quantity: 1 });
+    expect(pool).toContainEqual({ name: "Sol Ring", quantity: 1 });
+    expect(pool).toContainEqual({ name: "Swords to Plowshares", quantity: 1 });
+  });
+
+  test("merges duplicate names across zones, summing quantities", () => {
+    const parsed = {
+      deck: makeDeck({
+        mainboard: [{ name: "Plains", quantity: 5 }],
+        sideboard: [{ name: "Plains", quantity: 3 }],
+      }),
+      warnings: [],
+    };
+    const { pool } = flattenPileParse(parsed);
+    expect(pool).toEqual([{ name: "Plains", quantity: 8 }]);
+  });
+});
+
+test.describe("setCardStatus", () => {
+  test("returns a new payload with the status flipped (immutable)", () => {
+    const before = session();
+    const after = setCardStatus(before, "Sol Ring", "keep");
+    expect(after).not.toBe(before);
+    expect(after.statuses["Sol Ring"]).toBe("keep");
+    expect(before.statuses["Sol Ring"]).toBe("undecided");
+  });
+
+  test("ignores names not in the pool", () => {
+    const before = session();
+    const after = setCardStatus(before, "Black Lotus", "keep");
+    expect(after.statuses["Black Lotus"]).toBeUndefined();
+  });
+});
+
+test.describe("partitions", () => {
+  test("kept / cut / undecided partition the pool, quantity-aware", () => {
+    let payload = session();
+    payload = setCardStatus(payload, "Sol Ring", "keep");
+    payload = setCardStatus(payload, "Cultivate", "cut");
+
+    expect(keptCards(payload)).toEqual([{ name: "Sol Ring", quantity: 1 }]);
+    expect(cutCards(payload)).toEqual([{ name: "Cultivate", quantity: 1 }]);
+    expect(undecidedCards(payload).map((c) => c.name).sort()).toEqual([
+      "Adeline, Resplendent Cathar",
+      "Plains",
+    ]);
+  });
+
+  test("keptCount sums quantities, not unique names", () => {
+    let payload = session();
+    payload = setCardStatus(payload, "Plains", "keep");
+    payload = setCardStatus(payload, "Sol Ring", "keep");
+    expect(keptCount(payload)).toBe(13);
+  });
+});
+
+test.describe("buildFinalDeck", () => {
+  test("kept cards become the mainboard, cuts and undecided the sideboard, commanders excluded from mainboard", () => {
+    let payload = session({ commanders: ["Adeline, Resplendent Cathar"] });
+    payload = setCardStatus(payload, "Adeline, Resplendent Cathar", "keep");
+    payload = setCardStatus(payload, "Sol Ring", "keep");
+    payload = setCardStatus(payload, "Cultivate", "cut");
+    // Plains left undecided.
+
+    const deck = buildFinalDeck(payload, "Adeline's Hundred");
+    expect(deck.name).toBe("Adeline's Hundred");
+    expect(deck.source).toBe("text");
+    expect(deck.commanders).toEqual([
+      { name: "Adeline, Resplendent Cathar", quantity: 1 },
+    ]);
+    expect(deck.mainboard).toEqual([{ name: "Sol Ring", quantity: 1 }]);
+    expect(deck.sideboard.map((c) => c.name).sort()).toEqual([
+      "Cultivate",
+      "Plains",
+    ]);
+  });
+});
+
+test.describe("parseCruciblePayload", () => {
+  test("round-trips a serialized payload", () => {
+    let payload = session({ commanders: ["Adeline, Resplendent Cathar"] });
+    payload = setCardStatus(payload, "Sol Ring", "keep");
+    const restored = parseCruciblePayload(JSON.stringify(payload));
+    expect(restored).toEqual(payload);
+  });
+
+  test("returns null for corrupt or foreign JSON", () => {
+    expect(parseCruciblePayload("not json {")).toBeNull();
+    expect(parseCruciblePayload(JSON.stringify({ hello: "world" }))).toBeNull();
+    expect(parseCruciblePayload(null)).toBeNull();
+  });
+});

--- a/tests/unit/cut-suggestions.spec.ts
+++ b/tests/unit/cut-suggestions.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from "@playwright/test";
+import { suggestCuts, type CutSuggestion } from "../../src/lib/cut-suggestions";
+import {
+  createCrucibleSession,
+  setCardStatus,
+  type CruciblePayload,
+} from "../../src/lib/crucible-session";
+import { makeCard } from "../helpers";
+import type { DeckSynergyAnalysis, EnrichedCard } from "../../src/lib/types";
+import type { CompositionScorecardResult } from "../../src/lib/deck-composition";
+
+const ADELINE = makeCard({
+  name: "Adeline, Resplendent Cathar",
+  typeLine: "Legendary Creature — Human Knight",
+  colorIdentity: ["W"],
+});
+const SOL_RING = makeCard({ name: "Sol Ring", typeLine: "Artifact", colorIdentity: [] });
+const MURDER = makeCard({ name: "Murder", typeLine: "Instant", colorIdentity: ["B"] });
+const MANALITH = makeCard({ name: "Manalith", typeLine: "Artifact", colorIdentity: [] });
+const CULTIVATE = makeCard({ name: "Cultivate", typeLine: "Sorcery", colorIdentity: ["G"] });
+
+const CARDS: EnrichedCard[] = [ADELINE, SOL_RING, MURDER, MANALITH, CULTIVATE];
+const CARD_MAP = Object.fromEntries(CARDS.map((c) => [c.name, c]));
+
+function payloadWith(commanders: string[] = []): CruciblePayload {
+  return {
+    ...createCrucibleSession(
+      CARDS.map((c) => ({ name: c.name, quantity: 1 })),
+      []
+    ),
+    commanders,
+  };
+}
+
+function synergyWith(scores: Record<string, number>): DeckSynergyAnalysis {
+  return {
+    cardScores: Object.fromEntries(
+      Object.entries(scores).map(([name, score]) => [
+        name,
+        { cardName: name, score, axes: [], pairs: [] },
+      ])
+    ),
+    topSynergies: [],
+    antiSynergies: [],
+    knownCombos: [],
+    deckThemes: [],
+  } as unknown as DeckSynergyAnalysis;
+}
+
+function scorecardWith(
+  categories: CompositionScorecardResult["categories"]
+): CompositionScorecardResult {
+  return {
+    templateId: "command-zone",
+    templateName: "Command Zone",
+    categories,
+    overallHealth: "healthy",
+    healthSummary: "",
+    untaggedCount: 0,
+    untaggedCards: [],
+  };
+}
+
+function names(suggestions: CutSuggestion[]): string[] {
+  return suggestions.map((s) => s.name);
+}
+
+test.describe("suggestCuts", () => {
+  test("off-identity cards are suggested once commanders are set", () => {
+    const payload = payloadWith(["Adeline, Resplendent Cathar"]);
+    const suggestions = suggestCuts(payload, CARD_MAP, null, null);
+    const murder = suggestions.find((s) => s.name === "Murder");
+    expect(murder).toBeTruthy();
+    expect(murder!.reasons.join(" ")).toMatch(/off-identity/i);
+    // Cultivate (G) is also off a mono-W identity.
+    expect(names(suggestions)).toContain("Cultivate");
+    // Colorless artifacts are fine.
+    expect(names(suggestions)).not.toContain("Sol Ring");
+  });
+
+  test("no off-identity suggestions before a commander is chosen", () => {
+    const suggestions = suggestCuts(payloadWith(), CARD_MAP, null, null);
+    expect(suggestions.filter((s) => s.reasons.join(" ").match(/off-identity/i))).toEqual([]);
+  });
+
+  test("cards below the weak-synergy threshold are suggested with the low-synergy reason", () => {
+    const synergy = synergyWith({ Manalith: 12, "Sol Ring": 92 });
+    const suggestions = suggestCuts(payloadWith(), CARD_MAP, synergy, null);
+    const manalith = suggestions.find((s) => s.name === "Manalith");
+    expect(manalith).toBeTruthy();
+    expect(manalith!.reasons.join(" ")).toMatch(/low synergy/i);
+    expect(names(suggestions)).not.toContain("Sol Ring");
+  });
+
+  test("overfull categories suggest their lowest-scoring members beyond the max", () => {
+    const synergy = synergyWith({ "Sol Ring": 92, Manalith: 20, Cultivate: 60 });
+    const scorecard = scorecardWith([
+      {
+        tag: "Ramp",
+        label: "Ramp",
+        count: 3,
+        min: 1,
+        max: 2,
+        status: "high",
+        statusMessage: "1 over target",
+        cards: [
+          { name: "Sol Ring", quantity: 1 },
+          { name: "Manalith", quantity: 1 },
+          { name: "Cultivate", quantity: 1 },
+        ],
+      },
+    ]);
+    const suggestions = suggestCuts(payloadWith(), CARD_MAP, synergy, scorecard);
+    const manalith = suggestions.find((s) => s.name === "Manalith");
+    expect(manalith).toBeTruthy();
+    expect(manalith!.reasons.join(" ")).toMatch(/overfull/i);
+    // Only count - max = 1 member gets the overfull reason, and it is the weakest.
+    const overfull = suggestions.filter((s) => s.reasons.join(" ").match(/overfull/i));
+    expect(names(overfull)).toEqual(["Manalith"]);
+  });
+
+  test("commanders and already-cut cards are never suggested", () => {
+    let payload = payloadWith(["Adeline, Resplendent Cathar"]);
+    payload = setCardStatus(payload, "Murder", "cut");
+    const synergy = synergyWith({
+      "Adeline, Resplendent Cathar": 5,
+      Murder: 5,
+      Manalith: 5,
+    });
+    const suggestions = suggestCuts(payload, CARD_MAP, synergy, null);
+    expect(names(suggestions)).not.toContain("Adeline, Resplendent Cathar");
+    expect(names(suggestions)).not.toContain("Murder");
+    expect(names(suggestions)).toContain("Manalith");
+  });
+
+  test("dismissed suggestions are excluded and ranking is score-desc", () => {
+    const payload = payloadWith(["Adeline, Resplendent Cathar"]);
+    const synergy = synergyWith({ Manalith: 12 });
+    const all = suggestCuts(payload, CARD_MAP, synergy, null);
+    expect(names(all)).toContain("Murder");
+    const filtered = suggestCuts(payload, CARD_MAP, synergy, null, new Set(["Murder"]));
+    expect(names(filtered)).not.toContain("Murder");
+    for (let i = 1; i < all.length; i++) {
+      expect(all[i - 1].score).toBeGreaterThanOrEqual(all[i].score);
+    }
+  });
+});


### PR DESCRIPTION
## Intent

Rework the Crucible commander picker so multiple candidates no longer push the workbench UI down: candidates collapse into a fixed-height trigger that opens an anchored, filterable popover (new non-modal Popover ui primitive) listing every legal candidate with color-identity pips; the partner flow reuses the same control and the 8-candidate display cap is removed. The user chose this popover layout (Option A) from a set of mockups. Also fixes a hydration-race flake in DeckPage.selectTab. TDD: e2e specs updated first (crucible-triage popover/filter/Escape coverage, helpers gained commanderTrigger/openCommanderPopover), full suite green at 465 e2e + 2686 unit.

## What Changed

- Added the Crucible workbench (`/crucible`): a new pile-based deck-building flow with `CrucibleSessionContext` (chunked Scryfall enrichment, keep/cut/undecided triage state, commander/partner validation), lens-grouped triage UI, insight panels (charts, combos, suggested cuts), tracker rail, and handoff into the existing `/ritual` → `/reading` journey via "Seal the Deck".
- Added card-search-based pile building (both on initial import and mid-triage add), with chunked enrichment shared between import and add flows, retry-on-failure for combo fetches, and dedup/partner-pairing/legality fixes across session and grouping logic (`crucible-session.ts`, `crucible-grouping.ts`, `cut-suggestions.ts`, `commander-validation.ts`).
- Reworked the commander/partner candidate picker into a new `Popover` UI primitive (`src/components/ui/Popover.tsx`) so multiple candidates collapse into a fixed-height, filterable, anchored popover with color-identity pips instead of pushing the workbench layout down; removed the prior 8-candidate display cap and added a `--popover-shadow` token to replace a raw `rgba()` box-shadow.
- Added a `User-Agent` header to all server-side Scryfall requests, fixed a hydration-race flake in `DeckPage.selectTab`, and added/updated e2e coverage (`crucible-*.spec.ts`, `crucible-helpers.ts` with `commanderTrigger`/`openCommanderPopover`) plus unit tests for the new session, grouping, cut-suggestion, and commander-validation logic.

## Risk Assessment

✅ Low: The final commit (popover picker rework) is well-scoped, correctly removes the 8-candidate cap, adds solid Escape/outside-click/focus-restore handling in the new Popover primitive, includes matching e2e coverage (popover open/filter/Escape, updated helpers), and the DeckPage.selectTab hydration fix is a targeted, low-risk retry loop; a broader scan of the rest of the branch (session state, grouping/cut-suggestion/commander-validation logic, API routes) turned up no correctness, race-condition, or security issues, only two minor design-token deviations.

## Testing

Ran the project's full automated suite (2686 unit + 465 e2e, all green, matching the exact counts asserted in the intent) plus a targeted run of crucible-triage.spec.ts confirming the two new popover specs pass, and captured browser screenshots showing the collapsed fixed-height commander trigger, the anchored popover open with color-identity pips, and live filtering — directly demonstrating the Option A popover layout works as intended without pushing the workbench UI down.

- Evidence: Collapsed commander trigger (workbench layout unaffected by candidate count) (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXW06XS5N3WBRVY55JS5JWMF/01-commander-trigger-collapsed.png</code>)
- Evidence: Anchored commander popover open, listing candidates with color-identity pips (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXW06XS5N3WBRVY55JS5JWMF/02-commander-popover-open.png</code>)
- Evidence: Commander popover filtered to a single candidate (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXW06XS5N3WBRVY55JS5JWMF/03-commander-popover-filtered.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `src/components/ui/Popover.module.css:11` - box-shadow uses a raw `rgba(0, 0, 0, 0.55)` instead of an existing semantic token (`--sheet-shadow`, `--shadow-lg`, `--shadow-xl` are all already defined in design-system/tokens.css for this exact purpose). CLAUDE.md explicitly calls out grepping new code for `rgba(` as a pre-PR lint check for design-system violations.
- ℹ️ `src/components/CardSearchInput.tsx:197` - The search-error banner uses a raw Tailwind color class `text-rose-300` instead of a semantic Astral token, violating the project&#39;s documented &#39;no raw Tailwind color classes&#39; convention (pre-existing from an earlier commit in this branch range, still present at HEAD).

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `npm run test:unit (2686 passed)`
- `npx playwright test --config playwright.config.ts (full e2e suite, 465 passed)`
- `npx playwright test --config playwright.config.ts e2e/crucible-triage.spec.ts (13 passed, including the two new popover-specific specs: 'commander candidates live in a popover, not inline in the header' and 'the commander popover filters candidates and closes on Escape')`
- `Manual visual verification via a temporary evidence-capture Playwright spec driving the real CommanderPicker/Popover UI in a browser (screenshots), then removed the temp spec file`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `src/components/ui/Popover.module.css:11` - Popover&#39;s box-shadow uses a raw rgba() value instead of one of the existing --shadow-* tokens in design-system/tokens.css, deviating from this repo&#39;s semantic-token-only convention (the sibling Sheet.module.css uses var(--sheet-shadow)). No existing token matches this exact value, so picking a replacement is a design call, not a mechanical fix.

🔧 Fix: Add --popover-shadow token, replace raw rgba in Popover.module.css
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
