### PR TITLE
feat(reading): add dedicated /reading/meta page and harden EDHREC fetch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ src/
 │   │       ├── layout.tsx         # DeckReadingShell + CandidatesProvider
 │   │       ├── cards/page.tsx
 │   │       ├── composition/page.tsx
+│   │       ├── meta/page.tsx
 │   │       ├── synergy/page.tsx
 │   │       ├── interactions/page.tsx
 │   │       ├── hands/page.tsx
@@ -152,7 +153,7 @@ Design details: `docs/plans/crucible-deck-builder.md`.
 - `DeckData` -- `{ name, source, url, commanders[], mainboard[], sideboard[] }`
 - `EnrichedCard` -- Full card data from Scryfall (mana cost, oracle text, type line, keywords, power/toughness, etc.)
 - `DeckSessionPayload` -- `{ id, deck, cardMap?, parseWarnings, notFoundCount, ... }`
-- `ViewTab` -- union of 10 sub-route keys; `TAB_ROUTES[tab]` → `/reading/<slug>`
+- `ViewTab` -- union of 11 sub-route keys; `TAB_ROUTES[tab]` → `/reading/<slug>`
 - Source can be `"moxfield" | "archidekt" | "text"`
 
 ### Design System (Astral)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A web application for importing and analyzing Magic: The Gathering decklists. Built with Next.js and TypeScript.
 
-Import a deck (paste, Moxfield export, or Archidekt URL) and the app walks you through a four-stage **journey** — *import → ritual → reading → sub-route*. The reading lands on a verdict hero (bracket, power level, top theme), then fans out across ten sub-routes for cards, composition, synergy, interactions, opening hands, goldfish simulation, suggestions, candidate finder, deck-vs-deck compare, and share/export. Cards are automatically enriched via Scryfall (mana costs as official MTG symbols, oracle text with inline symbols, heuristic tags), combos are detected via Commander Spellbook, and a neutral **Stock ↔ Spicy** meta read (EDHREC staple coverage plus a per-card inclusion heat list) shows how conventional or off-meta your card choices are.
+Import a deck (paste, Moxfield export, or Archidekt URL) and the app walks you through a four-stage **journey** — *import → ritual → reading → sub-route*. The reading lands on a verdict hero (bracket, power level, top theme), then fans out across eleven sub-routes for cards, composition, meta, synergy, interactions, opening hands, goldfish simulation, suggestions, candidate finder, deck-vs-deck compare, and share/export. Cards are automatically enriched via Scryfall (mana costs as official MTG symbols, oracle text with inline symbols, heuristic tags), combos are detected via Commander Spellbook, and a neutral **Stock ↔ Spicy** meta read (EDHREC staple coverage plus a per-card inclusion heat list) shows how conventional or off-meta your card choices are.
 
 Don't have a finished deck yet? **The Crucible** (`/crucible`) is a deck-building workbench: pour in any pile of cards, organize it through lenses (category, synergy axis, type line, mana value, color identity, game changers), triage each card as keep/cut/undecided with an explicit commander pick, search up and add more cards mid-triage, share the pile via link or `.dck` download, and seal a legal 100-card Commander deck that flows straight into the reading journey (cuts are kept as sideboard candidates).
 
@@ -89,7 +89,7 @@ src/
 │   │   ├── page.tsx                # Verdict landing
 │   │   └── (shell)/                # Shared sidebar + drawer + candidates
 │   │       ├── layout.tsx
-│   │       └── <slug>/page.tsx     # 10 sub-routes
+│   │       └── <slug>/page.tsx     # 11 sub-routes
 │   ├── shared/page.tsx             # Decode share URL → /reading
 │   ├── crucible/                   # The Crucible pile triage workbench
 │   ├── compare/                    # Standalone two-deck compare

--- a/design-system/CLAUDE.md
+++ b/design-system/CLAUDE.md
@@ -20,7 +20,7 @@ covered by 408 e2e tests + 2473 unit tests. Mark these as done in the
 - ✅ Domain components — `<ManaCost>`, `<ColorPie>`, `<CurveConstellation>`,
   `<CardRow>`, `<DeckHero>` exposed via `src/components/deck/`.
 - ✅ Screens — every route below the table now exists, including the
-  ritual loader (`/ritual`), the verdict hero on `/reading`, and the ten
+  ritual loader (`/ritual`), the verdict hero on `/reading`, and the eleven
   shell sub-routes under `/reading/(shell)/`.
 - ✅ `prefers-reduced-motion` honored across CosmicLoader, ReadingOverview,
   DeckReadingShell, DeckSidebar, share page, and CosmosBackground.

--- a/docs/plans/edhrec-meta-score.md
+++ b/docs/plans/edhrec-meta-score.md
@@ -37,6 +37,9 @@ Live EDHREC data revealed two problems the mock hid: (1) the commander JSON only
 - **New `insufficient` status** when fewer than `MIN_RATED_CARDS` (10) deck cards are rated — the panel refuses to render a misleading read and explains why.
 - **Bands re-tuned to real inclusion:** Staple ≥60%, Standard 30–60%, Niche 10–30%, Spice <10%.
 
+### D4c — Dedicated reading page (revision)
+Live use showed the woven-in placement (overview panel + heat list on `/reading/cards`) gave no way to *return* to the meta read while navigating a reading. Added a first-class **`/reading/meta`** sub-route with a sidebar nav entry ("Meta", Deck group) — the full analysis (panel + bands + heat list) now has a home reachable anytime. The heat list moved off `/reading/cards` (removing the duplicate card listing) onto this page; the overview keeps the glance panel.
+
 ### D5 — Exclusions & normalization
 Exclude basic lands and the commander(s) from all rollups. Card-name matching between EDHREC's list and deck names reuses the case-insensitive + DFC-front-face (`" // "` split) + `flavor_name` normalization already used in `deck-enrich/route.ts`. The commander slug reuses the existing slugifier extracted from `buildEdhrecUrl` in `commander-validation.ts` (`atraxa-praetors-voice` form).
 

--- a/e2e/deck-header.spec.ts
+++ b/e2e/deck-header.spec.ts
@@ -57,8 +57,9 @@ test.describe("Deck Header", () => {
 
     const header = deckPage.page.getByTestId("deck-header");
     const tabs = header.getByRole("tab");
-    // Phase 4 added Compare + Share alongside the existing 8.
-    await expect(tabs).toHaveCount(10);
+    // Phase 4 added Compare + Share alongside the existing 8; the Meta tab
+    // (EDHREC stock/spicy) later brought the total to 11.
+    await expect(tabs).toHaveCount(11);
 
     await expect(header.getByRole("tab", { name: "Deck List" })).toBeVisible();
     await expect(header.getByRole("tab", { name: "Analysis" })).toBeVisible();

--- a/e2e/possible-additions.spec.ts
+++ b/e2e/possible-additions.spec.ts
@@ -423,9 +423,9 @@ test.describe("Additions tab", () => {
     const tablist = page.getByRole("tablist", { name: "Deck view" });
     const tabs = tablist.getByRole("tab");
 
-    // Phase 4: 10 tabs total (added Compare + Share alongside the
-    // existing 8). Additions is no longer the last tab.
-    await expect(tabs).toHaveCount(10);
+    // Phase 4: 10 tabs (added Compare + Share); the Meta tab later made 11.
+    // Additions is no longer the last tab.
+    await expect(tabs).toHaveCount(11);
 
     const additionsTab = tablist.getByRole("tab", { name: "Additions" });
     await expect(additionsTab).toBeVisible();

--- a/e2e/reading-meta-evidence.spec.ts
+++ b/e2e/reading-meta-evidence.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect, META_DECKLIST, DEFAULT_META_ENVELOPE } from "./fixtures";
+
+const EVIDENCE_DIR =
+  "/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXYRK5XTJV2N5MRRQKK7FBEN";
+
+async function importMeta(deckPage: import("./fixtures").DeckPage) {
+  await deckPage.goto();
+  await deckPage.mockMeta(DEFAULT_META_ENVELOPE);
+  await deckPage.fillDecklist(META_DECKLIST);
+  await deckPage.submitImport();
+  await deckPage.page.waitForURL(/\/reading(\/|$|\?)/, { timeout: 15_000 });
+}
+
+test.describe("evidence: dedicated /reading/meta page", () => {
+  test("nav to Meta tab from the sidebar opens the dedicated page and captures it", async ({
+    deckPage,
+  }) => {
+    const page = deckPage.page;
+    await importMeta(deckPage);
+
+    // Start on the cards page — the heat list was moved OFF here.
+    await page.goto("/reading/cards");
+    await expect(page.getByTestId("meta-heat-list")).toHaveCount(0);
+
+    // The Meta sidebar tab in the Deck group navigates to the dedicated page.
+    const tablist = page.getByRole("tablist", { name: "Deck view" });
+    const metaTab = tablist.getByRole("tab", { name: "Meta" });
+    await expect(metaTab).toBeVisible();
+    await metaTab.click();
+    await page.waitForURL(/\/reading\/meta(\/|$|\?)/, { timeout: 15_000 });
+
+    // The dedicated page hosts the full analysis.
+    await expect(page.getByTestId("section-header-meta")).toBeVisible();
+    await expect(page.getByTestId("meta-panel")).toBeVisible();
+    await expect(page.getByTestId("meta-heat-list")).toBeVisible();
+
+    await page.waitForTimeout(400); // let dial/band transitions settle
+    await page.screenshot({
+      path: `${EVIDENCE_DIR}/reading-meta-page-full.png`,
+      fullPage: true,
+    });
+
+    // Close-up of the heat list living on this page.
+    await page.getByTestId("meta-heat-list").scrollIntoViewIfNeeded();
+    await page
+      .getByTestId("meta-heat-list")
+      .screenshot({ path: `${EVIDENCE_DIR}/reading-meta-heat-list.png` });
+  });
+
+  test("heat list sort + filter on the meta page, captured", async ({ deckPage }) => {
+    const page = deckPage.page;
+    await importMeta(deckPage);
+    await page.goto("/reading/meta");
+
+    await expect(page.getByTestId("meta-heat-list")).toBeVisible();
+    // Filter to spice → staple drops out.
+    await page.getByTestId("meta-filter").selectOption("spice");
+    await expect(page.getByTestId("meta-row-Contentious Plan")).toBeVisible();
+    await expect(page.getByTestId("meta-row-Sol Ring")).toHaveCount(0);
+    await page.getByTestId("meta-heat-list").scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+    await page.screenshot({
+      path: `${EVIDENCE_DIR}/reading-meta-filtered-spice.png`,
+      fullPage: true,
+    });
+  });
+
+  test("meta panel still on /reading overview (glance), captured", async ({ deckPage }) => {
+    const page = deckPage.page;
+    await importMeta(deckPage);
+    await page.goto("/reading");
+    await expect(page.getByTestId("meta-panel")).toBeVisible();
+    await page.getByTestId("meta-panel").scrollIntoViewIfNeeded();
+    await page.waitForTimeout(300);
+    await page.getByTestId("meta-panel").screenshot({
+      path: `${EVIDENCE_DIR}/reading-overview-meta-panel.png`,
+    });
+  });
+});

--- a/e2e/reading-meta-evidence.spec.ts
+++ b/e2e/reading-meta-evidence.spec.ts
@@ -1,7 +1,17 @@
 import { test, expect, META_DECKLIST, DEFAULT_META_ENVELOPE } from "./fixtures";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 
-const EVIDENCE_DIR =
-  "/var/folders/5h/xwb2_w856w3fgxszkbhc00r00000gn/T/no-mistakes-evidence/01KXYRK5XTJV2N5MRRQKK7FBEN";
+// Derive the evidence dir from the OS temp dir so it resolves on every
+// platform (macOS `/var/folders/…`, Linux CI `/tmp/…`), and create it up
+// front — Playwright silently swallows a failed recursive mkdir, so an
+// absent parent surfaces later as an ENOENT on screenshot write.
+const EVIDENCE_DIR = join(tmpdir(), "no-mistakes-evidence", "01KXYRK5XTJV2N5MRRQKK7FBEN");
+
+test.beforeAll(() => {
+  mkdirSync(EVIDENCE_DIR, { recursive: true });
+});
 
 async function importMeta(deckPage: import("./fixtures").DeckPage) {
   await deckPage.goto();

--- a/e2e/reading-meta.spec.ts
+++ b/e2e/reading-meta.spec.ts
@@ -31,9 +31,22 @@ test.describe("/reading meta panel (Stock ↔ Spicy)", () => {
     await expect(readout).toContainText(/mean inclusion/i);
   });
 
-  test("cards page shows the inclusion heat list with sort and filter", async ({ deckPage }) => {
+  test("has a Meta tab in the reading nav that opens the dedicated page", async ({ deckPage }) => {
     await importMeta(deckPage);
+    // The sidebar lives on the shell sub-routes; from any of them the Meta tab
+    // is the page the user returns to while digging into a reading.
     await deckPage.page.goto("/reading/cards");
+    const tablist = deckPage.page.getByRole("tablist", { name: "Deck view" });
+    await tablist.getByRole("tab", { name: "Meta" }).click();
+    await deckPage.page.waitForURL(/\/reading\/meta(\/|$|\?)/, { timeout: 15_000 });
+    await expect(deckPage.page.getByTestId("section-header-meta")).toBeVisible();
+    await expect(deckPage.page.getByTestId("meta-panel")).toBeVisible();
+    await expect(deckPage.page.getByTestId("meta-heat-list")).toBeVisible();
+  });
+
+  test("meta page shows the inclusion heat list with sort and filter", async ({ deckPage }) => {
+    await importMeta(deckPage);
+    await deckPage.page.goto("/reading/meta");
     const list = deckPage.page.getByTestId("meta-heat-list");
     await expect(list).toBeVisible();
 

--- a/e2e/reading-meta.spec.ts
+++ b/e2e/reading-meta.spec.ts
@@ -66,7 +66,7 @@ test.describe("/reading meta panel (Stock ↔ Spicy)", () => {
 
   test("hovering a heat-list row reveals its card preview", async ({ deckPage }) => {
     await importMeta(deckPage);
-    await deckPage.page.goto("/reading/cards");
+    await deckPage.page.goto("/reading/meta");
     await expect(deckPage.page.getByTestId("meta-heat-list")).toBeVisible();
 
     await deckPage.page.getByTestId("meta-row-Sol Ring").hover();

--- a/src/app/reading/(shell)/cards/page.tsx
+++ b/src/app/reading/(shell)/cards/page.tsx
@@ -8,7 +8,6 @@ import SectionHeader, {
 } from "@/components/reading/SectionHeader";
 import ChapterFooter from "@/components/reading/ChapterFooter";
 import DeckList from "@/components/DeckList";
-import MetaHeatList from "@/components/reading/MetaHeatList";
 
 export default function CardsPage() {
   const { payload, enrichLoading } = useDeckSession();
@@ -73,9 +72,6 @@ export default function CardsPage() {
         cardMap={cardMap}
         enrichLoading={enrichLoading}
       />
-      {payload.deckMeta && (
-        <MetaHeatList meta={payload.deckMeta} cardMap={cardMap} />
-      )}
       <ChapterFooter current="list" />
     </div>
   );

--- a/src/app/reading/(shell)/meta/page.tsx
+++ b/src/app/reading/(shell)/meta/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useDeckSession } from "@/contexts/DeckSessionContext";
+import { readingRunningHead } from "@/lib/reading-format";
+import SectionHeader from "@/components/reading/SectionHeader";
+import ChapterFooter from "@/components/reading/ChapterFooter";
+import MetaPanel from "@/components/reading/MetaPanel";
+import MetaHeatList from "@/components/reading/MetaHeatList";
+
+export default function MetaPage() {
+  const { payload } = useDeckSession();
+  if (!payload) return null;
+  const { deck, cardMap, deckMeta } = payload;
+
+  return (
+    <div role="tabpanel" id="tabpanel-meta" aria-labelledby="tab-meta">
+      <SectionHeader
+        slug="meta"
+        runningHead={readingRunningHead(payload.createdAt, deck.name)}
+        eyebrow="Meta"
+        title="Stock ↔ Spicy"
+        tagline="How conventional this deck's card choices are for its commander, read from how often each card shows up in EDHREC's registered decks."
+      />
+      <MetaPanel />
+      {deckMeta && <MetaHeatList meta={deckMeta} cardMap={cardMap} />}
+      <ChapterFooter current="meta" />
+    </div>
+  );
+}

--- a/src/components/DeckSidebar.tsx
+++ b/src/components/DeckSidebar.tsx
@@ -129,9 +129,19 @@ function IconShareNode() {
   );
 }
 
+function IconGauge() {
+  return (
+    <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" width="20" height="20" aria-hidden="true">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3.5 14a6.5 6.5 0 1113 0" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M10 14l3.5-3.5" />
+    </svg>
+  );
+}
+
 const TAB_ICONS: Record<ViewTab, React.ReactNode> = {
   list: <IconList />,
   analysis: <IconChartBar />,
+  meta: <IconGauge />,
   synergy: <IconPuzzle />,
   interactions: <IconBolt />,
   hands: <IconHand />,

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -162,6 +162,7 @@ export default function CrucibleWorkbench() {
       });
     return () => {
       cancelled = true;
+      metaKeyRef.current = null; // allow a re-fetch if the lens is reopened
     };
   }, [lens, payload]);
 

--- a/src/components/crucible/CrucibleWorkbench.tsx
+++ b/src/components/crucible/CrucibleWorkbench.tsx
@@ -131,24 +131,32 @@ export default function CrucibleWorkbench() {
     return identity;
   }, [payload, cardMap]);
 
+  const metaCommanderKey =
+    lens === "meta" && payload && payload.commanders.length > 0
+      ? [...payload.commanders].sort().join("|")
+      : "";
+
   // Fetch EDHREC inclusion once per commander set, only while the meta lens is
   // open. Off by default — nothing loads until the lens is selected. Re-runs if
-  // the commander changes while the lens is active.
+  // the commander changes while the lens is active. Keyed on the commander set,
+  // not the whole payload, so triage (keep/cut) does not re-fire the fetch.
   useEffect(() => {
-    if (lens !== "meta" || !payload || payload.commanders.length === 0) return;
-    const key = [...payload.commanders].sort().join("|");
-    if (metaKeyRef.current === key) return;
-    metaKeyRef.current = key;
+    if (metaCommanderKey === "") return;
+    if (metaKeyRef.current === metaCommanderKey) return;
+    metaKeyRef.current = metaCommanderKey;
 
     let cancelled = false;
+    let settled = false;
+    const commanders = metaCommanderKey.split("|");
     metaDispatch({ type: "START" });
     fetch("/api/deck-meta", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ commanders: payload.commanders }),
+      body: JSON.stringify({ commanders }),
     })
       .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
       .then((json: { inclusionMap?: Record<string, number>; error?: string }) => {
+        settled = true;
         if (cancelled) return;
         if (json.error) {
           metaKeyRef.current = null; // allow a retry on re-select
@@ -156,15 +164,16 @@ export default function CrucibleWorkbench() {
         } else metaDispatch({ type: "SUCCESS", inclusion: json.inclusionMap ?? {} });
       })
       .catch(() => {
+        settled = true;
         if (cancelled) return;
         metaKeyRef.current = null; // allow a retry on re-select
         metaDispatch({ type: "ERROR" });
       });
     return () => {
       cancelled = true;
-      metaKeyRef.current = null; // allow a re-fetch if the lens is reopened
+      if (!settled) metaKeyRef.current = null; // torn down mid-flight — allow re-fetch on re-select
     };
-  }, [lens, payload]);
+  }, [metaCommanderKey]);
 
   const targetByLabel = useMemo(() => {
     const map = new Map<string, { min: number; max: number }>();

--- a/src/components/reading/MetaHeatList.tsx
+++ b/src/components/reading/MetaHeatList.tsx
@@ -26,7 +26,7 @@ export interface MetaHeatListProps {
   cardMap: Record<string, EnrichedCard> | null;
 }
 
-/** The per-card "inclusion heat list" for /reading/cards: every scored card
+/** The per-card "inclusion heat list" for /reading/meta: every scored card
  * with its EDHREC inclusion, sortable spicy→stock and filterable, with card
  * art on hover. Rendered only when meta data is present (ok / thin). */
 export default function MetaHeatList({ meta, cardMap }: MetaHeatListProps) {

--- a/src/components/reading/MetaPanel.tsx
+++ b/src/components/reading/MetaPanel.tsx
@@ -65,7 +65,7 @@ export default function MetaPanel() {
         <div className={styles.empty} data-testid="meta-insufficient">
           <p className={styles.emptyTitle}>Not enough EDHREC data</p>
           <p className={styles.emptyBody}>
-            Only {meta.ratedCount} of your cards are in EDHREC&apos;s data for this
+            Only {`${meta.ratedCount} `}of your cards are in EDHREC&apos;s data for this
             commander — too few to read a reliable stock vs. spice picture. EDHREC
             only tracks a few hundred notable cards per commander.
           </p>

--- a/src/lib/crucible-grouping.ts
+++ b/src/lib/crucible-grouping.ts
@@ -334,9 +334,10 @@ export function gameChangers(
 /**
  * Group the pool by EDHREC "stock ↔ spicy" standing for build-time triage:
  * Staples (inclusion ≥ 50%, safe keeps), Flex (10–50%, real choices), and
- * Spice (< 10% or unknown, the builder's call). Basic lands get their own
- * group (no meaningful meta signal); names enrichment could not resolve fall
- * into Unresolved. Empty groups are omitted.
+ * Spice (< 10%, the builder's call). Cards with no EDHREC data fall into their
+ * own Unrated group rather than Spice. Basic lands get their own group (no
+ * meaningful meta signal); names enrichment could not resolve fall into
+ * Unresolved. Empty groups are omitted.
  */
 export function groupByMeta(
   pool: DeckCard[],

--- a/src/lib/edhrec-fetch.ts
+++ b/src/lib/edhrec-fetch.ts
@@ -27,15 +27,6 @@ interface CacheEntry extends SlugData {
 
 const cache = new Map<string, CacheEntry>();
 
-/**
- * A resolvable EDHREC slug is lowercase alphanumerics and hyphens only. This is
- * already guaranteed by `commanderSlug`, but validating again at the fetch
- * boundary keeps a user-derived slug from ever influencing the request URL's
- * structure (path traversal, host injection) — the value can only select a page
- * under the fixed EDHREC commander path.
- */
-const SLUG_RE = /^[a-z0-9-]+$/;
-
 export interface EdhrecMetaEnvelope {
   source: MetaSource | null;
   commanderLabel: string;
@@ -48,18 +39,23 @@ export interface EdhrecMetaEnvelope {
 /** Fetch + parse a single slug, with a 24h cache. Returns an empty map (not an
  * error) when EDHREC has no page for the slug. Throws only on transport error. */
 async function fetchSlug(slug: string): Promise<SlugData> {
-  // Reject anything that isn't a plain commander slug before it can reach the
-  // request URL — an unresolvable slug is a no-data outcome, not a fetch.
-  if (!SLUG_RE.test(slug)) {
+  // Sanitize to a fresh allowlisted string: strip everything but lowercase
+  // alphanumerics and hyphens. This is the value that reaches the request URL,
+  // so the user-derived name can only ever select a page under the fixed EDHREC
+  // commander path — no host, scheme, or path-traversal injection is possible.
+  // (Also clears the CodeQL SSRF taint, which a boolean guard alone does not.)
+  const safeSlug = slug.replace(/[^a-z0-9-]/g, "");
+  // An empty/unresolvable slug is a no-data outcome, not a fetch.
+  if (!safeSlug) {
     return { inclusionMap: {}, potentialDecks: 0 };
   }
 
-  const cached = cache.get(slug);
+  const cached = cache.get(safeSlug);
   if (cached && cached.expires > Date.now()) {
     return { inclusionMap: cached.inclusionMap, potentialDecks: cached.potentialDecks };
   }
 
-  const res = await fetch(`${EDHREC_BASE}/${encodeURIComponent(slug)}.json`, {
+  const res = await fetch(`${EDHREC_BASE}/${safeSlug}.json`, {
     headers: REQUEST_HEADERS,
     cache: "no-store",
     signal: AbortSignal.timeout(10_000),
@@ -69,7 +65,7 @@ async function fetchSlug(slug: string): Promise<SlugData> {
   // we don't hammer EDHREC for a commander it will never have.
   if (res.status === 404) {
     const empty: SlugData = { inclusionMap: {}, potentialDecks: 0 };
-    cache.set(slug, { ...empty, expires: Date.now() + CACHE_TTL_MS });
+    cache.set(safeSlug, { ...empty, expires: Date.now() + CACHE_TTL_MS });
     return empty;
   }
   if (!res.ok) {
@@ -78,7 +74,7 @@ async function fetchSlug(slug: string): Promise<SlugData> {
 
   const json = await res.json();
   const parsed = parseEdhrecPayload(json);
-  cache.set(slug, { ...parsed, expires: Date.now() + CACHE_TTL_MS });
+  cache.set(safeSlug, { ...parsed, expires: Date.now() + CACHE_TTL_MS });
   return parsed;
 }
 

--- a/src/lib/view-tabs.ts
+++ b/src/lib/view-tabs.ts
@@ -1,6 +1,7 @@
 export type ViewTab =
   | "list"
   | "analysis"
+  | "meta"
   | "synergy"
   | "hands"
   | "additions"
@@ -20,7 +21,7 @@ export const NAV_CATEGORIES: NavCategory[] = [
   {
     id: "deck",
     label: "Deck",
-    items: ["list", "analysis"],
+    items: ["list", "analysis", "meta"],
   },
   {
     id: "mechanics",
@@ -53,6 +54,7 @@ export const ENRICHMENT_REQUIRED_TABS = new Set<ViewTab>([
 export const ALL_TABS: { key: ViewTab; label: string; badge?: string }[] = [
   { key: "list", label: "Deck List" },
   { key: "analysis", label: "Analysis" },
+  { key: "meta", label: "Meta" },
   { key: "synergy", label: "Synergy" },
   { key: "hands", label: "Hands" },
   { key: "additions", label: "Additions" },
@@ -71,6 +73,7 @@ export const ALL_TABS: { key: ViewTab; label: string; badge?: string }[] = [
 export const TAB_ROUTES: Record<ViewTab, string> = {
   list: "/reading/cards",
   analysis: "/reading/composition",
+  meta: "/reading/meta",
   synergy: "/reading/synergy",
   interactions: "/reading/interactions",
   hands: "/reading/hands",
@@ -99,6 +102,7 @@ export function tabFromPathname(pathname: string): ViewTab | null {
 export const READING_ORDER: ViewTab[] = [
   "list",
   "analysis",
+  "meta",
   "synergy",
   "interactions",
   "hands",

--- a/tests/unit/edhrec-fetch-url.spec.ts
+++ b/tests/unit/edhrec-fetch-url.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from "@playwright/test";
+import { resolveEdhrecMeta, __clearEdhrecCache } from "../../src/lib/edhrec-fetch";
+
+/**
+ * Guards the SSRF-hardening of the EDHREC fetch boundary (PR #131 CodeQL alert):
+ * the user-derived commander name is sanitized with `.replace(/[^a-z0-9-]/g, "")`
+ * before it reaches the request URL, so it can only ever select a page under the
+ * fixed https://json.edhrec.com/pages/commanders/<slug>.json path — no host,
+ * scheme, or path-traversal injection. Behavior for real commanders is unchanged.
+ *
+ * We stub global.fetch to capture the exact URL that would go on the wire.
+ */
+
+const FIXED_PREFIX = "https://json.edhrec.com/pages/commanders/";
+const captured: string[] = [];
+let originalFetch: typeof fetch;
+
+function stubFetch(status = 404) {
+  originalFetch = global.fetch;
+  global.fetch = (async (input: RequestInfo | URL) => {
+    captured.push(typeof input === "string" ? input : input.toString());
+    return new Response(status === 200 ? JSON.stringify({ cardlists: [] }) : "", {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as typeof fetch;
+}
+
+test.beforeEach(() => {
+  captured.length = 0;
+  __clearEdhrecCache();
+});
+
+test.afterEach(() => {
+  if (originalFetch) global.fetch = originalFetch;
+});
+
+test.describe("EDHREC fetch URL is always under the fixed commander path", () => {
+  test("a real commander produces the unchanged, expected URL", async () => {
+    stubFetch(404);
+    await resolveEdhrecMeta(["Atraxa, Praetors' Voice"]);
+    expect(captured).toEqual([`${FIXED_PREFIX}atraxa-praetors-voice.json`]);
+  });
+
+  test("adversarial names cannot escape the host or path", async () => {
+    stubFetch(404);
+    const attacks = [
+      "evil.com/../../secret",
+      "http://169.254.169.254/latest/meta-data",
+      "..%2F..%2Fadmin",
+      "foo?x=https://evil.com",
+      "a/../../b#frag",
+    ];
+    for (const name of attacks) {
+      captured.length = 0;
+      __clearEdhrecCache();
+      await resolveEdhrecMeta([name]);
+      for (const url of captured) {
+        // Every URL stays under the hardcoded EDHREC commander path...
+        expect(url.startsWith(FIXED_PREFIX)).toBe(true);
+        // ...and the slug segment is allowlisted chars only, then ".json".
+        const slug = url.slice(FIXED_PREFIX.length, -".json".length);
+        expect(slug).toMatch(/^[a-z0-9-]*$/);
+        // No traversal, host, scheme, or query survives into the request.
+        expect(url).not.toMatch(/\/\.\.|:\/\/(?!json\.edhrec)|[?#]/);
+      }
+    }
+  });
+
+  test("a name that sanitizes to empty yields no-data with NO network call", async () => {
+    stubFetch(404);
+    const env = await resolveEdhrecMeta(["///.@!"]);
+    expect(captured).toEqual([]); // no fetch at all
+    expect(env.inclusionMap).toEqual({});
+    expect(env.potentialDecks).toBe(0);
+    expect(env.error).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Intent

Address the PR #131 Review-section comment: a CodeQL 'Server-side request forgery' alert on src/lib/edhrec-fetch.ts, where the EDHREC fetch URL is built from a user-derived commander slug. It is effectively a false positive — the host and path are hardcoded (https://json.edhrec.com/pages/commanders/<slug>.json) and the slug was already guarded by a regex — but CodeQL's taint tracking does not treat a boolean regex guard as a sanitizer. Fix: replace the SLUG_RE.test() guard + encodeURIComponent with an explicit sanitizing transformation — const safeSlug = slug.replace(/[^a-z0-9-]/g, '') — and use safeSlug for both the request URL and the cache key, returning no-data when it is empty. This is the value that reaches the URL, so the user name can only ever select a page under the fixed EDHREC path (no host/scheme/path-traversal injection), and CodeQL recognizes the .replace() as a sanitizer so the SSRF alert clears. Behavior is unchanged for real commanders (commanderSlug already emits [a-z0-9-]); removed the now-unused SLUG_RE constant. tsc, lint, build, and all 2720 unit tests pass. Sits on top of the pipeline's prior meta commits (dedicated /reading/meta page, crucible refetch fixes) — retained, not dropped.

## What Changed

- Added a dedicated `/reading/meta` sub-route with its own sidebar nav entry and view-tab wiring, moving the EDHREC meta heat list off the cards page onto its own page (new `meta/page.tsx`, `DeckSidebar`, `view-tabs`, `MetaHeatList`/`MetaPanel`).
- Reworked `src/lib/edhrec-fetch.ts` to sanitize the user-derived commander slug with an explicit `replace(/[^a-z0-9-]/g, '')` transform used for both the request URL and cache key (returning no-data when empty), dropping the old `SLUG_RE` boolean guard and clearing the CodeQL SSRF alert without changing behavior for real commanders.
- Fixed the crucible meta lens: keyed the meta fetch on the commander set to stop a refetch storm and resolved the stuck-loading state (`CrucibleWorkbench`, `crucible-grouping`).
- Added unit coverage for the sanitized fetch URL and new e2e specs for the meta page, plus synced sub-route counts across the CLAUDE.md/README/design-system docs.

## Risk Assessment

✅ Low: Well-bounded change: the SSRF fix exactly matches the authoritative intent and is applied consistently, the crucible refetch-keying refactor is correct with sound teardown logic, and the new meta tab/route is wired consistently across all maps with tests updated to match.

## Testing

Installed deps and ran the full unit suite (2723 passing, no regression). Added a focused guard test that stubs global.fetch and asserts the exact URL reaching the network: real commanders produce the unchanged `.../commanders/atraxa-praetors-voice.json`, adversarial names (path traversal, SSRF metadata host, query/fragment injection) all collapse to allowlisted slugs under the hardcoded EDHREC path, and a name that sanitizes to empty makes zero fetch calls and returns a clean no-data envelope. Captured a reviewer-visible input→wire-URL transcript as the primary artifact; no screenshot applies because the change is a server-side fetch-URL builder with no rendered UI surface (the meta page's fetch is mocked in existing e2e tests).

<details>
<summary>Evidence: EDHREC fetch boundary: user input → URL on the wire</summary>

<code>=== EDHREC fetch boundary: user input -&gt; URL on the wire ===&#10;&#10;input : &#34;Atraxa, Praetors&#39; Voice&#34;&#10;fetch : https://json.edhrec.com/pages/commanders/atraxa-praetors-voice.json&#10;&#10;input : &#34;evil.com/../../secret&#34;&#10;fetch : https://json.edhrec.com/pages/commanders/evilcomsecret.json&#10;&#10;input : &#34;http://169.254.169.254/latest/meta-data&#34;&#10;fetch : https://json.edhrec.com/pages/commanders/http169254169254latestmeta-data.json&#10;&#10;input : &#34;foo?redirect=https://evil.com&#34;&#10;fetch : https://json.edhrec.com/pages/commanders/fooredirecthttpsevilcom.json&#10;&#10;input : &#34;///.@!&#34;&#10;fetch : (no network call — no-data outcome)</code>

```text
=== EDHREC fetch boundary: user input -> URL on the wire ===

  input : "Atraxa, Praetors' Voice"
  fetch : https://json.edhrec.com/pages/commanders/atraxa-praetors-voice.json

  input : "Thrasios, Triton Hero"
  fetch : https://json.edhrec.com/pages/commanders/thrasios-triton-hero.json

  input : "evil.com/../../secret"
  fetch : https://json.edhrec.com/pages/commanders/evilcomsecret.json

  input : "http://169.254.169.254/latest/meta-data"
  fetch : https://json.edhrec.com/pages/commanders/http169254169254latestmeta-data.json

  input : "foo?redirect=https://evil.com"
  fetch : https://json.edhrec.com/pages/commanders/fooredirecthttpsevilcom.json

  input : "///.@!"
  fetch : (no network call — no-data outcome)

  ✓  1 tests/unit/_edhrec_evidence_tmp.spec.ts:4:5 › dump input->wire-URL mapping (1ms)

  1 passed (269ms)
```
</details>
- Outcome: ⚠️ 1 info across 1 run (3m48s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 info</summary>

- ℹ️ `tests/unit/edhrec-fetch-url.spec.ts` - new test file written by agent: tests/unit/edhrec-fetch-url.spec.ts
- <code>`npx playwright test --config playwright.unit.config.ts tests/unit/edhrec-fetch-url.spec.ts` — new guard test stubbing global.fetch to capture the wire URL for real + adversarial commander names</code>
- <code>`npx playwright test --config playwright.unit.config.ts tests/unit/edhrec-slug.spec.ts tests/unit/edhrec-meta.spec.ts` — existing EDHREC slug/meta specs still green</code>
- <code>`npx playwright test --config playwright.unit.config.ts` — full unit suite: 2723 passed (2720 prior + 3 new)</code>
- `Generated an input→wire-URL transcript via a throwaway spec (removed after capture) proving real vs. adversarial URL resolution`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
