### PR TITLE
feat(crucible): share piles, virtualize workbench, name deck before sealing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A web application for importing and analyzing Magic: The Gathering decklists. Bu
 
 Import a deck (paste, Moxfield export, or Archidekt URL) and the app walks you through a four-stage **journey** — *import → ritual → reading → sub-route*. The reading lands on a verdict hero (bracket, power level, top theme), then fans out across ten sub-routes for cards, composition, synergy, interactions, opening hands, goldfish simulation, suggestions, candidate finder, deck-vs-deck compare, and share/export. Cards are automatically enriched via Scryfall (mana costs as official MTG symbols, oracle text with inline symbols, heuristic tags), and combos are detected via Commander Spellbook.
 
-Don't have a finished deck yet? **The Crucible** (`/crucible`) is a deck-building workbench: pour in any pile of cards, organize it through lenses (category, synergy axis, type line, mana value, color identity, game changers), triage each card as keep/cut/undecided with an explicit commander pick, search up and add more cards mid-triage, and seal a legal 100-card Commander deck that flows straight into the reading journey (cuts are kept as sideboard candidates).
+Don't have a finished deck yet? **The Crucible** (`/crucible`) is a deck-building workbench: pour in any pile of cards, organize it through lenses (category, synergy axis, type line, mana value, color identity, game changers), triage each card as keep/cut/undecided with an explicit commander pick, search up and add more cards mid-triage, share the pile via link or `.dck` download, and seal a legal 100-card Commander deck that flows straight into the reading journey (cuts are kept as sideboard candidates).
 
 See [Promises to You](./PROMISES.md) for how this tool handles your data and what drives the analysis.
 

--- a/docs/plans/crucible-deck-builder.md
+++ b/docs/plans/crucible-deck-builder.md
@@ -8,8 +8,9 @@ The Crucible is a new top-level route (`/crucible`) that accepts any number of c
 
 Scope decisions, locked during plan review:
 
-- **In:** pile import (paste), chunked enrichment with the CosmicLoader ritual treatment, explicit commander picker, lenses (By Category, By Synergy Axis, By Type Line, By Mana Value, By Color Identity, Flat List, Game Changers), Insight panels (Charts, Combos in Pile, Suggested Cuts, Cut Pile), tracker rail (kept count, category health, combo status, legality checklist), collapsible/sticky category groups with capped rendering ("Show all N" expansion), hover/tap card image previews, mid-triage card search (added at user direction after the initial review; see "Adding cards mid-triage" below), "Seal the Deck" handoff.
-- **Out (fast-follows, not v1):** share-a-pile URL, price/budget lens, Scryfall-backed "fill this gap" suggestions inside the Crucible, non-EDH formats, a deck-name input at seal (v1 uses the default name "Forged in the Crucible"), external card search in the commander picker (v1 only lists legal commanders found in the pool), true row virtualization (v1 caps rendered rows per group and offers "Show all N").
+- **In:** pile import (paste), chunked enrichment with the CosmicLoader ritual treatment, explicit commander picker, lenses (By Category, By Synergy Axis, By Type Line, By Mana Value, By Color Identity, Flat List, Game Changers), Insight panels (Charts, Combos in Pile, Suggested Cuts, Cut Pile), tracker rail (kept count, category health, combo status, legality checklist), collapsible/sticky category groups with virtualized rows, hover/tap card image previews, mid-triage card search (added at user direction after the initial review; see "Adding cards mid-triage" below), "Seal the Deck" handoff.
+- **Out (fast-follows, not v1):** price/budget lens, Scryfall-backed "fill this gap" suggestions inside the Crucible, non-EDH formats, external card search in the commander picker (v1 only lists legal commanders found in the pool).
+- **Shipped as fast-follows (post-v1):** share-a-pile URL (`/crucible?p=` link plus a Forge-style `.dck` download, see `src/lib/crucible-share.ts`); a deck-name input at seal on the tracker rail (blank falls back to the default name "Forged in the Crucible"); true row virtualization via `@tanstack/react-virtual` (replaces the v1 per-group render cap and "Show all N" expansion).
 
 ## Design Decisions
 
@@ -55,7 +56,7 @@ The workbench header hosts a `CardSearchInput` so cards can be searched up and a
 `analyzeDeckSynergy` takes a `DeckData`; the Crucible feeds it a synthetic one (chosen commanders + pool as mainboard). Before a commander is chosen, per-card axis scores still work (each axis `detect(card)` is commander-independent); anchor boosts and off-identity flagging activate after the pick via `resolveCommanderIdentity` + per-card `colorIdentity`.
 
 ### Lens grouping rules
-- **By Category:** tag-driven groups from `computeCompositionScorecard` against `TEMPLATE_COMMAND_ZONE` over the kept subset; groups show candidates/kept/target with a health bar. Groups at target auto-collapse; headers stick on scroll; groups cap rendered rows (60) with a "Show all N" expansion.
+- **By Category:** tag-driven groups from `computeCompositionScorecard` against `TEMPLATE_COMMAND_ZONE` over the kept subset; groups show candidates/kept/target with a health bar. Groups at target auto-collapse; headers stick on scroll; rows render through a `@tanstack/react-virtual` windowed list rather than a per-group render cap.
 - **By Synergy Axis:** axes sorted by pool-wide strength; only axes with strength >= 0.2 get a group; each card appears once under its strongest axis with a "+N axes" badge for its other homes; an "Unaligned" group gathers cards with no axis >= 0.2 (prime cut candidates).
 - **Game Changers:** cards flagged `isGameChanger` (list served by `/api/commander-rules`), with kept count shown against the deck's bracket allowance.
 - **Charts:** mana curve and color pip coverage over the kept subset via existing `computeManaCurve` / `computeColorDistribution` / `computeManaBaseMetrics` and the `CurveConstellation` / `ColorPie` components, with a kept-vs-pool toggle.
@@ -127,7 +128,7 @@ The workbench header hosts a `CardSearchInput` so cards can be searched up and a
   - Test case: hovering a card name reveals its image preview (aria-safe)
 - [x] 4.2 Create `src/components/crucible/CrucibleWorkbench.tsx`, `LensSwitcher.tsx`, `CrucibleCardRow.tsx`, `CommanderPicker.tsx`, `CutPile.tsx`
   - `CrucibleCardRow` wraps the disclosure/a11y patterns of `EnrichedCardRow` and adds the triage buttons and image preview (from `EnrichedCard.imageUris`; `Sheet` on touch)
-  - Collapsible groups with sticky headers; cap rendered rows per group with a "Show all N" expansion
+  - Collapsible groups with sticky headers; rows render through a `@tanstack/react-virtual` windowed list
   - All styling via semantic tokens; reduced-motion gates on any transition
 
 ### Phase 5: Insight panels

--- a/e2e/crucible-handoff.spec.ts
+++ b/e2e/crucible-handoff.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, mockCommanderRules } from "./crucible-helpers";
+import { test, expect, mockCommanderRules, HUNDRED_PILE } from "./crucible-helpers";
 
 /** 101 cards including Sol Ring so one cut leaves a legal 100 with a
  * sideboard entry to verify on the reading side. */
@@ -40,5 +40,29 @@ test.describe("Crucible handoff", () => {
     await expect(display).toContainText("Sideboard");
     await expect(display).toContainText("Sol Ring");
     await expect(display).toContainText("Atraxa, Praetors' Voice");
+  });
+
+  test("a custom deck name typed before sealing flows through to the reading", async ({ page, crucible }) => {
+    const customName = "Praetor's Reckoning";
+
+    await crucible.importPile(HUNDRED_PILE);
+
+    await crucible.chooseCommander("Atraxa, Praetors' Voice");
+    await crucible.keepButton("Forest").click();
+    await crucible.keepButton("Island").click();
+
+    await expect(crucible.keptCount).toContainText("100");
+
+    // Name the deck before sealing. The input is shared between the desktop
+    // rail and the mobile sheet, so filling either instance carries through.
+    await page.getByLabel("Deck name").first().fill(customName);
+
+    await expect(crucible.sealButton).toBeEnabled();
+    await crucible.sealButton.click();
+
+    await page.waitForURL(/\/reading/, { timeout: 15_000 });
+    await expect(page.getByTestId("reading-hero")).toContainText(customName, {
+      timeout: 15_000,
+    });
   });
 });

--- a/e2e/crucible-helpers.ts
+++ b/e2e/crucible-helpers.ts
@@ -2,7 +2,7 @@ import type { Page } from "@playwright/test";
 import { test as deckTest, expect } from "./fixtures";
 
 // ---------------------------------------------------------------------------
-// Sample piles — all names exist in the enriched-cards fixture bank so the
+// Sample piles - all names exist in the enriched-cards fixture bank so the
 // default /api/deck-enrich mock returns realistic data.
 // ---------------------------------------------------------------------------
 
@@ -47,7 +47,7 @@ export const PARTNER_PILE = `${SAMPLE_PILE}
 1 Thrasios, Triton Hero
 1 Tymna the Weaver`;
 
-/** A Choose-a-Background commander, its Background, and 98 basics — pairable
+/** A Choose-a-Background commander, its Background, and 98 basics - pairable
  * in the picker and sealable as a legal hundred. */
 export const BACKGROUND_PILE = `1 Wilson, Refined Grizzly
 1 Raised by Giants
@@ -182,7 +182,7 @@ export class CruciblePage {
       .click();
   }
 
-  /** The collapsed control that opens the candidate popover — either the
+  /** The collapsed control that opens the candidate popover - either the
    * initial "Choose from N candidates" button or the "Add a partner" button
    * once a first commander is locked in. */
   get commanderTrigger() {
@@ -213,7 +213,7 @@ export class CruciblePage {
 /**
  * Crucible test fixture. Depends on `deckPage` so the base fixture's route
  * mocks (/api/deck-enrich fixture bank, empty /api/deck-combos) and the
- * ritual-floor skip are active — Playwright fixtures are lazy, so a test
+ * ritual-floor skip are active - Playwright fixtures are lazy, so a test
  * that only destructures `page` would otherwise hit the live APIs.
  */
 export const test = deckTest.extend<{ crucible: CruciblePage }>({

--- a/e2e/crucible-helpers.ts
+++ b/e2e/crucible-helpers.ts
@@ -28,6 +28,19 @@ export const HUNDRED_PILE = `1 Atraxa, Praetors' Voice
 59 Forest
 40 Island`;
 
+/** Number of unique synthetic rows in LARGE_PILE. Chosen large enough that
+ * only a virtualized window of rows can be present in the DOM at once. */
+export const LARGE_PILE_SIZE = 180;
+
+/** A deliberately huge pile of unique synthetic names ("Relic 001" ..
+ * "Relic 180"). None are in the fixture bank, so each synthesizes as a plain
+ * colorless artifact and lands in a single "All Cards" group under the Flat
+ * List lens - the ideal shape for exercising row virtualization. */
+export const LARGE_PILE = Array.from(
+  { length: LARGE_PILE_SIZE },
+  (_, i) => `1 Relic ${String(i + 1).padStart(3, "0")}`
+).join("\n");
+
 /** SAMPLE_PILE plus the Thrasios/Tymna Partner pair, for two-commander
  * selection tests. Atraxa and Ezuri stay in as non-partner legendaries. */
 export const PARTNER_PILE = `${SAMPLE_PILE}

--- a/e2e/crucible-share.spec.ts
+++ b/e2e/crucible-share.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect, SAMPLE_PILE, mockCommanderRules } from "./crucible-helpers";
+
+test.describe("Crucible pile sharing", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+    await page
+      .context()
+      .grantPermissions(["clipboard-read", "clipboard-write"]);
+  });
+
+  test("Share pile copies a /crucible?p= URL and confirms", async ({
+    crucible,
+    page,
+  }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    await page.getByTestId("crucible-share-pile").click();
+
+    // Confirmation surfaces in the aria-live status region.
+    await expect(page.getByTestId("crucible-share-status")).toHaveText(
+      "Copied"
+    );
+
+    const copied = await page.evaluate(() => navigator.clipboard.readText());
+    expect(copied).toContain("/crucible?p=");
+    const url = new URL(copied);
+    expect(url.searchParams.get("p")).toBeTruthy();
+  });
+
+  test("opening a ?p= URL loads the shared pile into the workbench", async ({
+    crucible,
+    page,
+  }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    // Keep a couple cards so triage state is non-trivial, then share.
+    await crucible.keepButton("Sol Ring").click();
+    await page.getByTestId("crucible-share-pile").click();
+    await expect(page.getByTestId("crucible-share-status")).toHaveText(
+      "Copied"
+    );
+    const copied = await page.evaluate(() => navigator.clipboard.readText());
+
+    // Open the shared link in a fresh navigation.
+    await page.goto(copied);
+    await crucible.workbench.waitFor({ timeout: 15_000 });
+
+    // The pool total matches the shared pile (16 total cards in SAMPLE_PILE).
+    await expect(crucible.poolCount).toContainText("16 cards");
+    // The ?p= param is stripped after loading.
+    await expect(page).toHaveURL(/\/crucible$/);
+  });
+
+  test("Download .dck triggers a crucible-pile.dck download", async ({
+    crucible,
+    page,
+  }) => {
+    await crucible.importPile(SAMPLE_PILE);
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByTestId("crucible-download-dck").click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toBe("crucible-pile.dck");
+
+    const stream = await download.createReadStream();
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(chunk as Buffer);
+    const text = Buffer.concat(chunks).toString("utf-8");
+    expect(text).toContain("[metadata]");
+    expect(text).toContain("[Commander]");
+    expect(text).toContain("[Main]");
+    expect(text).toContain("1 Sol Ring");
+  });
+});

--- a/e2e/crucible-virtualization.spec.ts
+++ b/e2e/crucible-virtualization.spec.ts
@@ -1,0 +1,101 @@
+import {
+  test,
+  expect,
+  LARGE_PILE,
+  LARGE_PILE_SIZE,
+  SAMPLE_PILE,
+  mockCommanderRules,
+} from "./crucible-helpers";
+
+const ALL_ROWS = '[data-testid^="crucible-row-"]';
+
+function relic(n: number) {
+  return `Relic ${String(n).padStart(3, "0")}`;
+}
+
+test.describe("Crucible row virtualization", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockCommanderRules(page);
+  });
+
+  test("large piles render only a windowed subset of rows", async ({
+    page,
+    crucible,
+  }) => {
+    await crucible.importPile(LARGE_PILE);
+    await crucible.selectLens("Flat List");
+
+    // The first rows are on screen from the start.
+    await expect(crucible.row(relic(1))).toBeVisible();
+
+    // Virtualization means the DOM holds far fewer rows than the full pile.
+    const rendered = await page.locator(ALL_ROWS).count();
+    expect(rendered).toBeGreaterThan(0);
+    expect(rendered).toBeLessThan(LARGE_PILE_SIZE);
+
+    // A row deep in the list is not mounted while the top is in view.
+    await expect(crucible.row(relic(LARGE_PILE_SIZE))).toHaveCount(0);
+  });
+
+  test("scrolling mounts previously-absent rows", async ({ page, crucible }) => {
+    await crucible.importPile(LARGE_PILE);
+    await crucible.selectLens("Flat List");
+
+    const lastRow = crucible.row(relic(LARGE_PILE_SIZE));
+    await expect(lastRow).toHaveCount(0);
+
+    // Scroll the whole page to the bottom; the window virtualizer should mount
+    // the tail rows that were absent before.
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await expect(lastRow).toBeVisible();
+
+    // And the very first row is now virtualized out of the DOM.
+    await expect(crucible.row(relic(1))).toHaveCount(0);
+  });
+
+  test("collapsing a group still removes its rows under virtualization", async ({
+    page,
+    crucible,
+  }) => {
+    await crucible.importPile(LARGE_PILE);
+    await crucible.selectLens("Flat List");
+
+    await expect(crucible.row(relic(1))).toBeVisible();
+
+    const groupToggle = page.getByRole("button", { name: /all cards group/i });
+    await expect(groupToggle).toHaveAttribute("aria-expanded", "true");
+    await groupToggle.click();
+    await expect(groupToggle).toHaveAttribute("aria-expanded", "false");
+
+    // No card rows remain once the only group is collapsed.
+    await expect(page.locator(ALL_ROWS)).toHaveCount(0);
+  });
+
+  test("keep toggle works on a virtualized row", async ({ crucible }) => {
+    await crucible.importPile(LARGE_PILE);
+    await crucible.selectLens("Flat List");
+
+    await crucible.keepButton(relic(1)).click();
+    await expect(crucible.keepButton(relic(1))).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    await expect(crucible.keptCount).toContainText("1");
+  });
+
+  test("small piles render every row for scroll-free access", async ({
+    page,
+    crucible,
+  }) => {
+    await crucible.importPile(SAMPLE_PILE);
+    await crucible.selectLens("Flat List");
+
+    // A dozen-ish rows all fit; Sol Ring and a land are both present at once.
+    await expect(crucible.row("Sol Ring")).toBeVisible();
+    await expect(crucible.row("Forest")).toBeVisible();
+    await expect(crucible.row("Island")).toBeVisible();
+
+    const rendered = await page.locator(ALL_ROWS).count();
+    expect(rendered).toBeGreaterThanOrEqual(13);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.1",
       "dependencies": {
         "@resvg/resvg-wasm": "^2.6.2",
+        "@tanstack/react-virtual": "^3.14.6",
         "d3-force": "^3.0.0",
         "next": "16.2.3",
         "react": "19.2.3",
@@ -1606,6 +1607,33 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.6.tgz",
+      "integrity": "sha512-4+Uq8m0/gzO4kMCHUEpTtGX1RnONK0C+g88b2ltwPMWUBiaVarBuWKoPJaz7gj1cKCVRAdyu+U8GcKhwCc2beA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.4.tgz",
+      "integrity": "sha512-nGm5KteqxasUdThLc2izl6dHUqLv0LQj7Nuyo5gYalTPf/U8a9ermvsl7reT+6ioBW1l8WfpP/mcU338nLXpqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@resvg/resvg-wasm": "^2.6.2",
+    "@tanstack/react-virtual": "^3.14.6",
     "d3-force": "^3.0.0",
     "next": "16.2.3",
     "react": "19.2.3",

--- a/src/app/crucible/page.tsx
+++ b/src/app/crucible/page.tsx
@@ -106,7 +106,7 @@ function CruciblePageContent() {
     const { done, total } = enrichProgress;
     const tagline =
       total > 1
-        ? `The pile is being weighed — part ${Math.min(done + 1, total)} of ${total}.`
+        ? `The pile is being weighed - part ${Math.min(done + 1, total)} of ${total}.`
         : "The pile is being weighed.";
     return <CosmicLoader tagline={tagline} />;
   }

--- a/src/app/crucible/page.tsx
+++ b/src/app/crucible/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
+import { decodeCruciblePile } from "@/lib/crucible-share";
 import CosmicLoader from "@/components/ritual/CosmicLoader";
 import CrucibleImport from "@/components/crucible/CrucibleImport";
 import CrucibleWorkbench from "@/components/crucible/CrucibleWorkbench";
 import { Button, Card } from "@/components/ui";
 
-export default function CruciblePage() {
+function CruciblePageContent() {
   const {
     hydration,
     payload,
@@ -15,12 +18,64 @@ export default function CruciblePage() {
     enrichProgress,
     retryEnrichment,
     clearCrucible,
+    loadPile,
   } = useCrucibleSession();
+
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const sharedParam = searchParams.get("p");
+
+  // Decode a `?p=` shared pile once, then strip the param and load it into a
+  // fresh session. Corrupt/foreign links fall back to the import screen with a
+  // non-fatal notice.
+  const consumedShareRef = useRef(false);
+  const [shareState, setShareState] = useState<"idle" | "loading" | "error">(
+    sharedParam ? "loading" : "idle"
+  );
+
+  useEffect(() => {
+    if (!sharedParam || consumedShareRef.current) return;
+    consumedShareRef.current = true;
+    void (async () => {
+      const decoded = await decodeCruciblePile(sharedParam);
+      router.replace("/crucible");
+      if (!decoded) {
+        setShareState("error");
+        return;
+      }
+      loadPile(decoded);
+      setShareState("idle");
+    })();
+  }, [sharedParam, router, loadPile]);
+
+  if (shareState === "loading") {
+    return <CosmicLoader tagline="Unsealing the shared pile." />;
+  }
 
   if (hydration === "pending") return null;
 
   if (!payload) {
-    return <CrucibleImport />;
+    return (
+      <>
+        {shareState === "error" ? (
+          <div
+            role="status"
+            data-testid="crucible-share-notice"
+            style={{
+              maxWidth: 720,
+              margin: "0 auto",
+              padding: "var(--space-8) var(--space-12) 0",
+              color: "var(--status-warn)",
+              fontSize: "var(--text-sm)",
+            }}
+          >
+            That shared pile link was invalid or corrupted. Import a pile to
+            begin.
+          </div>
+        ) : null}
+        <CrucibleImport />
+      </>
+    );
   }
 
   if (enrichError) {
@@ -57,4 +112,12 @@ export default function CruciblePage() {
   }
 
   return <CrucibleWorkbench />;
+}
+
+export default function CruciblePage() {
+  return (
+    <Suspense fallback={null}>
+      <CruciblePageContent />
+    </Suspense>
+  );
 }

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -124,7 +124,7 @@ export default function CrucibleWorkbench() {
           label: group.axisName,
           meta:
             group.axisId === UNALIGNED_AXIS_ID
-              ? `${group.cards.length} cards · no strong theme — prime cut fodder`
+              ? `${group.cards.length} cards · no strong theme - prime cut fodder`
               : `pool strength ${group.strength.toFixed(2)} · ${group.cards.length} cards`,
           cards: group.cards.map((card) => ({
             card,

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/crucible-grouping";
 import { TEMPLATE_COMMAND_ZONE } from "@/lib/deck-composition";
 import { keptQuantityOf } from "@/lib/crucible-session";
+import { encodeCruciblePile, serializePileToDck } from "@/lib/crucible-share";
 import type { DeckCard } from "@/lib/types";
 import { Button } from "@/components/ui";
 import CardSearchInput from "@/components/CardSearchInput";
@@ -76,6 +77,8 @@ export default function CrucibleWorkbench() {
   const [dismissedNotFound, setDismissedNotFound] = useState<Set<string>>(
     () => new Set()
   );
+  const [shareCopied, setShareCopied] = useState(false);
+  const [shareError, setShareError] = useState(false);
 
   const commanderIdentity = useMemo<Set<string> | null>(() => {
     if (!payload || !cardMap || payload.commanders.length === 0) return null;
@@ -228,6 +231,36 @@ export default function CrucibleWorkbench() {
 
   if (!payload || !cardMap) return null;
 
+  const sharedPayload = payload;
+
+  const handleSharePile = async () => {
+    try {
+      const encoded = await encodeCruciblePile(sharedPayload);
+      const url = `${window.location.origin}/crucible?p=${encoded}`;
+      await navigator.clipboard.writeText(url);
+      setShareError(false);
+      setShareCopied(true);
+      window.setTimeout(() => setShareCopied(false), 2000);
+    } catch {
+      setShareCopied(false);
+      setShareError(true);
+      window.setTimeout(() => setShareError(false), 4000);
+    }
+  };
+
+  const handleDownloadDck = () => {
+    const dck = serializePileToDck(sharedPayload, "Crucible Pile");
+    const blob = new Blob([dck], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = "crucible-pile.dck";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+  };
+
   const poolTotal = payload.pool.reduce((sum, c) => sum + c.quantity, 0);
   const isInsight = lens === "charts" || lens === "combos" || lens === "cuts" || lens === "cutpile";
 
@@ -256,6 +289,36 @@ export default function CrucibleWorkbench() {
             candidateNames={EMPTY_CANDIDATES}
             onAddCard={addCard}
           />
+        </div>
+        <div className={styles.shareActions}>
+          <Button
+            variant="secondary"
+            size="sm"
+            data-testid="crucible-share-pile"
+            onClick={handleSharePile}
+          >
+            Share pile
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            data-testid="crucible-download-dck"
+            onClick={handleDownloadDck}
+          >
+            Download .dck
+          </Button>
+          <span
+            role="status"
+            aria-live="polite"
+            data-testid="crucible-share-status"
+            className={styles.shareStatus}
+          >
+            {shareCopied
+              ? "Copied"
+              : shareError
+                ? "Copy failed"
+                : ""}
+          </span>
         </div>
       </header>
 

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
 import {
@@ -69,6 +69,7 @@ export default function CrucibleWorkbench() {
     addCard,
     setStatus,
     setKeptQuantity,
+    deckName,
   } = useCrucibleSession();
 
   const [lens, setLens] = useState<CrucibleLens>("category");
@@ -207,11 +208,24 @@ export default function CrucibleWorkbench() {
   // fixed-height scrollbox). scrollMargin is the list's offset from the top of
   // the document, captured via a callback ref (runs at commit, not during
   // render) so the virtualizer's scroll math lines up with the page scroll.
+  // A ResizeObserver keeps it fresh when layout above the list changes height
+  // after mount (e.g. dismissing the not-found banner shifts the list up);
+  // its callback fires asynchronously, so it does not trip set-state-in-effect.
   const [scrollMargin, setScrollMargin] = useState(0);
+  const scrollMarginObserverRef = useRef<ResizeObserver | null>(null);
   const setListRef = useCallback((node: HTMLDivElement | null) => {
-    if (node) {
+    scrollMarginObserverRef.current?.disconnect();
+    scrollMarginObserverRef.current = null;
+    if (!node) return;
+    const measure = () => {
       const top = node.offsetTop;
       setScrollMargin((prev) => (prev === top ? prev : top));
+    };
+    measure();
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(measure);
+      observer.observe(document.body);
+      scrollMarginObserverRef.current = observer;
     }
   }, []);
 
@@ -249,7 +263,7 @@ export default function CrucibleWorkbench() {
   };
 
   const handleDownloadDck = () => {
-    const dck = serializePileToDck(sharedPayload, "Crucible Pile");
+    const dck = serializePileToDck(sharedPayload, deckName);
     const blob = new Blob([dck], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
     const anchor = document.createElement("a");

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -205,12 +205,15 @@ export default function CrucibleWorkbench() {
   }, [groups, collapsed, undecidedOnly, statuses]);
 
   // Window virtualizer preserves the whole-page scroll UX (no inner
-  // fixed-height scrollbox). scrollMargin is the list's offset from the top of
-  // the document, captured via a callback ref (runs at commit, not during
-  // render) so the virtualizer's scroll math lines up with the page scroll.
-  // A ResizeObserver keeps it fresh when layout above the list changes height
-  // after mount (e.g. dismissing the not-found banner shifts the list up);
-  // its callback fires asynchronously, so it does not trip set-state-in-effect.
+  // fixed-height scrollbox). scrollMargin is the list's offset measured from
+  // the document top via getBoundingClientRect().top + window.scrollY (not
+  // offsetTop, which is relative to the nearest positioned ancestor below the
+  // sticky nav and under-reports by the nav height), captured via a callback
+  // ref (runs at commit, not during render) so the virtualizer's scroll math
+  // lines up with the page scroll. A ResizeObserver keeps it fresh when layout
+  // above the list changes height after mount (e.g. dismissing the not-found
+  // banner shifts the list up); its callback fires asynchronously, so it does
+  // not trip set-state-in-effect.
   const [scrollMargin, setScrollMargin] = useState(0);
   const scrollMarginObserverRef = useRef<ResizeObserver | null>(null);
   const setListRef = useCallback((node: HTMLDivElement | null) => {
@@ -218,7 +221,7 @@ export default function CrucibleWorkbench() {
     scrollMarginObserverRef.current = null;
     if (!node) return;
     const measure = () => {
-      const top = node.offsetTop;
+      const top = node.getBoundingClientRect().top + window.scrollY;
       setScrollMargin((prev) => (prev === top ? prev : top));
     };
     measure();

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
 import {
   groupByCategory,
@@ -26,9 +27,15 @@ import SuggestedCuts from "./SuggestedCuts";
 import CutPile from "./CutPile";
 import styles from "./crucible.module.css";
 
-/** Rows rendered per group before the "Show all" expansion. Keeps huge piles
- * responsive without a virtualization library. */
-const ROWS_PER_GROUP = 60;
+/** Estimated pixel heights for the window virtualizer. The real heights are
+ * measured after mount via `measureElement`; these only seed the first paint
+ * and the scroll-range math for offscreen rows. */
+const ROW_ESTIMATE = 64;
+const HEADER_ESTIMATE = 52;
+
+/** Extra rows rendered beyond the viewport on each side. Small piles fall well
+ * under this window, so every row stays mounted and directly scroll-to-able. */
+const OVERSCAN = 12;
 
 /** Nothing is excluded from the add-card search: re-adding a name already in
  * the pile bumps its quantity (useful for basics), and singleton legality
@@ -43,6 +50,13 @@ interface RenderGroup {
   meta?: string;
   cards: { card: DeckCard; badge?: string }[];
 }
+
+/** A single virtualized item: either a group header or a card row. The visible
+ * (non-collapsed, filtered) groups are flattened into one list of these so a
+ * single window virtualizer can span every group. */
+type FlatItem =
+  | { kind: "header"; group: RenderGroup; collapsed: boolean }
+  | { kind: "row"; groupId: string; card: DeckCard; badge?: string };
 
 export default function CrucibleWorkbench() {
   const {
@@ -59,7 +73,6 @@ export default function CrucibleWorkbench() {
   const [lens, setLens] = useState<CrucibleLens>("category");
   const [undecidedOnly, setUndecidedOnly] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
-  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [dismissedNotFound, setDismissedNotFound] = useState<Set<string>>(
     () => new Set()
   );
@@ -164,6 +177,55 @@ export default function CrucibleWorkbench() {
     }
   }, [payload, cardMap, tagCache, lens, targetByLabel]);
 
+  const statuses = payload?.statuses;
+
+  // Flatten the visible groups (respecting collapse + the undecided filter)
+  // into a single item list so one window virtualizer can span every group.
+  const flatItems = useMemo<FlatItem[]>(() => {
+    const items: FlatItem[] = [];
+    for (const group of groups) {
+      const isCollapsed = collapsed.has(group.id);
+      items.push({ kind: "header", group, collapsed: isCollapsed });
+      if (isCollapsed) continue;
+      for (const { card, badge } of group.cards) {
+        if (
+          undecidedOnly &&
+          (statuses?.[card.name] ?? "undecided") !== "undecided"
+        ) {
+          continue;
+        }
+        items.push({ kind: "row", groupId: group.id, card, badge });
+      }
+    }
+    return items;
+  }, [groups, collapsed, undecidedOnly, statuses]);
+
+  // Window virtualizer preserves the whole-page scroll UX (no inner
+  // fixed-height scrollbox). scrollMargin is the list's offset from the top of
+  // the document, captured via a callback ref (runs at commit, not during
+  // render) so the virtualizer's scroll math lines up with the page scroll.
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const setListRef = useCallback((node: HTMLDivElement | null) => {
+    if (node) {
+      const top = node.offsetTop;
+      setScrollMargin((prev) => (prev === top ? prev : top));
+    }
+  }, []);
+
+  const virtualizer = useWindowVirtualizer({
+    count: flatItems.length,
+    estimateSize: (index) =>
+      flatItems[index]?.kind === "header" ? HEADER_ESTIMATE : ROW_ESTIMATE,
+    overscan: OVERSCAN,
+    scrollMargin,
+    getItemKey: (index) => {
+      const item = flatItems[index];
+      return item.kind === "header"
+        ? `header:${item.group.id}`
+        : `row:${item.groupId}:${item.card.name}`;
+    },
+  });
+
   if (!payload || !cardMap) return null;
 
   const poolTotal = payload.pool.reduce((sum, c) => sum + c.quantity, 0);
@@ -238,87 +300,83 @@ export default function CrucibleWorkbench() {
           {lens === "cuts" ? <SuggestedCuts /> : null}
           {lens === "cutpile" ? <CutPile /> : null}
           {!isInsight ? (
-            <div data-testid="crucible-groups">
-              {groups.map((group) => {
-                const isCollapsed = collapsed.has(group.id);
-                const visibleCards = undecidedOnly
-                  ? group.cards.filter(
-                      ({ card }) =>
-                        (payload.statuses[card.name] ?? "undecided") === "undecided"
-                    )
-                  : group.cards;
-                const isExpanded = expandedGroups.has(group.id);
-                const shownCards = isExpanded
-                  ? visibleCards
-                  : visibleCards.slice(0, ROWS_PER_GROUP);
+            <div
+              ref={setListRef}
+              data-testid="crucible-groups"
+              className={styles.groups}
+              style={{ height: virtualizer.getTotalSize() }}
+            >
+              {virtualizer.getVirtualItems().map((virtualItem) => {
+                const item = flatItems[virtualItem.index];
                 return (
-                  <section key={group.id} className={styles.group}>
-                    <button
-                      type="button"
-                      className={styles.groupHead}
-                      aria-expanded={!isCollapsed}
-                      aria-label={`${group.label} group`}
-                      onClick={() => toggleCollapsed(group.id)}
-                    >
-                      <span className={styles.groupChevron} aria-hidden="true">
-                        {isCollapsed ? "▸" : "▾"}
-                      </span>
-                      <span className={styles.groupLabel}>{group.label}</span>
-                      {group.meta ? (
-                        <span className={styles.groupMeta}>{group.meta}</span>
-                      ) : null}
-                    </button>
-                    {!isCollapsed
-                      ? shownCards.map(({ card, badge }) => (
-                          <CrucibleCardRow
-                            key={card.name}
-                            card={card}
-                            enriched={cardMap[card.name]}
-                            status={payload.statuses[card.name] ?? "undecided"}
-                            locked={payload.commanders.includes(card.name)}
-                            keptQuantity={keptQuantityOf(payload, card)}
-                            onSetKeptQuantity={(count) =>
-                              setKeptQuantity(card.name, count)
-                            }
-                            offIdentity={
-                              commanderIdentity !== null &&
-                              (cardMap[card.name]?.colorIdentity ?? []).some(
-                                (color) => !commanderIdentity.has(color)
-                              )
-                            }
-                            synergyScore={synergy?.cardScores[card.name]?.score}
-                            badge={badge}
-                            onKeep={() =>
-                              setStatus(
-                                card.name,
-                                payload.statuses[card.name] === "keep"
-                                  ? "undecided"
-                                  : "keep"
-                              )
-                            }
-                            onCut={() =>
-                              setStatus(
-                                card.name,
-                                payload.statuses[card.name] === "cut"
-                                  ? "undecided"
-                                  : "cut"
-                              )
-                            }
-                          />
-                        ))
-                      : null}
-                    {!isCollapsed && visibleCards.length > shownCards.length ? (
+                  <div
+                    key={virtualItem.key}
+                    data-index={virtualItem.index}
+                    ref={virtualizer.measureElement}
+                    className={styles.vItem}
+                    style={{
+                      transform: `translateY(${
+                        virtualItem.start - virtualizer.options.scrollMargin
+                      }px)`,
+                    }}
+                  >
+                    {item.kind === "header" ? (
                       <button
                         type="button"
-                        className={styles.groupShowAll}
-                        onClick={() =>
-                          setExpandedGroups((prev) => new Set(prev).add(group.id))
-                        }
+                        className={styles.groupHead}
+                        aria-expanded={!item.collapsed}
+                        aria-label={`${item.group.label} group`}
+                        onClick={() => toggleCollapsed(item.group.id)}
                       >
-                        Show all {visibleCards.length}
+                        <span className={styles.groupChevron} aria-hidden="true">
+                          {item.collapsed ? "▸" : "▾"}
+                        </span>
+                        <span className={styles.groupLabel}>
+                          {item.group.label}
+                        </span>
+                        {item.group.meta ? (
+                          <span className={styles.groupMeta}>
+                            {item.group.meta}
+                          </span>
+                        ) : null}
                       </button>
-                    ) : null}
-                  </section>
+                    ) : (
+                      <CrucibleCardRow
+                        card={item.card}
+                        enriched={cardMap[item.card.name]}
+                        status={payload.statuses[item.card.name] ?? "undecided"}
+                        locked={payload.commanders.includes(item.card.name)}
+                        keptQuantity={keptQuantityOf(payload, item.card)}
+                        onSetKeptQuantity={(count) =>
+                          setKeptQuantity(item.card.name, count)
+                        }
+                        offIdentity={
+                          commanderIdentity !== null &&
+                          (cardMap[item.card.name]?.colorIdentity ?? []).some(
+                            (color) => !commanderIdentity.has(color)
+                          )
+                        }
+                        synergyScore={synergy?.cardScores[item.card.name]?.score}
+                        badge={item.badge}
+                        onKeep={() =>
+                          setStatus(
+                            item.card.name,
+                            payload.statuses[item.card.name] === "keep"
+                              ? "undecided"
+                              : "keep"
+                          )
+                        }
+                        onCut={() =>
+                          setStatus(
+                            item.card.name,
+                            payload.statuses[item.card.name] === "cut"
+                              ? "undecided"
+                              : "cut"
+                          )
+                        }
+                      />
+                    )}
+                  </div>
                 );
               })}
             </div>

--- a/src/components/crucible/TrackerRail.tsx
+++ b/src/components/crucible/TrackerRail.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCrucibleSession } from "@/contexts/CrucibleSessionContext";
 import { useDeckSession } from "@/contexts/DeckSessionContext";
 import { generateDeckId, type DeckSessionPayload } from "@/lib/deck-session";
-import { Button, Sheet } from "@/components/ui";
+import { Button, Input, Sheet } from "@/components/ui";
 import { comboState } from "./CrucibleCombos";
 import styles from "./crucible.module.css";
 
@@ -22,6 +22,8 @@ function TrackerContent() {
     legality,
     combos,
     combosOverBy,
+    deckName,
+    setDeckName,
     finalize,
     clearCrucible,
   } = useCrucibleSession();
@@ -44,7 +46,8 @@ function TrackerContent() {
   const canSeal = legality?.isValid === true && !sealing;
 
   const handleSeal = () => {
-    const deck = finalize(DEFAULT_DECK_NAME);
+    const trimmed = deckName.trim();
+    const deck = finalize(trimmed.length > 0 ? trimmed : DEFAULT_DECK_NAME);
     if (!deck) return;
     setSealing(true);
     const readingPayload: DeckSessionPayload = {
@@ -132,6 +135,16 @@ function TrackerContent() {
             </p>
           ))
         )}
+      </div>
+
+      <div className={styles.deckNameField}>
+        <p className={styles.trackerEyebrow}>Deck Name</p>
+        <Input
+          aria-label="Deck name"
+          placeholder={DEFAULT_DECK_NAME}
+          value={deckName}
+          onChange={(e) => setDeckName(e.target.value)}
+        />
       </div>
 
       <Button

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -811,9 +811,18 @@
   color: var(--status-warn);
 }
 
+.deckNameField {
+  margin-top: var(--space-8);
+  padding-top: var(--space-8);
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
 .sealButton {
   width: 100%;
-  margin-top: var(--space-8);
+  margin-top: var(--space-6);
 }
 
 .trackerToggle {

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -891,3 +891,20 @@
   flex: 0 1 280px;
   min-width: 200px;
 }
+
+/* ─── Share actions ──────────────────────────────────────────── */
+.shareActions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.shareStatus {
+  font-family: var(--font-mono);
+  font-size: var(--text-eyebrow);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent);
+  min-width: 4ch;
+}

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -1,4 +1,4 @@
-/* The Crucible — shared styles for the deck-building workbench. */
+/* The Crucible - shared styles for the deck-building workbench. */
 
 /* ─── Import ─────────────────────────────────────────────────── */
 .importMain {

--- a/src/components/crucible/crucible.module.css
+++ b/src/components/crucible/crucible.module.css
@@ -164,19 +164,27 @@
 }
 
 /* ─── Groups ─────────────────────────────────────────────────── */
-.group {
-  margin-bottom: var(--space-10);
+/* The groups list is a window-virtualized flat list of headers + rows. Its
+ * height is driven inline by the virtualizer's total size, and each item is
+ * absolutely positioned via .vItem, so only the on-screen window mounts. */
+.groups {
+  position: relative;
+  width: 100%;
+}
+
+.vItem {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
 }
 
 .groupHead {
-  position: sticky;
-  top: 0;
-  z-index: 2;
   display: flex;
   align-items: baseline;
   gap: var(--space-5);
   width: 100%;
-  padding: var(--space-4) var(--space-2);
+  padding: var(--space-6) var(--space-2) var(--space-4);
   border: none;
   background: var(--bg-base);
   color: inherit;
@@ -204,17 +212,6 @@
   color: var(--ink-tertiary);
   min-width: 0;
   overflow-wrap: anywhere;
-}
-
-.groupShowAll {
-  margin: var(--space-2) 0 0;
-  padding: var(--space-3) var(--space-6);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  background: var(--surface-2);
-  color: var(--ink-secondary);
-  font-size: var(--text-sm);
-  cursor: pointer;
 }
 
 /* ─── Card rows ──────────────────────────────────────────────── */

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -624,6 +624,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     combosSubsetKeyRef.current = null;
     const payload = createCrucibleSession(pool, warnings);
     saveCrucibleSession(payload);
+    setDeckName("");
     dispatch({ type: "NEW_PILE", payload });
   }, []);
 
@@ -640,6 +641,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       createdAt: Date.now(),
     };
     saveCrucibleSession(payload);
+    setDeckName("");
     dispatch({ type: "NEW_PILE", payload });
   }, []);
 
@@ -783,6 +785,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     combosIdRef.current = null;
     combosSubsetKeyRef.current = null;
     clearCrucibleSession();
+    setDeckName("");
     dispatch({ type: "CLEAR" });
   }, []);
 

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -45,7 +45,7 @@ import { ENRICH_CHUNK_SIZE, chunk } from "@/lib/enrich-chunking";
 /** /api/deck-combos rejects requests above this many unique names. Combos
  * cannot be chunked without missing cross-chunk pairs, so for larger piles
  * detection runs over the keep+undecided subset once cuts bring it under the
- * cap — until then the UI shows how many more unique cuts are needed. */
+ * cap - until then the UI shows how many more unique cuts are needed. */
 const COMBOS_MAX_NAMES = 250;
 
 /** Debounce for combo refetches after the first threshold crossing, so triage
@@ -300,7 +300,7 @@ const CrucibleSessionContext = createContext<CrucibleSessionContextValue | null>
 export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
   // Transient builder-chosen deck name. Lives outside the reducer/session
-  // payload because it doesn't need persistence — it's only read at seal.
+  // payload because it doesn't need persistence - it's only read at seal.
   const [deckName, setDeckName] = useState("");
   const enrichAbortRef = useRef<AbortController | null>(null);
   const combosAbortRef = useRef<AbortController | null>(null);
@@ -373,7 +373,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
         type: "ENRICH_ERROR",
         error:
           err instanceof TypeError
-            ? "Network error — could not reach card data service"
+            ? "Network error - could not reach card data service"
             : "Could not load card details",
       });
     }
@@ -489,7 +489,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
 
   // Banned list + game changers, fetched once per provider lifetime. The
   // effect re-runs on every payload change, so it must NOT abort in its
-  // cleanup — a triage click mid-fetch would kill the request and leave
+  // cleanup - a triage click mid-fetch would kill the request and leave
   // legality null forever. Abort only on provider unmount, and clear the
   // fetched flag on failure so a later payload change retries.
   const rulesAbortRef = useRef<AbortController | null>(null);
@@ -537,7 +537,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   );
 
   // Keyed on pool + commanders (stable across triage clicks), NOT the whole
-  // payload — the O(n²) synergy engine must not re-run on every keep/cut.
+  // payload - the O(n²) synergy engine must not re-run on every keep/cut.
   const pool = state.payload?.pool ?? null;
   const commanders = state.payload?.commanders ?? null;
   const synergy = useMemo<DeckSynergyAnalysis | null>(() => {

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useReducer,
   useRef,
+  useState,
   type ReactNode,
 } from "react";
 import type { DeckCard, DeckData, DeckSynergyAnalysis, EnrichedCard } from "@/lib/types";
@@ -255,6 +256,10 @@ interface CrucibleSessionContextValue {
   /** Ranked cut suggestions, minus dismissed ones. */
   cutSuggestions: CutSuggestion[];
   keptTotal: number;
+  /** Builder-chosen deck name, shared across the tracker rail and its mobile
+   * sheet. Transient (not persisted); blank falls back to a default at seal. */
+  deckName: string;
+  setDeckName: (name: string) => void;
   /** Start a fresh crucible from an imported pile. Persists and triggers
    * enrichment + combo fetches in the background. */
   setPile: (pool: DeckCard[], warnings: string[]) => void;
@@ -289,6 +294,9 @@ const CrucibleSessionContext = createContext<CrucibleSessionContextValue | null>
 
 export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, initialState);
+  // Transient builder-chosen deck name. Lives outside the reducer/session
+  // payload because it doesn't need persistence — it's only read at seal.
+  const [deckName, setDeckName] = useState("");
   const enrichAbortRef = useRef<AbortController | null>(null);
   const combosAbortRef = useRef<AbortController | null>(null);
   const enrichedIdRef = useRef<string | null>(null);
@@ -775,6 +783,8 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       legality,
       cutSuggestions,
       keptTotal,
+      deckName,
+      setDeckName,
       setPile,
       addCard,
       setStatus,
@@ -805,6 +815,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       legality,
       cutSuggestions,
       keptTotal,
+      deckName,
       setPile,
       addCard,
       setStatus,

--- a/src/contexts/CrucibleSessionContext.tsx
+++ b/src/contexts/CrucibleSessionContext.tsx
@@ -27,6 +27,7 @@ import {
 import { suggestCuts, type CutSuggestion } from "@/lib/cut-suggestions";
 import {
   createCrucibleSession,
+  generateCrucibleId,
   loadCrucibleSession,
   saveCrucibleSession,
   clearCrucibleSession,
@@ -263,6 +264,10 @@ interface CrucibleSessionContextValue {
   /** Start a fresh crucible from an imported pile. Persists and triggers
    * enrichment + combo fetches in the background. */
   setPile: (pool: DeckCard[], warnings: string[]) => void;
+  /** Load a decoded shared pile (pool + triage state) into a FRESH session.
+   * Preserves statuses/keptQuantities/commanders but stamps a new id, so a
+   * shared link opens as a brand-new crucible. */
+  loadPile: (incoming: CruciblePayload) => void;
   /** Add a single card to the pile mid-triage (new name arrives undecided;
    * an existing name gets a quantity bump). Enriches it incrementally and
    * refreshes combo detection where the pile size allows. */
@@ -622,6 +627,22 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
     dispatch({ type: "NEW_PILE", payload });
   }, []);
 
+  const loadPile = useCallback((incoming: CruciblePayload) => {
+    enrichAbortRef.current?.abort();
+    combosAbortRef.current?.abort();
+    if (combosDebounceRef.current) clearTimeout(combosDebounceRef.current);
+    enrichedIdRef.current = null;
+    combosIdRef.current = null;
+    combosSubsetKeyRef.current = null;
+    const payload: CruciblePayload = {
+      ...incoming,
+      crucibleId: generateCrucibleId(),
+      createdAt: Date.now(),
+    };
+    saveCrucibleSession(payload);
+    dispatch({ type: "NEW_PILE", payload });
+  }, []);
+
   const addCard = useCallback(
     (name: string) => {
       const current = addCardPayloadRef.current;
@@ -786,6 +807,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       deckName,
       setDeckName,
       setPile,
+      loadPile,
       addCard,
       setStatus,
       keepAll,
@@ -817,6 +839,7 @@ export function CrucibleSessionProvider({ children }: { children: ReactNode }) {
       keptTotal,
       deckName,
       setPile,
+      loadPile,
       addCard,
       setStatus,
       keepAll,

--- a/src/lib/crucible-share.ts
+++ b/src/lib/crucible-share.ts
@@ -266,7 +266,11 @@ export function serializePileToDck(
   }
   lines.push("");
   lines.push("[Main]");
+  // Commanders live in payload.pool but belong only in the command zone;
+  // emitting them in [Main] too would double-count them on re-import.
+  const commanders = new Set(payload.commanders);
   for (const card of payload.pool) {
+    if (commanders.has(card.name)) continue;
     lines.push(`${card.quantity} ${card.name}`);
   }
   return lines.join("\n") + "\n";

--- a/src/lib/crucible-share.ts
+++ b/src/lib/crucible-share.ts
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------
-// Crucible Share Codec — serialize/deserialize an in-progress pile
+// Crucible Share Codec - serialize/deserialize an in-progress pile
 //
 // Two shapes:
 //   1. A shareable URL payload: a compact JSON view of the pile (pool,
@@ -42,7 +42,7 @@ interface CompactPile {
 function statusToCode(status: CrucibleCardStatus): StatusCode | null {
   if (status === "keep") return "k";
   if (status === "cut") return "c";
-  return null; // undecided — omitted
+  return null; // undecided - omitted
 }
 
 function codeToStatus(code: unknown): CrucibleCardStatus {
@@ -118,7 +118,7 @@ function compactToPayload(parsed: unknown): CruciblePayload | null {
 }
 
 // ---------------------------------------------------------------------------
-// Base64url helpers (no +, /, or = padding) — mirrors deck-codec.ts
+// Base64url helpers (no +, /, or = padding) - mirrors deck-codec.ts
 // ---------------------------------------------------------------------------
 
 function toBase64Url(bytes: Uint8Array): string {
@@ -146,7 +146,7 @@ function fromBase64Url(str: string): Uint8Array {
 }
 
 // ---------------------------------------------------------------------------
-// Compression helpers — mirrors deck-codec.ts
+// Compression helpers - mirrors deck-codec.ts
 // ---------------------------------------------------------------------------
 
 async function compressGzip(data: Uint8Array): Promise<Uint8Array> {

--- a/src/lib/crucible-share.ts
+++ b/src/lib/crucible-share.ts
@@ -1,0 +1,273 @@
+// ---------------------------------------------------------------------------
+// Crucible Share Codec — serialize/deserialize an in-progress pile
+//
+// Two shapes:
+//   1. A shareable URL payload: a compact JSON view of the pile (pool,
+//      triage statuses, kept quantities, commanders), gzip-compressed and
+//      base64url-encoded. Mirrors the low-level helpers in deck-codec.ts.
+//   2. A downloadable Forge-style `.dck` INI text file, human readable and
+//      round-trippable.
+//
+// The volatile session fields (crucibleId, createdAt) are dropped on encode
+// and regenerated on decode: a shared pile always lands in a FRESH session.
+// ---------------------------------------------------------------------------
+
+import {
+  generateCrucibleId,
+  type CruciblePayload,
+  type CrucibleCardStatus,
+} from "./crucible-session";
+import type { DeckCard } from "./types";
+
+// ---------------------------------------------------------------------------
+// Compact payload shape
+// ---------------------------------------------------------------------------
+
+/** Status codes keep the encoded blob small. "undecided" is the default and
+ * is never stored explicitly. */
+type StatusCode = "k" | "c";
+
+interface CompactPile {
+  v: 1;
+  /** pool: [name, quantity][] */
+  p: [string, number][];
+  /** non-undecided statuses: name -> "k" | "c" */
+  s: Record<string, StatusCode>;
+  /** partial kept counts: name -> count */
+  k: Record<string, number>;
+  /** chosen commander names */
+  c: string[];
+}
+
+function statusToCode(status: CrucibleCardStatus): StatusCode | null {
+  if (status === "keep") return "k";
+  if (status === "cut") return "c";
+  return null; // undecided — omitted
+}
+
+function codeToStatus(code: unknown): CrucibleCardStatus {
+  if (code === "k") return "keep";
+  if (code === "c") return "cut";
+  return "undecided";
+}
+
+function buildCompactPile(payload: CruciblePayload): CompactPile {
+  const s: Record<string, StatusCode> = {};
+  for (const [name, status] of Object.entries(payload.statuses)) {
+    const code = statusToCode(status);
+    if (code) s[name] = code;
+  }
+  return {
+    v: 1,
+    p: payload.pool.map((card) => [card.name, card.quantity]),
+    s,
+    k: { ...payload.keptQuantities },
+    c: [...payload.commanders],
+  };
+}
+
+function compactToPayload(parsed: unknown): CruciblePayload | null {
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.v !== 1 || !Array.isArray(obj.p)) return null;
+
+  const pool: DeckCard[] = [];
+  for (const entry of obj.p) {
+    if (
+      !Array.isArray(entry) ||
+      typeof entry[0] !== "string" ||
+      typeof entry[1] !== "number"
+    ) {
+      return null;
+    }
+    pool.push({ name: entry[0], quantity: entry[1] });
+  }
+
+  const rawStatuses =
+    obj.s && typeof obj.s === "object"
+      ? (obj.s as Record<string, unknown>)
+      : {};
+  const statuses: Record<string, CrucibleCardStatus> = {};
+  // Every pool name gets an entry, defaulting to undecided.
+  for (const card of pool) {
+    statuses[card.name] = codeToStatus(rawStatuses[card.name]);
+  }
+
+  const rawKept =
+    obj.k && typeof obj.k === "object"
+      ? (obj.k as Record<string, unknown>)
+      : {};
+  const keptQuantities: Record<string, number> = {};
+  for (const [name, value] of Object.entries(rawKept)) {
+    if (typeof value === "number") keptQuantities[name] = value;
+  }
+
+  const commanders = Array.isArray(obj.c)
+    ? obj.c.filter((name): name is string => typeof name === "string")
+    : [];
+
+  return {
+    crucibleId: generateCrucibleId(),
+    pool,
+    statuses,
+    keptQuantities,
+    commanders,
+    parseWarnings: [],
+    createdAt: Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Base64url helpers (no +, /, or = padding) — mirrors deck-codec.ts
+// ---------------------------------------------------------------------------
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function fromBase64Url(str: string): Uint8Array {
+  let base64 = str.replace(/-/g, "+").replace(/_/g, "/");
+  while (base64.length % 4 !== 0) {
+    base64 += "=";
+  }
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+// ---------------------------------------------------------------------------
+// Compression helpers — mirrors deck-codec.ts
+// ---------------------------------------------------------------------------
+
+async function compressGzip(data: Uint8Array): Promise<Uint8Array> {
+  const cs = new CompressionStream("gzip");
+  const writer = cs.writable.getWriter();
+  const copy = data.buffer.slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength
+  ) as ArrayBuffer;
+  void writer.write(new Uint8Array(copy));
+  void writer.close();
+
+  const chunks: Uint8Array[] = [];
+  const reader = cs.readable.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+  const compressed = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    compressed.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return compressed;
+}
+
+async function decompressGzip(data: Uint8Array): Promise<Uint8Array> {
+  const ds = new DecompressionStream("gzip");
+  const writer = ds.writable.getWriter();
+  const copy = data.buffer.slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength
+  ) as ArrayBuffer;
+  void writer.write(new Uint8Array(copy));
+  void writer.close();
+
+  const chunks: Uint8Array[] = [];
+  const reader = ds.readable.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const totalLen = chunks.reduce((sum, c) => sum + c.length, 0);
+  const decompressed = new Uint8Array(totalLen);
+  let offset = 0;
+  for (const chunk of chunks) {
+    decompressed.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return decompressed;
+}
+
+// ---------------------------------------------------------------------------
+// Public encode / decode
+// ---------------------------------------------------------------------------
+
+/** Encode an in-progress pile to a base64url gzip string for a share URL. */
+export async function encodeCruciblePile(
+  payload: CruciblePayload
+): Promise<string> {
+  const compact = buildCompactPile(payload);
+  const json = JSON.stringify(compact);
+  const encoded = new TextEncoder().encode(json);
+  const compressed = await compressGzip(encoded);
+  return toBase64Url(compressed);
+}
+
+/**
+ * Decode a shared pile back into a fresh CruciblePayload. Returns null for
+ * corrupt encodings or foreign (non-crucible) payloads so callers can fall
+ * back to the normal import screen gracefully.
+ */
+export async function decodeCruciblePile(
+  encoded: string
+): Promise<CruciblePayload | null> {
+  if (!encoded) return null;
+  try {
+    const compressed = fromBase64Url(encoded);
+    const decompressed = await decompressGzip(compressed);
+    const json = new TextDecoder().decode(decompressed);
+    return compactToPayload(JSON.parse(json));
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Forge-style .dck serializer
+// ---------------------------------------------------------------------------
+
+const DEFAULT_DCK_NAME = "Crucible Pile";
+
+/**
+ * Serialize a pile to a Forge-style INI `.dck` file: a `[metadata]` section
+ * with a `Name` line, a `[Commander]` section listing chosen commanders (one
+ * `1 <name>` per line), and a `[Main]` section listing every pool card as
+ * `<qty> <name>`. Human readable and round-trippable.
+ */
+export function serializePileToDck(
+  payload: CruciblePayload,
+  name: string = DEFAULT_DCK_NAME
+): string {
+  const trimmed = name.trim() || DEFAULT_DCK_NAME;
+  const lines: string[] = [];
+  lines.push("[metadata]");
+  lines.push(`Name=${trimmed}`);
+  lines.push("");
+  lines.push("[Commander]");
+  for (const commander of payload.commanders) {
+    lines.push(`1 ${commander}`);
+  }
+  lines.push("");
+  lines.push("[Main]");
+  for (const card of payload.pool) {
+    lines.push(`${card.quantity} ${card.name}`);
+  }
+  return lines.join("\n") + "\n";
+}

--- a/tests/unit/crucible-share.spec.ts
+++ b/tests/unit/crucible-share.spec.ts
@@ -140,13 +140,23 @@ test.describe("serializePileToDck", () => {
     expect(commanderSection).toContain("1 Atraxa, Praetors' Voice");
   });
 
-  test("lists every pool card as `<qty> <name>` in [Main]", () => {
+  test("lists non-commander pool cards as `<qty> <name>` in [Main]", () => {
     const dck = serializePileToDck(makePayload());
     const mainSection = dck.slice(dck.indexOf("[Main]"));
     expect(mainSection).toContain("1 Sol Ring");
     expect(mainSection).toContain("3 Forest");
     expect(mainSection).toContain("2 Island");
-    expect(mainSection).toContain("1 Atraxa, Praetors' Voice");
+  });
+
+  test("does not duplicate the commander in [Main] (command zone only)", () => {
+    const dck = serializePileToDck(makePayload());
+    const commanderSection = dck.slice(
+      dck.indexOf("[Commander]"),
+      dck.indexOf("[Main]")
+    );
+    const mainSection = dck.slice(dck.indexOf("[Main]"));
+    expect(commanderSection).toContain("1 Atraxa, Praetors' Voice");
+    expect(mainSection).not.toContain("Atraxa, Praetors' Voice");
   });
 
   test("falls back to a default name when none is provided", () => {

--- a/tests/unit/crucible-share.spec.ts
+++ b/tests/unit/crucible-share.spec.ts
@@ -1,0 +1,164 @@
+import { test, expect } from "@playwright/test";
+import {
+  encodeCruciblePile,
+  decodeCruciblePile,
+  serializePileToDck,
+} from "../../src/lib/crucible-share";
+import type { CruciblePayload } from "../../src/lib/crucible-session";
+
+function makePayload(overrides: Partial<CruciblePayload> = {}): CruciblePayload {
+  return {
+    crucibleId: "crucible-fixture",
+    pool: [
+      { name: "Atraxa, Praetors' Voice", quantity: 1 },
+      { name: "Sol Ring", quantity: 1 },
+      { name: "Forest", quantity: 3 },
+      { name: "Island", quantity: 2 },
+    ],
+    statuses: {
+      "Atraxa, Praetors' Voice": "keep",
+      "Sol Ring": "keep",
+      Forest: "cut",
+      Island: "undecided",
+    },
+    keptQuantities: { Forest: 0 },
+    commanders: ["Atraxa, Praetors' Voice"],
+    parseWarnings: [],
+    createdAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+test.describe("encodeCruciblePile / decodeCruciblePile", () => {
+  test("round-trip preserves pool, statuses, commanders, keptQuantities", async () => {
+    const payload = makePayload({
+      keptQuantities: { Island: 1 },
+      statuses: {
+        "Atraxa, Praetors' Voice": "keep",
+        "Sol Ring": "keep",
+        Forest: "cut",
+        Island: "keep",
+      },
+    });
+    const encoded = await encodeCruciblePile(payload);
+    expect(typeof encoded).toBe("string");
+    expect(encoded.length).toBeGreaterThan(0);
+
+    const decoded = await decodeCruciblePile(encoded);
+    expect(decoded).not.toBeNull();
+    if (!decoded) return;
+
+    expect(decoded.pool).toEqual(payload.pool);
+    expect(decoded.statuses).toEqual(payload.statuses);
+    expect(decoded.commanders).toEqual(payload.commanders);
+    expect(decoded.keptQuantities).toEqual(payload.keptQuantities);
+  });
+
+  test("every pool name has a status entry after decode", async () => {
+    const payload = makePayload();
+    const decoded = await decodeCruciblePile(await encodeCruciblePile(payload));
+    expect(decoded).not.toBeNull();
+    if (!decoded) return;
+    for (const card of payload.pool) {
+      expect(decoded.statuses[card.name]).toBeDefined();
+    }
+    // Undecided is the default and must survive the round-trip.
+    expect(decoded.statuses.Island).toBe("undecided");
+  });
+
+  test("regenerates crucibleId and createdAt (does not trust the encoded ones)", async () => {
+    const payload = makePayload();
+    const decoded = await decodeCruciblePile(await encodeCruciblePile(payload));
+    expect(decoded).not.toBeNull();
+    if (!decoded) return;
+    expect(typeof decoded.crucibleId).toBe("string");
+    expect(decoded.crucibleId.length).toBeGreaterThan(0);
+    expect(typeof decoded.createdAt).toBe("number");
+  });
+
+  test("empty keptQuantities and commanders round-trip cleanly", async () => {
+    const payload = makePayload({
+      commanders: [],
+      keptQuantities: {},
+      statuses: {
+        "Atraxa, Praetors' Voice": "undecided",
+        "Sol Ring": "undecided",
+        Forest: "undecided",
+        Island: "undecided",
+      },
+    });
+    const decoded = await decodeCruciblePile(await encodeCruciblePile(payload));
+    expect(decoded).not.toBeNull();
+    if (!decoded) return;
+    expect(decoded.commanders).toEqual([]);
+    expect(decoded.keptQuantities).toEqual({});
+  });
+
+  test("returns null for corrupt base64url input", async () => {
+    expect(await decodeCruciblePile("!!!not-valid!!!")).toBeNull();
+    expect(await decodeCruciblePile("")).toBeNull();
+  });
+
+  test("returns null for foreign (non-crucible) payloads", async () => {
+    // A valid gzip+base64url blob whose JSON is not a crucible pile.
+    const foreign = { v: 2, n: "Some Deck", c: [], m: [["cmm", "1", 1]] };
+    const bytes = new TextEncoder().encode(JSON.stringify(foreign));
+    const cs = new CompressionStream("gzip");
+    const writer = cs.writable.getWriter();
+    void writer.write(bytes);
+    void writer.close();
+    const compressed = new Uint8Array(
+      await new Response(cs.readable).arrayBuffer()
+    );
+    let binary = "";
+    for (const b of compressed) binary += String.fromCharCode(b);
+    const encoded = btoa(binary)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(await decodeCruciblePile(encoded)).toBeNull();
+  });
+});
+
+test.describe("serializePileToDck", () => {
+  test("emits [metadata], [Commander], and [Main] sections", () => {
+    const dck = serializePileToDck(makePayload(), "My Pile");
+    expect(dck).toContain("[metadata]");
+    expect(dck).toContain("Name=My Pile");
+    expect(dck).toContain("[Commander]");
+    expect(dck).toContain("[Main]");
+    // Sections appear in the canonical order.
+    expect(dck.indexOf("[metadata]")).toBeLessThan(dck.indexOf("[Commander]"));
+    expect(dck.indexOf("[Commander]")).toBeLessThan(dck.indexOf("[Main]"));
+  });
+
+  test("lists each commander as a single copy", () => {
+    const dck = serializePileToDck(makePayload());
+    const commanderSection = dck
+      .slice(dck.indexOf("[Commander]"), dck.indexOf("[Main]"))
+      .trim();
+    expect(commanderSection).toContain("1 Atraxa, Praetors' Voice");
+  });
+
+  test("lists every pool card as `<qty> <name>` in [Main]", () => {
+    const dck = serializePileToDck(makePayload());
+    const mainSection = dck.slice(dck.indexOf("[Main]"));
+    expect(mainSection).toContain("1 Sol Ring");
+    expect(mainSection).toContain("3 Forest");
+    expect(mainSection).toContain("2 Island");
+    expect(mainSection).toContain("1 Atraxa, Praetors' Voice");
+  });
+
+  test("falls back to a default name when none is provided", () => {
+    const dck = serializePileToDck(makePayload({ commanders: [] }));
+    expect(dck).toMatch(/Name=.+/);
+  });
+
+  test("omits commander lines when no commanders are chosen", () => {
+    const dck = serializePileToDck(makePayload({ commanders: [] }), "Pile");
+    const commanderSection = dck
+      .slice(dck.indexOf("[Commander]"), dck.indexOf("[Main]"))
+      .trim();
+    expect(commanderSection).toBe("[Commander]");
+  });
+});


### PR DESCRIPTION
## What Changed

- Added pile sharing from the Crucible: a new `crucible-share` codec encodes/decodes a pile to a `?p=` URL (round-tripped on reopen and stripped from the address bar) and serializes to a downloadable `.dck` file, wired into the workbench with copy-link and download controls.
- Virtualized the workbench rows with a windowing library, removing the per-group render cap so arbitrarily large piles render efficiently; group headers became absolutely-positioned rows and `scrollMargin` now uses a true document offset (`getBoundingClientRect().top + scrollY`).
- Let users name the deck before sealing: `CrucibleSessionContext` tracks a transient `deckName` (reset when a new pile loads) that flows into the sealed `DeckData` and downstream reading hero.

## Risk Assessment

✅ Low: The only new changes are the two targeted fixes from the prior round (correct document-offset scrollMargin and resetting the transient deckName on new/loaded/cleared piles), both applied correctly with no new problems.

## Testing

Ran the crucible-share unit suite (12 passed) and the share/virtualization/handoff e2e suites (10 passed) after installing deps and Chromium, then drove each feature in a real browser to capture reviewer-visible evidence: the Share-pile 'Copied' confirmation and generated /crucible?p= URL, a round-tripped .dck INI file, virtualization screenshots proving only ~23 of 180 rows mount at the top while the tail mounts on scroll, and the custom deck name 'Praetor's Reckoning' flowing through sealing into the reading hero. All checks passed; transient test spec and Playwright outputs were removed and the worktree left clean.

- Evidence: Reading hero shows Crucible-typed deck name (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXXGNB34KFXEND9QP39EXCMW/reading-hero-custom-name.png</code>)
- Evidence: Share pile copied confirmation in workbench header (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXXGNB34KFXEND9QP39EXCMW/share-pile-copied.png</code>)
- Evidence: Virtualization: tail rows (Relic 168-180) + deck-name rail after scroll (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXXGNB34KFXEND9QP39EXCMW/virtualization-bottom.png</code>)
- Evidence: Virtualization: top-of-list window (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXXGNB34KFXEND9QP39EXCMW/virtualization-top.png</code>)
- Evidence: Reopened ?p= URL rebuilds pile workbench (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXXGNB34KFXEND9QP39EXCMW/share-reopened-workbench.png</code>)
- Evidence: Deck name entered before sealing (local file: <code>/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXXGNB34KFXEND9QP39EXCMW/deck-name-before-seal.png</code>)
<details>
<summary>Evidence: Generated Forge-style .dck file</summary>

<code>[metadata]&#10;Name=Crucible Pile&#10;&#10;[Commander]&#10;1 Atraxa, Praetors&#39; Voice&#10;&#10;[Main]&#10;1 Ezuri, Stalker of Spheres&#10;1 Sol Ring&#10;1 Command Tower&#10;... (13 main cards)</code>

```text
[metadata]
Name=Crucible Pile

[Commander]
1 Atraxa, Praetors' Voice

[Main]
1 Ezuri, Stalker of Spheres
1 Sol Ring
1 Command Tower
1 Arcane Signet
1 Swords to Plowshares
1 Counterspell
1 Cultivate
1 Llanowar Elves
1 Lightning Bolt
1 Path to Exile
3 Forest
2 Island
```
</details>
<details>
<summary>Evidence: Virtualization row count (180 pile → 23 mounted)</summary>

<code>Pile size: 180 unique cards&#10;Rows mounted in DOM (top of list): 23</code>

```text
Pile size: 180 unique cards
Rows mounted in DOM (top of list): 23
```
</details>
<details>
<summary>Evidence: Generated share URL</summary>

`http://localhost:3000/crucible?p=H4sIAAAAAAAAE0WPQWuDQBCF_8owl172kva2tyRYKOQgsfQiHgad6uJmR2ZXDRH_ewloc3zv8c17s...`

```text
http://localhost:3000/crucible?p=H4sIAAAAAAAAE0WPQWuDQBCF_8owl172kva2tyRYKOQgsfQiHgad6uJmR2ZXDRH_ewloc3zv8c17s-CE9mBwQFuWeExKdzKQK3ESjW_wI65mNIfKlJg9RnUGikS-ZwX5hWLoWDlueSEeri60mzzL7UahgW-ZWTfvqDUFhsK1gdOOzaJNhCSQe5ljR6-LZxlDYo0De79bo09uorSPungKMpNC5qd_7uLaLgUXWjiJ33tySt2zJbs7v9OfohwTmo-n-IqeQoPmvaoMRrTL6yOLPa4Ge7TLarBGW1brH8SvhPw7AQAA
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed ✅</summary>

- ⚠️ `src/components/crucible/CrucibleWorkbench.tsx:221` - scrollMargin is set from `node.offsetTop`, which is measured relative to the nearest positioned ancestor (the root layout&#39;s `&lt;div className=&#34;relative z-10 flex-1&#34;&gt;` in src/app/layout.tsx:55), not the document. Because that div sits below the sticky TopNav, offsetTop under-reports the list&#39;s true document offset by the nav&#39;s height. The comment claims this is &#39;the list&#39;s offset from the top of the document&#39;, but it is not. The window virtualizer&#39;s visible-range math is therefore offset by the nav height. It&#39;s largely masked by the 12-row OVERSCAN, but the scroll geometry is incorrect. Use `node.getBoundingClientRect().top + window.scrollY` (both in the initial measure and the ResizeObserver callback) for a true document offset.
- ℹ️ `src/contexts/CrucibleSessionContext.tsx:778` - `deckName` is transient state held outside the reducer and is never reset in `clearCrucible` (or `loadPile`/`setPile`). Starting a new pile via &#39;start over&#39; inside the crucible route retains a previously-typed deck name in the input. Minor: reset `setDeckName(&#34;&#34;)` in clearCrucible/loadPile for a clean slate.
- ℹ️ `src/components/crucible/crucible.module.css:176` - Virtualization moved group headers from `position: sticky` to absolutely-positioned .vItem rows, so headers no longer stick to the top of the viewport while scrolling within a long group. This is an intentional, documented tradeoff of the flat window virtualizer, noted here for awareness only.

🔧 Fix: fix crucible scrollMargin doc offset and reset deckName on new pile
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`npx playwright test --config playwright.unit.config.ts tests/unit/crucible-share.spec.ts` (12 passed) — share codec round-trip + .dck serialization</code>
- <code>`npx playwright test --config playwright.config.ts e2e/crucible-share.spec.ts e2e/crucible-virtualization.spec.ts e2e/crucible-handoff.spec.ts` (10 passed)</code>
- `Temporary evidence spec driving each flow in Chromium: share-pile copy + 'Copied' confirmation, reopen ?p= URL rebuilds 16-card pile and strips param, Download .dck content, 180-card virtualization top/bottom window, deck-name → reading-hero handoff`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
